### PR TITLE
[codex] Harden distillation provider contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ node src/cli.js distillCheckpoint \
   --sessionId demo-session
 ```
 
+Inspect distillation run metadata:
+
+```bash
+node src/cli.js listDistillRuns \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --sessionId demo-session
+```
+
 CLI output is JSON so adapters and scripts can consume it directly.
 
 ## Public Repo Hygiene

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,6 +163,23 @@ Provider outputs should include:
 Memory candidates must not automatically become durable memories unless the
 caller explicitly chooses that policy.
 
+## Distill Run Metadata
+
+Every distillation attempt should be recorded separately from checkpoints.
+
+Distill run records should capture:
+
+- provider name
+- run status: `started`, `succeeded`, or `failed`
+- source event count and raw event ids
+- previous checkpoint id when present
+- requested output schema
+- provider metadata on success
+- error message and stack on failure
+
+Failed distillation must not delete or mutate raw evidence. A checkpoint should
+only be inserted after provider output passes validation.
+
 ## Retrieval Policy
 
 Default retrieval should be compact, explainable, scoped, and on demand.

--- a/src/cli.js
+++ b/src/cli.js
@@ -68,6 +68,7 @@ async function main() {
         'getMemory',
         'appendRaw',
         'distillCheckpoint',
+        'listDistillRuns',
       ],
     });
     return;
@@ -90,6 +91,8 @@ async function main() {
     printJson(app.appendRaw(coreOptions));
   } else if (command === 'distillCheckpoint') {
     printJson(await app.distillCheckpoint(coreOptions));
+  } else if (command === 'listDistillRuns') {
+    printJson(app.listDistillRuns(coreOptions));
   } else {
     throw new Error(`Unknown command: ${command}`);
   }

--- a/src/core.js
+++ b/src/core.js
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { loadConfig } from './config/index.js';
 import { createDistillProvider } from './distill/index.js';
+import { validateDistillOutput } from './distill/validate.js';
 import { searchMemories } from './retrieval/search.js';
 import { normalizeScopeOptions } from './scopes/index.js';
 import { ContextForgeStore } from './storage/sqlite.js';
@@ -28,6 +29,7 @@ function withStore(config, fn) {
 
 export function createContextForge(options = {}) {
   const config = loadConfig(options);
+  const distillProviders = options.distillProviders || {};
 
   return {
     config,
@@ -104,33 +106,76 @@ export function createContextForge(options = {}) {
     async distillCheckpoint(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.sessionId, 'sessionId');
-      const provider = createDistillProvider(options.provider || config.distillProvider);
+      const provider = createDistillProvider(options.provider || config.distillProvider, distillProviders);
 
       return withStore(config, async (store) => {
         const rawEvents = store.listRawEvents({ ...scope, sessionId: options.sessionId });
         const previousCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId });
         const conversationId =
           options.conversationId || rawEvents.find((event) => event.conversationId)?.conversationId || null;
-
-        const output = await provider.distill({
-          session: {
-            ...scope,
-            sessionId: options.sessionId,
-            conversationId,
-          },
-          rawEvents,
-          previousCheckpoint,
-          requestedOutputSchema: {
-            summaryShort: 'string',
-            summaryText: 'string',
-            decisions: 'string[]',
-            todos: 'string[]',
-            openQuestions: 'string[]',
-            memoryCandidates: 'object[]',
+        const requestedOutputSchema = {
+          summaryShort: 'string',
+          summaryText: 'string',
+          decisions: 'string[]',
+          todos: 'string[]',
+          openQuestions: 'string[]',
+          memoryCandidates: 'object[]',
+          sourceEventCount: 'number',
+          provider: 'string',
+          metadata: 'object',
+        };
+        const distillRun = store.startDistillRun({
+          ...scope,
+          sessionId: options.sessionId,
+          conversationId,
+          provider: provider.name,
+          sourceEventCount: rawEvents.length,
+          inputMetadata: {
+            rawEventIds: rawEvents.map((event) => event.id),
+            previousCheckpointId: previousCheckpoint?.id || null,
+            requestedOutputSchema,
           },
         });
 
-        return store.insertCheckpoint({
+        let rawOutput;
+        try {
+          rawOutput = await provider.distill({
+            session: {
+              ...scope,
+              sessionId: options.sessionId,
+              conversationId,
+            },
+            rawEvents,
+            previousCheckpoint,
+            requestedOutputSchema,
+          });
+        } catch (error) {
+          store.failDistillRun({
+            id: distillRun.id,
+            error,
+            outputMetadata: {
+              providerFailed: true,
+            },
+          });
+          throw error;
+        }
+
+        let output;
+        try {
+          output = validateDistillOutput(rawOutput);
+        } catch (error) {
+          store.failDistillRun({
+            id: distillRun.id,
+            error,
+            outputMetadata: {
+              validationFailed: true,
+              receivedType: Array.isArray(rawOutput) ? 'array' : typeof rawOutput,
+            },
+          });
+          throw error;
+        }
+
+        const checkpoint = store.insertCheckpoint({
           ...scope,
           sessionId: options.sessionId,
           conversationId,
@@ -141,8 +186,36 @@ export function createContextForge(options = {}) {
           openQuestions: output.openQuestions,
           sourceEventCount: output.sourceEventCount ?? rawEvents.length,
           provider: output.provider || provider.name,
+          distillRunId: distillRun.id,
+          metadata: {
+            providerMetadata: output.metadata,
+            memoryCandidates: output.memoryCandidates,
+          },
         });
+
+        store.completeDistillRun({
+          id: distillRun.id,
+          outputMetadata: {
+            checkpointId: checkpoint.id,
+            provider: checkpoint.provider,
+            memoryCandidateCount: output.memoryCandidates.length,
+            providerMetadata: output.metadata,
+          },
+        });
+
+        return checkpoint;
       });
+    },
+
+    listDistillRuns(options) {
+      const scope = normalizeScopeOptions(options, config);
+      requireOption(options.sessionId, 'sessionId');
+      return withStore(config, (store) =>
+        store.listDistillRuns({
+          ...scope,
+          sessionId: options.sessionId,
+        }),
+      );
     },
   };
 }

--- a/src/distill/index.js
+++ b/src/distill/index.js
@@ -1,6 +1,13 @@
 import { distillWithMockProvider } from './providers/mock.js';
 
-export function createDistillProvider(name) {
+export function createDistillProvider(name, overrides = {}) {
+  if (overrides[name]) {
+    return {
+      name,
+      distill: overrides[name],
+    };
+  }
+
   if (name === 'mock') {
     return {
       name,

--- a/src/distill/providers/mock.js
+++ b/src/distill/providers/mock.js
@@ -29,5 +29,8 @@ export async function distillWithMockProvider(input) {
     openQuestions: collectLines(events, /\?/),
     memoryCandidates: [],
     sourceEventCount,
+    metadata: {
+      roles,
+    },
   };
 }

--- a/src/distill/validate.js
+++ b/src/distill/validate.js
@@ -1,0 +1,53 @@
+const ARRAY_FIELDS = ['decisions', 'todos', 'openQuestions', 'memoryCandidates'];
+
+function assertString(value, field) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Provider output field "${field}" must be a non-empty string.`);
+  }
+}
+
+function assertArray(value, field) {
+  if (!Array.isArray(value)) {
+    throw new Error(`Provider output field "${field}" must be an array.`);
+  }
+}
+
+export function validateDistillOutput(output) {
+  if (!output || typeof output !== 'object' || Array.isArray(output)) {
+    throw new Error('Provider output must be an object.');
+  }
+
+  assertString(output.summaryShort, 'summaryShort');
+  assertString(output.summaryText, 'summaryText');
+
+  for (const field of ARRAY_FIELDS) {
+    assertArray(output[field], field);
+  }
+
+  if (
+    output.sourceEventCount != null &&
+    (!Number.isInteger(output.sourceEventCount) || output.sourceEventCount < 0)
+  ) {
+    throw new Error('Provider output field "sourceEventCount" must be a non-negative integer.');
+  }
+
+  if (output.provider != null && typeof output.provider !== 'string') {
+    throw new Error('Provider output field "provider" must be a string when present.');
+  }
+
+  if (output.metadata != null && (typeof output.metadata !== 'object' || Array.isArray(output.metadata))) {
+    throw new Error('Provider output field "metadata" must be an object when present.');
+  }
+
+  return {
+    summaryShort: output.summaryShort,
+    summaryText: output.summaryText,
+    decisions: output.decisions,
+    todos: output.todos,
+    openQuestions: output.openQuestions,
+    memoryCandidates: output.memoryCandidates,
+    sourceEventCount: output.sourceEventCount,
+    provider: output.provider,
+    metadata: output.metadata || {},
+  };
+}

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import Database from 'better-sqlite3';
 
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 
 function nowIso() {
   return new Date().toISOString();
@@ -70,7 +70,29 @@ function hydrateCheckpoint(row) {
     openQuestions: parseJson(row.open_questions_json, []),
     sourceEventCount: row.source_event_count,
     provider: row.provider,
+    distillRunId: row.distill_run_id,
+    metadata: parseJson(row.metadata_json, {}),
     createdAt: row.created_at,
+  };
+}
+
+function hydrateDistillRun(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    scopeType: row.scope_type,
+    scopeKey: row.scope_key,
+    sessionId: row.session_id,
+    conversationId: row.conversation_id,
+    provider: row.provider,
+    status: row.status,
+    sourceEventCount: row.source_event_count,
+    inputMetadata: parseJson(row.input_metadata_json, {}),
+    outputMetadata: parseJson(row.output_metadata_json, {}),
+    errorMessage: row.error_message,
+    errorStack: row.error_stack,
+    createdAt: row.created_at,
+    completedAt: row.completed_at,
   };
 }
 
