### PR TITLE
[codex] Build ContextForge v0 core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ coverage/
 
 # Runtime state
 .contextforge/
-.agent-memory/
 data/
 *.db
 *.db-shm

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md - ContextForge
 
-ContextForge is a standalone public project. Treat it as separate from the
-OpenClaw workspace.
+ContextForge is a standalone public project. Treat it as separate from any
+private reference implementation.
 
 ## Mission
 
@@ -18,14 +18,14 @@ The core idea is not another flat memory file. ContextForge should provide:
 
 ## Source Boundary
 
-The working OpenClaw agent-memory system is the original reference
-implementation, but do not mutate it while working in this repo.
+Private agent-memory systems may be useful reference material, but do not
+mutate them while working in this repo.
 
-- Do not edit `/home/ubuntu/.openclaw/workspace` unless the user explicitly asks.
-- Do not copy private OpenClaw/persona/user data into this repo.
+- Do not edit external/private workspaces unless the user explicitly asks.
+- Do not copy private persona, user, customer, or runtime data into this repo.
 - When borrowing code, extract generic engine logic only.
-- Remove OpenClaw-specific paths, agent names, hooks, secrets, and assumptions.
-- Keep this repo usable without OpenClaw installed.
+- Remove private paths, agent names, hooks, secrets, and assumptions.
+- Keep this repo usable without any private runtime installed.
 
 ## Product Principles
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ginishuh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,106 @@ bring-your-own distillation providers, such as:
 - direct model APIs
 - local model runners
 
+The v0 implementation ships with a `mock` provider first. It gives the storage,
+CLI, and checkpoint contract something deterministic to test before real model
+adapters are added.
+
+## Quick Start
+
+Requirements:
+
+- Node.js 20 or newer
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the test suite:
+
+```bash
+npm test
+```
+
+Inspect or initialize the local store:
+
+```bash
+node src/cli.js dbInfo
+```
+
+By default, runtime data is stored in `.contextforge/contextforge.db` under the
+current working directory. This directory and SQLite sidecar files are ignored by
+git. To use another location, set `CONTEXTFORGE_DATA_DIR`.
+
+## v0 CLI Workflow
+
+Create or update a durable memory:
+
+```bash
+node src/cli.js remember \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --key storage-mode \
+  --category decision \
+  --tag storage \
+  --content "Use local SQLite in .contextforge for v0 runtime state."
+```
+
+Search durable memories:
+
+```bash
+node src/cli.js search \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --query "sqlite runtime"
+```
+
+Fetch one memory by key:
+
+```bash
+node src/cli.js getMemory \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --key storage-mode
+```
+
+Start a session and append synthetic raw evidence:
+
+```bash
+node src/cli.js beginSession \
+  --scope repo \
+  --scopeKey github.com/example/contextforge
+
+node src/cli.js appendRaw \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --sessionId demo-session \
+  --role user \
+  --content "Decision: keep v0 retrieval lexical and explainable."
+```
+
+Distill a checkpoint with the mock provider:
+
+```bash
+node src/cli.js distillCheckpoint \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --sessionId demo-session
+```
+
+CLI output is JSON so adapters and scripts can consume it directly.
+
+## Public Repo Hygiene
+
+- Runtime state lives under `.contextforge/` by default and is ignored by git.
+- SQLite database files and sidecars are ignored.
+- Examples and tests use synthetic data only.
+- ContextForge does not require a private workspace or external agent runtime.
+
 ## Status
 
-Early extraction from a working OpenClaw agent-memory system. The first public
-version should focus on a small core before copying any OpenClaw-specific code.
+Early v0 core. The current implementation includes SQLite migrations, scoped
+durable memories, raw event capture, lexical search with match reasons, and mock
+checkpoint distillation. Real distillation providers and MCP/agent adapters are
+future work.

--- a/docs/issues/001-build-contextforge-v0.md
+++ b/docs/issues/001-build-contextforge-v0.md
@@ -5,14 +5,14 @@
 Build the first useful local version of ContextForge: a standalone, self-hosted
 memory and distillation runtime for coding agents.
 
-This work should happen inside `/home/ubuntu/contextforge`. Do not modify the
-OpenClaw workspace unless the user explicitly asks.
+This work should happen inside this repository. Do not modify external reference
+implementations while working here.
 
 ## Background
 
-ContextForge is being extracted from a working OpenClaw agent-memory system, but
-it must become a clean public project. The goal is not to copy OpenClaw as-is.
-The goal is to extract the generic product:
+ContextForge is inspired by a working private agent-memory system, but it must
+become a clean public project. The goal is not to copy a private implementation
+as-is. The goal is to extract the generic product:
 
 - canonical durable memory
 - scoped retrieval
@@ -21,14 +21,9 @@ The goal is to extract the generic product:
 - pluggable distillation providers
 - future adapters for Codex, Claude Code, and MCP
 
-The original OpenClaw implementation can be inspected as a reference at:
-
-```text
-/home/ubuntu/.openclaw/workspace/scripts/agent-memory
-/home/ubuntu/.openclaw/workspace/plugins/agent-memory-runtime
-```
-
-Reference only. Do not mutate those paths.
+Any private reference implementation is reference only. Do not mutate it from
+this repository, and do not copy private data, paths, names, hooks, secrets, or
+deployment assumptions.
 
 ## Product Direction
 
@@ -52,7 +47,7 @@ Important principles:
 
 - Do not build a UI.
 - Do not build multi-tenant SaaS.
-- Do not require OpenClaw.
+- Do not require any private runtime or workspace.
 - Do not require a remote VPS.
 - Do not implement every provider.
 - Do not commit real user memory, raw logs, SQLite DB files, or secrets.
@@ -247,38 +242,32 @@ The next Codex session should finish this issue when all are true:
 - A checkpoint can be produced through a mock or real distill provider.
 - Runtime DB files are ignored by git.
 - README documents the v0 workflow.
-- No OpenClaw private data or paths are required at runtime.
+- No private data, private names, or machine-specific paths are required at
+  runtime.
 
 ## Suggested First Commands
 
-From the new repo:
+From the repo:
 
 ```bash
-cd /home/ubuntu/contextforge
 sed -n '1,240p' AGENTS.md
 sed -n '1,240p' README.md
 sed -n '1,260p' docs/issues/001-build-contextforge-v0.md
 git status --short --branch
 ```
 
-Then inspect the original implementation only as reference:
-
-```bash
-sed -n '1,220p' /home/ubuntu/.openclaw/workspace/scripts/agent-memory/README.md
-find /home/ubuntu/.openclaw/workspace/scripts/agent-memory -maxdepth 2 -type f | sort | sed -n '1,160p'
-```
-
-Do not edit the OpenClaw paths.
+Private reference implementations may be inspected only outside the public repo
+and only as reference material. Do not edit them from this worktree.
 
 ## Implementation Notes
 
 Prefer incremental extraction over bulk copying. The v0 repo should feel clean to
-outside users who have never seen OpenClaw.
+outside users who have never seen the private reference implementation.
 
 If copying code from the original implementation:
 
-- remove hardcoded OpenClaw paths
-- remove agent-specific defaults such as `main`, `engineer`, `shira`
+- remove hardcoded private paths
+- remove agent-specific or user-specific defaults
 - remove private namespace assumptions
 - replace private examples with synthetic examples
 - keep only generic storage, retrieval, and distillation logic