@@ -86,6 +108,13 @@ export class ContextForgeStore {
 
   close() {
     this.db.close();
+  }
+
+  ensureColumn(table, column, definition) {
+    const columns = this.db.prepare(`PRAGMA table_info(${table})`).all();
+    if (!columns.some((item) => item.name === column)) {
+      this.db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+    }
   }
 
   migrate() {
@@ -134,7 +163,26 @@ export class ContextForgeStore {
         open_questions_json TEXT NOT NULL DEFAULT '[]',
         source_event_count INTEGER NOT NULL DEFAULT 0,
         provider TEXT NOT NULL,
+        distill_run_id TEXT,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
         created_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS distill_runs (
+        id TEXT PRIMARY KEY,
+        scope_type TEXT NOT NULL CHECK (scope_type IN ('shared', 'repo', 'local')),
+        scope_key TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        conversation_id TEXT,
+        provider TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('started', 'succeeded', 'failed')),
+        source_event_count INTEGER NOT NULL DEFAULT 0,
+        input_metadata_json TEXT NOT NULL DEFAULT '{}',
+        output_metadata_json TEXT NOT NULL DEFAULT '{}',
+        error_message TEXT,
+        error_stack TEXT,
+        created_at TEXT NOT NULL,
+        completed_at TEXT
       );
 
       CREATE TABLE IF NOT EXISTS memory_events (
@@ -152,7 +200,12 @@ export class ContextForgeStore {
         ON raw_events(scope_type, scope_key, session_id, created_at);
       CREATE INDEX IF NOT EXISTS idx_checkpoints_session
         ON checkpoints(scope_type, scope_key, session_id, created_at);
+      CREATE INDEX IF NOT EXISTS idx_distill_runs_session
+        ON distill_runs(scope_type, scope_key, session_id, created_at);
     `);
+
+    this.ensureColumn('checkpoints', 'distill_run_id', 'TEXT');
+    this.ensureColumn('checkpoints', 'metadata_json', "TEXT NOT NULL DEFAULT '{}'");
 
     this.db
       .prepare(`
@@ -175,6 +228,7 @@ export class ContextForgeStore {
         memories: count('memories'),
         rawEvents: count('raw_events'),
         checkpoints: count('checkpoints'),
+        distillRuns: count('distill_runs'),
         memoryEvents: count('memory_events'),
       },
     };
@@ -316,15 +370,18 @@ export class ContextForgeStore {
     openQuestions = [],
     sourceEventCount = 0,
     provider,
+    distillRunId = null,
+    metadata = {},
   }) {
     const row = this.db
       .prepare(`
         INSERT INTO checkpoints (
           id, scope_type, scope_key, session_id, conversation_id,
           summary_short, summary_text, decisions_json, todos_json,
-          open_questions_json, source_event_count, provider, created_at
+          open_questions_json, source_event_count, provider, distill_run_id,
+          metadata_json, created_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         RETURNING *
       `)
       .get(
@@ -340,8 +397,89 @@ export class ContextForgeStore {
         json(openQuestions, []),
         Number(sourceEventCount),
         provider,
+        distillRunId,
+        json(metadata, {}),
         nowIso(),
       );
     return hydrateCheckpoint(row);
+  }
+
+  startDistillRun({
+    scopeType,
+    scopeKey,
+    sessionId,
+    conversationId = null,
+    provider,
+    sourceEventCount = 0,
+    inputMetadata = {},
+  }) {
+    const row = this.db
+      .prepare(`
+        INSERT INTO distill_runs (
+          id, scope_type, scope_key, session_id, conversation_id, provider,
+          status, source_event_count, input_metadata_json, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, 'started', ?, ?, ?)
+        RETURNING *
+      `)
+      .get(
+        randomUUID(),
+        scopeType,
+        scopeKey,
+        sessionId,
+        conversationId,
+        provider,
+        Number(sourceEventCount),
+        json(inputMetadata, {}),
+        nowIso(),
+      );
+    return hydrateDistillRun(row);
+  }
+
+  completeDistillRun({ id, outputMetadata = {} }) {
+    const row = this.db
+      .prepare(`
+        UPDATE distill_runs
+        SET status = 'succeeded',
+            output_metadata_json = ?,
+            completed_at = ?
+        WHERE id = ?
+        RETURNING *
+      `)
+      .get(json(outputMetadata, {}), nowIso(), id);
+    return hydrateDistillRun(row);
+  }
+
+  failDistillRun({ id, error, outputMetadata = {} }) {
+    const row = this.db
+      .prepare(`
+        UPDATE distill_runs
+        SET status = 'failed',
+            output_metadata_json = ?,
+            error_message = ?,
+            error_stack = ?,
+            completed_at = ?
+        WHERE id = ?
+        RETURNING *
+      `)
+      .get(
+        json(outputMetadata, {}),
+        error?.message || String(error),
+        error?.stack || null,
+        nowIso(),
+        id,
+      );
+    return hydrateDistillRun(row);
+  }
+
+  listDistillRuns({ scopeType, scopeKey, sessionId }) {
+    return this.db
+      .prepare(`
+        SELECT * FROM distill_runs
+        WHERE scope_type = ? AND scope_key = ? AND session_id = ?
+        ORDER BY created_at ASC, id ASC
+      `)
+      .all(scopeType, scopeKey, sessionId)
+      .map(hydrateDistillRun);
   }
 }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -19,7 +19,7 @@ test('dbInfo initializes a fresh SQLite store', async () => {
 
   const info = app.dbInfo();
 
-  assert.equal(info.schemaVersion, 1);
+  assert.equal(info.schemaVersion, 2);
   assert.equal(info.tables.memories, 0);
   assert.match(info.dbPath, /contextforge\.db$/);
 });
@@ -86,12 +86,120 @@ test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
 
   assert.equal(checkpoint.provider, 'mock');
   assert.equal(checkpoint.sourceEventCount, 2);
+  assert.ok(checkpoint.distillRunId);
+  assert.deepEqual(checkpoint.metadata.providerMetadata, { roles: 'user, assistant' });
   assert.equal(checkpoint.decisions.length, 1);
   assert.equal(checkpoint.todos.length, 1);
 
   const info = app.dbInfo();
   assert.equal(info.tables.rawEvents, 2);
   assert.equal(info.tables.checkpoints, 1);
+  assert.equal(info.tables.distillRuns, 1);
+
+  const runs = app.listDistillRuns({
+    scope: 'repo',
+    scopeKey: 'repo-a',
+    sessionId: session.sessionId,
+  });
+  assert.equal(runs.length, 1);
+  assert.equal(runs[0].status, 'succeeded');
+  assert.equal(runs[0].outputMetadata.checkpointId, checkpoint.id);
+});
+
+test('distillCheckpoint rejects malformed provider output and preserves raw evidence', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'bad_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      bad_provider: async () => ({
+        summaryShort: 'Missing required arrays.',
+        summaryText: 'Malformed output should be rejected.',
+      }),
+    },
+  });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-b',
+    sessionId: 'bad-session',
+    role: 'user',
+    content: 'Keep this raw event even when validation fails.',
+  });
+
+  await assert.rejects(
+    () =>
+      app.distillCheckpoint({
+        scope: 'repo',
+        scopeKey: 'repo-b',
+        sessionId: 'bad-session',
+      }),
+    /decisions.*array/,
+  );
+
+  const info = app.dbInfo();
+  assert.equal(info.tables.rawEvents, 1);
+  assert.equal(info.tables.checkpoints, 0);
+  assert.equal(info.tables.distillRuns, 1);
+
+  const runs = app.listDistillRuns({
+    scope: 'repo',
+    scopeKey: 'repo-b',
+    sessionId: 'bad-session',
+  });
+  assert.equal(runs[0].status, 'failed');
+  assert.equal(runs[0].outputMetadata.validationFailed, true);
+});
+
+test('distillCheckpoint records provider failures without deleting raw evidence', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'failing_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      failing_provider: async () => {
+        throw new Error('synthetic provider failure');
+      },
+    },
+  });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-c',
+    sessionId: 'failing-session',
+    role: 'assistant',
+    content: 'Raw evidence should survive provider exceptions.',
+  });
+
+  await assert.rejects(
+    () =>
+      app.distillCheckpoint({
+        scope: 'repo',
+        scopeKey: 'repo-c',
+        sessionId: 'failing-session',
+      }),
+    /synthetic provider failure/,
+  );
+
+  const info = app.dbInfo();
+  assert.equal(info.tables.rawEvents, 1);
+  assert.equal(info.tables.checkpoints, 0);
+  assert.equal(info.tables.distillRuns, 1);
+
+  const runs = app.listDistillRuns({
+    scope: 'repo',
+    scopeKey: 'repo-c',
+    sessionId: 'failing-session',
+  });
+  assert.equal(runs[0].status, 'failed');
+  assert.equal(runs[0].errorMessage, 'synthetic provider failure');
+  assert.equal(runs[0].outputMetadata.providerFailed, true);
 });
 
 test('CLI supports the v0 workflow with synthetic data', async () => {
@@ -99,7 +207,7 @@ test('CLI supports the v0 workflow with synthetic data', async () => {
   const env = { ...process.env, CONTEXTFORGE_DATA_DIR: dataDir };
 
   const dbInfo = await execFileAsync('node', ['src/cli.js', 'dbInfo'], { env });
-  assert.match(dbInfo.stdout, /"schemaVersion": 1/);
+  assert.match(dbInfo.stdout, /"schemaVersion": 2/);
 
   await execFileAsync(
     'node',
@@ -161,6 +269,22 @@ test('CLI supports the v0 workflow with synthetic data', async () => {
     { env },
   );
   assert.match(checkpoint.stdout, /"provider": "mock"/);
+
+  const runs = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'listDistillRuns',
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'cli-repo',
+      '--sessionId',
+      'cli-session',
+    ],
+    { env },
+  );
+  assert.match(runs.stdout, /"status": "succeeded"/);
 });
 
 test('runtime database artifacts are ignored by git rules', async () => {


### PR DESCRIPTION
## Summary

- adds provider output validation before checkpoint insertion
- records every distillation attempt in a distill_runs table with started/succeeded/failed status
- stores input metadata, provider metadata, validation failure metadata, and provider error details
- links successful checkpoints back to their distill run and exposes checkpoint metadata
- adds listDistillRuns CLI/core access for debugging
- preserves raw evidence when provider output is malformed or provider execution fails

Refs #5.

## Validation

- npm test
- npm pack --dry-run
- npm audit --audit-level=moderate
- git diff --check
- public-safety search for private reference names and machine-specific paths