--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CONTEXTFORGE_DATA_DIR="${CONTEXTFORGE_DATA_DIR:-$(mktemp -d -t contextforge-demo-XXXXXX)}"
+
+node src/cli.js dbInfo
+
+node src/cli.js remember \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --key storage-mode \
+  --category decision \
+  --tag storage \
+  --content "Use local SQLite in .contextforge for v0 runtime state."
+
+node src/cli.js search \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --query "sqlite runtime"
+
+node src/cli.js appendRaw \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --sessionId demo-session \
+  --role user \
+  --content "Decision: keep v0 retrieval lexical and explainable."
+
+node src/cli.js distillCheckpoint \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --sessionId demo-session

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,474 @@
+{
+  "name": "contextforge",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "contextforge",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "better-sqlite3": "^12.9.0"
+      },
+      "bin": {
+        "contextforge": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,10 +2,39 @@
   "name": "contextforge",
   "version": "0.0.0",
   "description": "Self-hosted memory and distillation runtime for coding agents.",
-  "private": true,
   "type": "module",
+  "bin": {
+    "contextforge": "src/cli.js"
+  },
+  "files": [
+    "src",
+    "examples",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "keywords": [
+    "agents",
+    "memory",
+    "distillation",
+    "sqlite",
+    "cli"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ginishuh/contextforge.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ginishuh/contextforge/issues"
+  },
+  "homepage": "https://github.com/ginishuh/contextforge#readme",
   "scripts": {
     "test": "node --test"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "better-sqlite3": "^12.9.0"
+  }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import { createContextForge } from './core.js';
+
+function parseArgs(argv) {
+  const command = argv[2];
+  const options = {};
+  const positionals = [];
+
+  for (let i = 3; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) {
+      positionals.push(token);
+      continue;
+    }
+
+    const name = token.slice(2);
+    const next = argv[i + 1];
+    if (next == null || next.startsWith('--')) {
+      options[name] = true;
+    } else if (options[name] == null) {
+      options[name] = next;
+      i += 1;
+    } else if (Array.isArray(options[name])) {
+      options[name].push(next);
+      i += 1;
+    } else {
+      options[name] = [options[name], next];
+      i += 1;
+    }
+  }
+
+  return { command, options, positionals };
+}
+
+function toCoreOptions(options) {
+  const tags = options.tag || options.tags;
+  return {
+    scope: options.scope,
+    scopeKey: options.scopeKey,
+    key: options.key,
+    content: options.content,
+    category: options.category,
+    tags: Array.isArray(tags) ? tags : typeof tags === 'string' ? tags.split(',').filter(Boolean) : [],
+    importance: options.importance == null ? 0 : Number(options.importance),
+    query: options.query,
+    limit: options.limit == null ? 10 : Number(options.limit),
+    sessionId: options.sessionId,
+    conversationId: options.conversationId,
+    role: options.role,
+    provider: options.provider,
+    metadata: options.metadata ? JSON.parse(options.metadata) : {},
+  };
+}
+
+function printJson(value) {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+async function main() {
+  const { command, options } = parseArgs(process.argv);
+  if (!command || command === 'help' || command === '--help') {
+    printJson({
+      commands: [
+        'dbInfo',
+        'beginSession',
+        'remember',
+        'search',
+        'getMemory',
+        'appendRaw',
+        'distillCheckpoint',
+      ],
+    });
+    return;
+  }
+
+  const app = createContextForge();
+  const coreOptions = toCoreOptions(options);
+
+  if (command === 'dbInfo') {
+    printJson(app.dbInfo());
+  } else if (command === 'beginSession') {
+    printJson(app.beginSession(coreOptions));
+  } else if (command === 'remember') {
+    printJson(app.remember(coreOptions));
+  } else if (command === 'search') {
+    printJson(app.search(coreOptions));
+  } else if (command === 'getMemory') {
+    printJson(app.getMemory(coreOptions));
+  } else if (command === 'appendRaw') {
+    printJson(app.appendRaw(coreOptions));
+  } else if (command === 'distillCheckpoint') {
+    printJson(await app.distillCheckpoint(coreOptions));
+  } else {
+    throw new Error(`Unknown command: ${command}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,0 +1,21 @@
+import path from 'node:path';
+
+const VALID_SCOPES = new Set(['shared', 'repo', 'local']);
+
+export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
+  const dataDir = env.CONTEXTFORGE_DATA_DIR
+    ? path.resolve(cwd, env.CONTEXTFORGE_DATA_DIR)
+    : path.join(cwd, '.contextforge');
+
+  const defaultScope = env.CONTEXTFORGE_DEFAULT_SCOPE || 'repo';
+  if (!VALID_SCOPES.has(defaultScope)) {
+    throw new Error(`Invalid CONTEXTFORGE_DEFAULT_SCOPE: ${defaultScope}`);
+  }
+
+  return {
+    dataDir,
+    defaultScope,
+    defaultScopeKey: env.CONTEXTFORGE_DEFAULT_SCOPE_KEY || null,
+    distillProvider: env.CONTEXTFORGE_DISTILL_PROVIDER || 'mock',
+  };
+}

--- a/src/core.js
+++ b/src/core.js
@@ -1,0 +1,148 @@
+import { randomUUID } from 'node:crypto';
+import { loadConfig } from './config/index.js';
+import { createDistillProvider } from './distill/index.js';
+import { searchMemories } from './retrieval/search.js';
+import { normalizeScopeOptions } from './scopes/index.js';
+import { ContextForgeStore } from './storage/sqlite.js';
+
+function requireOption(value, name) {
+  if (value == null || value === '') {
+    throw new Error(`${name} is required.`);
+  }
+}
+
+function withStore(config, fn) {
+  const store = new ContextForgeStore({ dataDir: config.dataDir });
+  try {
+    const result = fn(store);
+    if (result && typeof result.then === 'function') {
+      return result.finally(() => store.close());
+    }
+    store.close();
+    return result;
+  } catch (error) {
+    store.close();
+    throw error;
+  }
+}
+
+export function createContextForge(options = {}) {
+  const config = loadConfig(options);
+
+  return {
+    config,
+
+    dbInfo() {
+      return withStore(config, (store) => store.dbInfo());
+    },
+
+    beginSession(options = {}) {
+      const scope = normalizeScopeOptions(options, config);
+      return {
+        sessionId: options.sessionId || `cf_${randomUUID()}`,
+        conversationId: options.conversationId || null,
+        scopeType: scope.scopeType,
+        scopeKey: scope.scopeKey,
+        createdAt: new Date().toISOString(),
+      };
+    },
+
+    remember(options) {
+      const scope = normalizeScopeOptions(options, config);
+      return withStore(config, (store) =>
+        store.rememberMemory({
+          ...scope,
+          key: options.key,
+          content: options.content,
+          category: options.category,
+          tags: options.tags,
+          importance: options.importance,
+        }),
+      );
+    },
+
+    getMemory(options) {
+      const scope = normalizeScopeOptions(options, config);
+      requireOption(options.key, 'key');
+      return withStore(config, (store) =>
+        store.getMemory({
+          ...scope,
+          key: options.key,
+        }),
+      );
+    },
+
+    search(options) {
+      const scope = normalizeScopeOptions(options, config);
+      requireOption(options.query, 'query');
+      return withStore(config, (store) =>
+        searchMemories(store, {
+          ...scope,
+          query: options.query,
+          limit: options.limit,
+        }),
+      );
+    },
+
+    appendRaw(options) {
+      const scope = normalizeScopeOptions(options, config);
+      requireOption(options.sessionId, 'sessionId');
+      requireOption(options.role, 'role');
+      requireOption(options.content, 'content');
+      return withStore(config, (store) =>
+        store.appendRawEvent({
+          ...scope,
+          sessionId: options.sessionId,
+          conversationId: options.conversationId,
+          role: options.role,
+          content: options.content,
+          metadata: options.metadata,
+        }),
+      );
+    },
+
+    async distillCheckpoint(options) {
+      const scope = normalizeScopeOptions(options, config);
+      requireOption(options.sessionId, 'sessionId');
+      const provider = createDistillProvider(options.provider || config.distillProvider);
+
+      return withStore(config, async (store) => {
+        const rawEvents = store.listRawEvents({ ...scope, sessionId: options.sessionId });
+        const previousCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId });
+        const conversationId =
+          options.conversationId || rawEvents.find((event) => event.conversationId)?.conversationId || null;
+
+        const output = await provider.distill({
+          session: {
+            ...scope,
+            sessionId: options.sessionId,
+            conversationId,
+          },
+          rawEvents,
+          previousCheckpoint,
+          requestedOutputSchema: {
+            summaryShort: 'string',
+            summaryText: 'string',
+            decisions: 'string[]',
+            todos: 'string[]',
+            openQuestions: 'string[]',
+            memoryCandidates: 'object[]',
+          },
+        });
+
+        return store.insertCheckpoint({
+          ...scope,
+          sessionId: options.sessionId,
+          conversationId,
+          summaryShort: output.summaryShort,
+          summaryText: output.summaryText,
+          decisions: output.decisions,
+          todos: output.todos,
+          openQuestions: output.openQuestions,
+          sourceEventCount: output.sourceEventCount ?? rawEvents.length,
+          provider: output.provider || provider.name,
+        });
+      });
+    },
+  };
+}

--- a/src/distill/index.js
+++ b/src/distill/index.js
@@ -1,0 +1,12 @@
+import { distillWithMockProvider } from './providers/mock.js';
+
+export function createDistillProvider(name) {
+  if (name === 'mock') {
+    return {
+      name,
+      distill: distillWithMockProvider,
+    };
+  }
+
+  throw new Error(`Unsupported distill provider "${name}". Available providers: mock.`);
+}

--- a/src/distill/providers/mock.js
+++ b/src/distill/providers/mock.js
@@ -1,0 +1,33 @@
+function firstUsefulLine(events) {
+  const event = events.find((item) => item.content && item.content.trim());
+  if (!event) return 'No raw events were available for this checkpoint.';
+  return `${event.role}: ${event.content.trim().slice(0, 120)}`;
+}
+
+function collectLines(events, pattern) {
+  return events
+    .filter((event) => pattern.test(event.content))
+    .map((event) => `${event.role}: ${event.content.trim()}`);
+}
+
+export async function distillWithMockProvider(input) {
+  const events = input.rawEvents || [];
+  const roles = [...new Set(events.map((event) => event.role))].join(', ') || 'none';
+  const sourceEventCount = events.length;
+
+  return {
+    provider: 'mock',
+    summaryShort: `Mock checkpoint for ${sourceEventCount} event(s).`,
+    summaryText: [
+      `Scope: ${input.session.scopeType}:${input.session.scopeKey}`,
+      `Session: ${input.session.sessionId}`,
+      `Roles: ${roles}`,
+      `First event: ${firstUsefulLine(events)}`,
+    ].join('\n'),
+    decisions: collectLines(events, /\b(decision|decide|decided)\b/i),
+    todos: collectLines(events, /\b(todo|next|follow up|fix|implement)\b/i),
+    openQuestions: collectLines(events, /\?/),
+    memoryCandidates: [],
+    sourceEventCount,
+  };
+}

--- a/src/retrieval/search.js
+++ b/src/retrieval/search.js
@@ -1,0 +1,58 @@
+function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9_./:-]+/)
+    .filter((token) => token.length > 1);
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function scoreMemory(memory, queryTokens) {
+  const fields = {
+    key: memory.key,
+    category: memory.category,
+    content: memory.content,
+    tags: memory.tags.join(' '),
+  };
+
+  let score = 0;
+  const matched = [];
+  for (const token of queryTokens) {
+    const hitFields = Object.entries(fields)
+      .filter(([, value]) => String(value || '').toLowerCase().includes(token))
+      .map(([name]) => name);
+    if (hitFields.length > 0) {
+      score += hitFields.includes('content') ? 2 : 1;
+      matched.push({ token, fields: hitFields });
+    }
+  }
+
+  return {
+    score,
+    matched,
+  };
+}
+
+export function searchMemories(store, { scopeType, scopeKey, query, limit = 10 }) {
+  const queryTokens = unique(tokenize(query));
+  if (queryTokens.length === 0) {
+    return [];
+  }
+
+  return store
+    .listMemories({ scopeType, scopeKey })
+    .map((memory) => {
+      const match = scoreMemory(memory, queryTokens);
+      return {
+        type: 'memory',
+        score: match.score,
+        why: match.matched,
+        memory,
+      };
+    })
+    .filter((result) => result.score > 0)
+    .sort((a, b) => b.score - a.score || b.memory.importance - a.memory.importance)
+    .slice(0, limit);
+}

--- a/src/scopes/index.js
+++ b/src/scopes/index.js
@@ -1,0 +1,19 @@
+const VALID_SCOPE_TYPES = new Set(['shared', 'repo', 'local']);
+
+export function validateScope(scopeType, scopeKey) {
+  if (!VALID_SCOPE_TYPES.has(scopeType)) {
+    throw new Error(`Invalid scope type "${scopeType}". Expected shared, repo, or local.`);
+  }
+
+  if (!scopeKey || typeof scopeKey !== 'string') {
+    throw new Error('scopeKey is required.');
+  }
+
+  return { scopeType, scopeKey };
+}
+
+export function normalizeScopeOptions(options, config) {
+  const scopeType = options.scopeType || options.scope || config.defaultScope;
+  const scopeKey = options.scopeKey || config.defaultScopeKey;
+  return validateScope(scopeType, scopeKey);
+}

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -1,0 +1,347 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import Database from 'better-sqlite3';
+
+const SCHEMA_VERSION = 1;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function json(value, fallback) {
+  return JSON.stringify(value ?? fallback);
+}
+
+function parseJson(value, fallback) {
+  if (value == null || value === '') {
+    return fallback;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function hydrateMemory(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    scopeType: row.scope_type,
+    scopeKey: row.scope_key,
+    key: row.memory_key,
+    category: row.category,
+    content: row.content,
+    tags: parseJson(row.tags_json, []),
+    importance: row.importance,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function hydrateRawEvent(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    scopeType: row.scope_type,
+    scopeKey: row.scope_key,
+    sessionId: row.session_id,
+    conversationId: row.conversation_id,
+    role: row.role,
+    content: row.content,
+    metadata: parseJson(row.metadata_json, {}),
+    createdAt: row.created_at,
+  };
+}
+
+function hydrateCheckpoint(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    scopeType: row.scope_type,
+    scopeKey: row.scope_key,
+    sessionId: row.session_id,
+    conversationId: row.conversation_id,
+    summaryShort: row.summary_short,
+    summaryText: row.summary_text,
+    decisions: parseJson(row.decisions_json, []),
+    todos: parseJson(row.todos_json, []),
+    openQuestions: parseJson(row.open_questions_json, []),
+    sourceEventCount: row.source_event_count,
+    provider: row.provider,
+    createdAt: row.created_at,
+  };
+}
+
+export class ContextForgeStore {
+  constructor({ dataDir }) {
+    this.dataDir = dataDir;
+    fs.mkdirSync(dataDir, { recursive: true });
+    this.dbPath = path.join(dataDir, 'contextforge.db');
+    this.db = new Database(this.dbPath);
+    this.db.exec('PRAGMA foreign_keys = ON;');
+    this.migrate();
+  }
+
+  close() {
+    this.db.close();
+  }
+
+  migrate() {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS schema_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS memories (
+        id TEXT PRIMARY KEY,
+        scope_type TEXT NOT NULL CHECK (scope_type IN ('shared', 'repo', 'local')),
+        scope_key TEXT NOT NULL,
+        memory_key TEXT NOT NULL,
+        category TEXT NOT NULL DEFAULT 'note',
+        content TEXT NOT NULL,
+        tags_json TEXT NOT NULL DEFAULT '[]',
+        importance INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE (scope_type, scope_key, memory_key)
+      );
+
+      CREATE TABLE IF NOT EXISTS raw_events (
+        id TEXT PRIMARY KEY,
+        scope_type TEXT NOT NULL CHECK (scope_type IN ('shared', 'repo', 'local')),
+        scope_key TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        conversation_id TEXT,
+        role TEXT NOT NULL,
+        content TEXT NOT NULL,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS checkpoints (
+        id TEXT PRIMARY KEY,
+        scope_type TEXT NOT NULL CHECK (scope_type IN ('shared', 'repo', 'local')),
+        scope_key TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        conversation_id TEXT,
+        summary_short TEXT NOT NULL,
+        summary_text TEXT NOT NULL,
+        decisions_json TEXT NOT NULL DEFAULT '[]',
+        todos_json TEXT NOT NULL DEFAULT '[]',
+        open_questions_json TEXT NOT NULL DEFAULT '[]',
+        source_event_count INTEGER NOT NULL DEFAULT 0,
+        provider TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS memory_events (
+        id TEXT PRIMARY KEY,
+        memory_id TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL,
+        FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE CASCADE
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_memories_scope
+        ON memories(scope_type, scope_key);
+      CREATE INDEX IF NOT EXISTS idx_raw_events_session
+        ON raw_events(scope_type, scope_key, session_id, created_at);
+      CREATE INDEX IF NOT EXISTS idx_checkpoints_session
+        ON checkpoints(scope_type, scope_key, session_id, created_at);
+    `);
+
+    this.db
+      .prepare(`
+        INSERT INTO schema_meta (key, value)
+        VALUES ('schema_version', ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+      `)
+      .run(String(SCHEMA_VERSION));
+  }
+
+  dbInfo() {
+    const count = (table) => this.db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get().count;
+    return {
+      dataDir: this.dataDir,
+      dbPath: this.dbPath,
+      schemaVersion: Number(
+        this.db.prepare("SELECT value FROM schema_meta WHERE key = 'schema_version'").get().value,
+      ),
+      tables: {
+        memories: count('memories'),
+        rawEvents: count('raw_events'),
+        checkpoints: count('checkpoints'),
+        memoryEvents: count('memory_events'),
+      },
+    };
+  }
+
+  rememberMemory({ scopeType, scopeKey, key, content, category = 'note', tags = [], importance = 0 }) {
+    if (!key) throw new Error('memory key is required.');
+    if (!content) throw new Error('memory content is required.');
+
+    const id = randomUUID();
+    const timestamp = nowIso();
+    const row = this.db
+      .prepare(`
+        INSERT INTO memories (
+          id, scope_type, scope_key, memory_key, category, content,
+          tags_json, importance, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(scope_type, scope_key, memory_key) DO UPDATE SET
+          category = excluded.category,
+          content = excluded.content,
+          tags_json = excluded.tags_json,
+          importance = excluded.importance,
+          updated_at = excluded.updated_at
+        RETURNING *
+      `)
+      .get(
+        id,
+        scopeType,
+        scopeKey,
+        key,
+        category,
+        content,
+        json(tags, []),
+        Number(importance),
+        timestamp,
+        timestamp,
+      );
+
+    this.db
+      .prepare(`
+        INSERT INTO memory_events (id, memory_id, event_type, metadata_json, created_at)
+        VALUES (?, ?, ?, ?, ?)
+      `)
+      .run(randomUUID(), row.id, 'remember', json({ key }, {}), nowIso());
+
+    return hydrateMemory(row);
+  }
+
+  getMemory({ scopeType, scopeKey, key }) {
+    const row = this.db
+      .prepare(`
+        SELECT * FROM memories
+        WHERE scope_type = ? AND scope_key = ? AND memory_key = ?
+      `)
+      .get(scopeType, scopeKey, key);
+    return hydrateMemory(row);
+  }
+
+  listMemories({ scopeType, scopeKey }) {
+    return this.db
+      .prepare(`
+        SELECT * FROM memories
+        WHERE scope_type = ? AND scope_key = ?
+        ORDER BY importance DESC, updated_at DESC, memory_key ASC
+      `)
+      .all(scopeType, scopeKey)
+      .map(hydrateMemory);
+  }
+
+  appendRawEvent({
+    scopeType,
+    scopeKey,
+    sessionId,
+    conversationId = null,
+    role,
+    content,
+    metadata = {},
+  }) {
+    if (!sessionId) throw new Error('sessionId is required.');
+    if (!role) throw new Error('role is required.');
+    if (!content) throw new Error('content is required.');
+
+    const row = this.db
+      .prepare(`
+        INSERT INTO raw_events (
+          id, scope_type, scope_key, session_id, conversation_id,
+          role, content, metadata_json, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        RETURNING *
+      `)
+      .get(
+        randomUUID(),
+        scopeType,
+        scopeKey,
+        sessionId,
+        conversationId,
+        role,
+        content,
+        json(metadata, {}),
+        nowIso(),
+      );
+    return hydrateRawEvent(row);
+  }
+
+  listRawEvents({ scopeType, scopeKey, sessionId }) {
+    return this.db
+      .prepare(`
+        SELECT * FROM raw_events
+        WHERE scope_type = ? AND scope_key = ? AND session_id = ?
+        ORDER BY created_at ASC, id ASC
+      `)
+      .all(scopeType, scopeKey, sessionId)
+      .map(hydrateRawEvent);
+  }
+
+  getLatestCheckpoint({ scopeType, scopeKey, sessionId }) {
+    const row = this.db
+      .prepare(`
+        SELECT * FROM checkpoints
+        WHERE scope_type = ? AND scope_key = ? AND session_id = ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1
+      `)
+      .get(scopeType, scopeKey, sessionId);
+    return hydrateCheckpoint(row);
+  }
+
+  insertCheckpoint({
+    scopeType,
+    scopeKey,
+    sessionId,
+    conversationId = null,
+    summaryShort,
+    summaryText,
+    decisions = [],
+    todos = [],
+    openQuestions = [],
+    sourceEventCount = 0,
+    provider,
+  }) {
+    const row = this.db
+      .prepare(`
+        INSERT INTO checkpoints (
+          id, scope_type, scope_key, session_id, conversation_id,
+          summary_short, summary_text, decisions_json, todos_json,
+          open_questions_json, source_event_count, provider, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        RETURNING *
+      `)
+      .get(
+        randomUUID(),
+        scopeType,
+        scopeKey,
+        sessionId,
+        conversationId,
+        summaryShort,
+        summaryText,
+        json(decisions, []),
+        json(todos, []),
+        json(openQuestions, []),
+        Number(sourceEventCount),
+        provider,
+        nowIso(),
+      );
+    return hydrateCheckpoint(row);
+  }
+}

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import test from 'node:test';
+import { createContextForge } from '../src/core.js';
+
+const execFileAsync = promisify(execFile);
+
+async function makeTempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'contextforge-test-'));
+}
+
+test('dbInfo initializes a fresh SQLite store', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  const info = app.dbInfo();
+
+  assert.equal(info.schemaVersion, 1);
+  assert.equal(info.tables.memories, 0);
+  assert.match(info.dbPath, /contextforge\.db$/);
+});
+
+test('remember, getMemory, and search use explicit scopes', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  const memory = app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/example/contextforge',
+    key: 'storage-mode',
+    content: 'Use local SQLite in .contextforge for v0 runtime state.',
+    category: 'decision',
+    tags: ['storage', 'sqlite'],
+    importance: 5,
+  });
+
+  assert.equal(memory.key, 'storage-mode');
+  assert.equal(memory.scopeType, 'repo');
+
+  const fetched = app.getMemory({
+    scope: 'repo',
+    scopeKey: 'github.com/example/contextforge',
+    key: 'storage-mode',
+  });
+  assert.equal(fetched.content, memory.content);
+
+  const results = app.search({
+    scope: 'repo',
+    scopeKey: 'github.com/example/contextforge',
+    query: 'sqlite runtime',
+  });
+  assert.equal(results.length, 1);
+  assert.equal(results[0].memory.key, 'storage-mode');
+  assert.ok(results[0].why.some((hit) => hit.token === 'sqlite'));
+});
+
+test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+  const session = app.beginSession({ scope: 'repo', scopeKey: 'repo-a' });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-a',
+    sessionId: session.sessionId,
+    role: 'user',
+    content: 'Decision: use a mock provider for the first distillation smoke test.',
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-a',
+    sessionId: session.sessionId,
+    role: 'assistant',
+    content: 'Next implement the provider contract and CLI command.',
+  });
+
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-a',
+    sessionId: session.sessionId,
+  });
+
+  assert.equal(checkpoint.provider, 'mock');
+  assert.equal(checkpoint.sourceEventCount, 2);
+  assert.equal(checkpoint.decisions.length, 1);
+  assert.equal(checkpoint.todos.length, 1);
+
+  const info = app.dbInfo();
+  assert.equal(info.tables.rawEvents, 2);
+  assert.equal(info.tables.checkpoints, 1);
+});
+
+test('CLI supports the v0 workflow with synthetic data', async () => {
+  const dataDir = await makeTempDir();
+  const env = { ...process.env, CONTEXTFORGE_DATA_DIR: dataDir };
+
+  const dbInfo = await execFileAsync('node', ['src/cli.js', 'dbInfo'], { env });
+  assert.match(dbInfo.stdout, /"schemaVersion": 1/);
+
+  await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'remember',
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'cli-repo',
+      '--key',
+      'retrieval',
+      '--content',
+      'Search durable memories before checkpoints.',
+      '--tag',
+      'retrieval',
+    ],
+    { env },
+  );
+
+  const search = await execFileAsync(
+    'node',
+    ['src/cli.js', 'search', '--scope', 'repo', '--scopeKey', 'cli-repo', '--query', 'durable'],
+    { env },
+  );
+  assert.match(search.stdout, /"key": "retrieval"/);
+
+  await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'appendRaw',
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'cli-repo',
+      '--sessionId',
+      'cli-session',
+      '--role',
+      'user',
+      '--content',
+      'What should happen next?',
+    ],
+    { env },
+  );
+
+  const checkpoint = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'distillCheckpoint',
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'cli-repo',
+      '--sessionId',
+      'cli-session',
+    ],
+    { env },
+  );
+  assert.match(checkpoint.stdout, /"provider": "mock"/);
+});
+
+test('runtime database artifacts are ignored by git rules', async () => {
+  const gitignore = await fs.readFile('.gitignore', 'utf8');
+  assert.match(gitignore, /^\.contextforge\/$/m);
+  assert.match(gitignore, /^\*\.db$/m);
+  assert.match(gitignore, /^\*\.db-wal$/m);
+  assert.match(gitignore, /^\*\.db-shm$/m);
+});


### PR DESCRIPTION
## Summary

- adds the first local ContextForge v0 core with SQLite-backed memories, raw events, checkpoints, and schema metadata
- adds JSON CLI commands for dbInfo, beginSession, remember, search, getMemory, appendRaw, and distillCheckpoint
- uses better-sqlite3 with a mock distillation provider so the checkpoint contract is testable without private runtimes
- adds public repo hygiene: MIT license, package metadata, npm files allowlist, synthetic demo, sanitized agent/issue docs

Refs #1.

## Validation

- npm test
- npm pack --dry-run
- npm audit --audit-level=moderate
- git diff --check --cached
- examples/demo.sh

## Notes

This is intentionally a draft. Real distillation providers, MCP/adapter surfaces, and any richer retrieval such as FTS should follow after the local core settles.
