### PR TITLE
[codex] Add codex_exec distillation provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ bring-your-own distillation providers, such as:
 - direct model APIs
 - local model runners
 
-The v0 implementation ships with a `mock` provider first. It gives the storage,
-CLI, and checkpoint contract something deterministic to test before real model
-adapters are added.
+The v0 implementation ships with a deterministic `mock` provider and a
+`codex_exec` provider. The `codex_exec` provider shells out to `codex exec`,
+requests JSON-only output with a schema, validates the result, and records
+provider run metadata.
 
 ## Quick Start
 
@@ -141,6 +142,35 @@ node src/cli.js listDistillRuns \
 
 CLI output is JSON so adapters and scripts can consume it directly.
 
+## codex_exec Provider
+
+Use the Codex CLI as the distillation backend:
+
+```bash
+CONTEXTFORGE_DISTILL_PROVIDER=codex_exec \
+node src/cli.js distillCheckpoint \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --sessionId demo-session
+```
+
+Optional environment variables:
+
+- `CONTEXTFORGE_CODEX_EXEC_COMMAND`: Codex executable name or path. Default:
+  `codex`.
+- `CONTEXTFORGE_CODEX_EXEC_MODEL`: model passed to `codex exec --model`.
+- `CONTEXTFORGE_CODEX_EXEC_SANDBOX`: sandbox passed to `codex exec --sandbox`.
+  Default: `read-only`.
+- `CONTEXTFORGE_CODEX_EXEC_TIMEOUT_MS`: provider timeout. Default: `120000`.
+- `CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS`: raw-event prompt budget. Default:
+  `12000`.
+- `CONTEXTFORGE_CODEX_EXEC_CWD`: working directory passed to `codex exec --cd`.
+  Default: current working directory.
+
+Failure modes are preserved as distillation runs. If `codex exec` exits
+non-zero, times out, or returns malformed JSON, ContextForge records a failed
+`distill_runs` row and leaves raw events untouched for retry or debugging.
+
 ## Public Repo Hygiene
 
 - Runtime state lives under `.contextforge/` by default and is ignored by git.
@@ -152,5 +182,6 @@ CLI output is JSON so adapters and scripts can consume it directly.
 
 Early v0 core. The current implementation includes SQLite migrations, scoped
 durable memories, raw event capture, lexical search with match reasons, and mock
-checkpoint distillation. Real distillation providers and MCP/agent adapters are
-future work.
+checkpoint distillation. The first real provider, `codex_exec`, is available for
+local Codex CLI-backed checkpoint distillation. MCP/agent adapters and additional
+providers are future work.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,6 +148,10 @@ Provider inputs should include:
 - optional relevant durable memories
 - requested output schema
 
+The first real provider is `codex_exec`, which shells out to `codex exec`,
+requests structured JSON output, applies timeout and raw-input budget controls,
+and then uses the same provider validation path as every other adapter.
+
 Provider outputs should include:
 
 - `summaryShort`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,6 +21,8 @@ Delivered:
 
 Tracking issue: #5.
 
+Status: merged in PR #12.
+
 Goals:
 
 - finalize distillation input/output schema
@@ -60,7 +62,7 @@ Goals:
 
 Tracking issue: #6.
 
-Recommended first provider: `codex_exec`.
+Selected first provider: `codex_exec`.
 
 Requirements:
 
@@ -125,8 +127,6 @@ Keep vector search as a retrieval surface, not the canonical source of truth.
 
 - What exact default should repo scope keys use: git remote URL, normalized
   `owner/repo`, absolute path hash, or explicit user config?
-- Should `codex_exec` be the first real provider, or should direct API come first
-  because it is easier to test in CI?
 - In remote mode, should distillation providers run client-side, server-side, or
   both depending on provider type?
 - How should provider prompts be versioned?

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -2,6 +2,18 @@ import path from 'node:path';
 
 const VALID_SCOPES = new Set(['shared', 'repo', 'local']);
 
+function parsePositiveInteger(value, name, fallback) {
+  if (value == null || value === '') {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return parsed;
+}
+
 export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
   const dataDir = env.CONTEXTFORGE_DATA_DIR
     ? path.resolve(cwd, env.CONTEXTFORGE_DATA_DIR)
@@ -17,5 +29,21 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
     defaultScope,
     defaultScopeKey: env.CONTEXTFORGE_DEFAULT_SCOPE_KEY || null,
     distillProvider: env.CONTEXTFORGE_DISTILL_PROVIDER || 'mock',
+    codexExec: {
+      command: env.CONTEXTFORGE_CODEX_EXEC_COMMAND || 'codex',
+      model: env.CONTEXTFORGE_CODEX_EXEC_MODEL || null,
+      sandbox: env.CONTEXTFORGE_CODEX_EXEC_SANDBOX || 'read-only',
+      cwd: env.CONTEXTFORGE_CODEX_EXEC_CWD ? path.resolve(cwd, env.CONTEXTFORGE_CODEX_EXEC_CWD) : cwd,
+      timeoutMs: parsePositiveInteger(
+        env.CONTEXTFORGE_CODEX_EXEC_TIMEOUT_MS,
+        'CONTEXTFORGE_CODEX_EXEC_TIMEOUT_MS',
+        120000,
+      ),
+      maxInputChars: parsePositiveInteger(
+        env.CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS,
+        'CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS',
+        12000,
+      ),
+    },
   };
 }

--- a/src/core.js
+++ b/src/core.js
@@ -30,6 +30,10 @@ function withStore(config, fn) {
 export function createContextForge(options = {}) {
   const config = loadConfig(options);
   const distillProviders = options.distillProviders || {};
+  const codexExec = {
+    ...config.codexExec,
+    runner: options.codexExecRunner,
+  };
 
   return {
     config,
@@ -106,7 +110,9 @@ export function createContextForge(options = {}) {
     async distillCheckpoint(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.sessionId, 'sessionId');
-      const provider = createDistillProvider(options.provider || config.distillProvider, distillProviders);
+      const provider = createDistillProvider(options.provider || config.distillProvider, distillProviders, {
+        codexExec,
+      });
 
       return withStore(config, async (store) => {
         const rawEvents = store.listRawEvents({ ...scope, sessionId: options.sessionId });

--- a/src/distill/index.js
+++ b/src/distill/index.js
@@ -1,6 +1,7 @@
 import { distillWithMockProvider } from './providers/mock.js';
+import { createCodexExecProvider } from './providers/codex_exec.js';
 
-export function createDistillProvider(name, overrides = {}) {
+export function createDistillProvider(name, overrides = {}, options = {}) {
   if (overrides[name]) {
     return {
       name,
@@ -15,5 +16,12 @@ export function createDistillProvider(name, overrides = {}) {
     };
   }
 
-  throw new Error(`Unsupported distill provider "${name}". Available providers: mock.`);
+  if (name === 'codex_exec') {
+    return {
+      name,
+      distill: createCodexExecProvider(options.codexExec),
+    };
+  }
+
+  throw new Error(`Unsupported distill provider "${name}". Available providers: mock, codex_exec.`);
 }

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -1,0 +1,301 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const OUTPUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'summaryShort',
+    'summaryText',
+    'decisions',
+    'todos',
+    'openQuestions',
+    'memoryCandidates',
+    'sourceEventCount',
+    'provider',
+    'metadata',
+  ],
+  properties: {
+    summaryShort: { type: 'string', minLength: 1 },
+    summaryText: { type: 'string', minLength: 1 },
+    decisions: { type: 'array', items: { type: 'string' } },
+    todos: { type: 'array', items: { type: 'string' } },
+    openQuestions: { type: 'array', items: { type: 'string' } },
+    memoryCandidates: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['key', 'content', 'reason'],
+        properties: {
+          key: { type: 'string' },
+          content: { type: 'string' },
+          reason: { type: 'string' },
+        },
+      },
+    },
+    sourceEventCount: { type: 'integer', minimum: 0 },
+    provider: { type: 'string' },
+    metadata: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['providerNotes'],
+      properties: {
+        providerNotes: { type: 'string' },
+      },
+    },
+  },
+};
+
+function truncateText(value, maxChars) {
+  const text = String(value || '');
+  if (text.length <= maxChars) {
+    return { text, truncated: false };
+  }
+  return {
+    text: `${text.slice(0, Math.max(0, maxChars))}\n[truncated]`,
+    truncated: true,
+  };
+}
+
+function compactCheckpoint(checkpoint) {
+  if (!checkpoint) return null;
+  return {
+    id: checkpoint.id,
+    summaryShort: checkpoint.summaryShort,
+    summaryText: checkpoint.summaryText,
+    decisions: checkpoint.decisions,
+    todos: checkpoint.todos,
+    openQuestions: checkpoint.openQuestions,
+    sourceEventCount: checkpoint.sourceEventCount,
+    createdAt: checkpoint.createdAt,
+  };
+}
+
+function buildRawEventPayload(rawEvents, maxInputChars) {
+  const events = [];
+  let remaining = maxInputChars;
+  let truncated = false;
+
+  for (const event of rawEvents) {
+    const base = {
+      id: event.id,
+      role: event.role,
+      createdAt: event.createdAt,
+      metadata: event.metadata,
+    };
+
+    if (remaining <= 0) {
+      truncated = true;
+      events.push({ ...base, content: '[omitted: context budget exhausted]', truncated: true });
+      continue;
+    }
+
+    const content = truncateText(event.content, remaining);
+    remaining -= content.text.length;
+    truncated = truncated || content.truncated;
+    events.push({ ...base, content: content.text, truncated: content.truncated });
+  }
+
+  return { events, truncated };
+}
+
+export function buildCodexExecPrompt(input, options = {}) {
+  const maxInputChars = options.maxInputChars || 12000;
+  const rawPayload = buildRawEventPayload(input.rawEvents || [], maxInputChars);
+  const payload = {
+    task: 'Distill coding-agent raw events into one ContextForge checkpoint.',
+    rules: [
+      'Return only JSON that matches the requested schema.',
+      'Do not include Markdown, code fences, commentary, or private assumptions.',
+      'Preserve uncertainty in openQuestions instead of inventing facts.',
+      'Use only the raw events and previous checkpoint supplied in this request.',
+    ],
+    session: input.session,
+    requestedOutputSchema: input.requestedOutputSchema,
+    previousCheckpoint: compactCheckpoint(input.previousCheckpoint),
+    rawEvents: rawPayload.events,
+  };
+
+  return {
+    prompt: [
+      'You are the ContextForge codex_exec distillation provider.',
+      'Distill the supplied evidence into a checkpoint for future coding-agent continuity.',
+      'Return exactly one JSON object and no surrounding text.',
+      '',
+      JSON.stringify(payload, null, 2),
+    ].join('\n'),
+    metadata: {
+      rawEventCount: rawPayload.events.length,
+      inputTruncated: rawPayload.truncated,
+      maxInputChars,
+    },
+  };
+}
+
+async function readTextIfPresent(filePath) {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return '';
+    }
+    throw error;
+  }
+}
+
+function stripJsonFence(text) {
+  const trimmed = text.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return fenced ? fenced[1].trim() : trimmed;
+}
+
+export function parseCodexExecJson(text) {
+  const stripped = stripJsonFence(text);
+  try {
+    return JSON.parse(stripped);
+  } catch {
+    const start = stripped.indexOf('{');
+    const end = stripped.lastIndexOf('}');
+    if (start !== -1 && end > start) {
+      try {
+        return JSON.parse(stripped.slice(start, end + 1));
+      } catch {
+        throw new Error('Codex exec did not return valid JSON.');
+      }
+    }
+    throw new Error('Codex exec did not return valid JSON.');
+  }
+}
+
+function summarizeStderr(stderr) {
+  const trimmed = stderr.trim();
+  if (!trimmed) return '';
+
+  const errorLines = trimmed
+    .split(/\r?\n/)
+    .filter((line) => /\b(error|failed|invalid|timeout)\b/i.test(line))
+    .join('\n')
+    .trim();
+  const summary = errorLines || trimmed.slice(-1000);
+  return summary.length > 2000 ? `${summary.slice(0, 2000)}\n[truncated]` : summary;
+}
+
+export function runCodexExecCommand({ command, args, prompt, timeoutMs, cwd, env = process.env }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill('SIGTERM');
+      reject(new Error(`codex_exec timed out after ${timeoutMs}ms.`));
+    }, timeoutMs);
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on('close', (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve({ stdout, stderr, code, signal });
+      } else {
+        const stderrSummary = summarizeStderr(stderr);
+        const suffix = stderrSummary ? ` ${stderrSummary}` : '';
+        reject(new Error(`codex_exec exited with code ${code}.${suffix}`));
+      }
+    });
+
+    child.stdin.end(prompt);
+  });
+}
+
+export function createCodexExecProvider(options = {}) {
+  const runner = options.runner || runCodexExecCommand;
+  const command = options.command || 'codex';
+  const model = options.model || null;
+  const sandbox = options.sandbox || 'read-only';
+  const cwd = options.cwd || process.cwd();
+  const timeoutMs = options.timeoutMs || 120000;
+  const maxInputChars = options.maxInputChars || 12000;
+
+  return async function distillWithCodexExecProvider(input) {
+    const startedAt = Date.now();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'contextforge-codex-exec-'));
+    const schemaPath = path.join(tempDir, 'checkpoint.schema.json');
+    const outputPath = path.join(tempDir, 'checkpoint.json');
+    const prompt = buildCodexExecPrompt(input, { maxInputChars });
+
+    await fs.writeFile(schemaPath, `${JSON.stringify(OUTPUT_SCHEMA, null, 2)}\n`, 'utf8');
+
+    const args = [
+      'exec',
+      '--skip-git-repo-check',
+      '--ephemeral',
+      '--sandbox',
+      sandbox,
+      '--cd',
+      cwd,
+      '--output-schema',
+      schemaPath,
+      '--output-last-message',
+      outputPath,
+    ];
+    if (model) {
+      args.push('--model', model);
+    }
+    args.push('-');
+
+    try {
+      const result = await runner({
+        command,
+        args,
+        prompt: prompt.prompt,
+        timeoutMs,
+        cwd,
+        env: process.env,
+      });
+      const outputText = (await readTextIfPresent(outputPath)) || result.stdout || '';
+      const output = parseCodexExecJson(outputText);
+
+      return {
+        ...output,
+        provider: output.provider || 'codex_exec',
+        sourceEventCount: output.sourceEventCount ?? (input.rawEvents || []).length,
+        metadata: {
+          ...(output.metadata || {}),
+          codexExec: {
+            command,
+            model,
+            sandbox,
+            timeoutMs,
+            elapsedMs: Date.now() - startedAt,
+            ...prompt.metadata,
+          },
+        },
+      };
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  };
+}

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -202,6 +202,113 @@ test('distillCheckpoint records provider failures without deleting raw evidence'
   assert.equal(runs[0].outputMetadata.providerFailed, true);
 });
 
+test('codex_exec provider distills synthetic raw events through a runner', async () => {
+  const dataDir = await makeTempDir();
+  let invocation;
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'codex_exec',
+      CONTEXTFORGE_CODEX_EXEC_COMMAND: 'codex-fake',
+      CONTEXTFORGE_CODEX_EXEC_MODEL: 'gpt-test',
+      CONTEXTFORGE_CODEX_EXEC_TIMEOUT_MS: '1234',
+      CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS: '5000',
+    },
+    cwd: process.cwd(),
+    codexExecRunner: async (args) => {
+      invocation = args;
+      return {
+        stdout: JSON.stringify({
+          summaryShort: 'Codex checkpoint for synthetic events.',
+          summaryText: 'The user decided to test the codex_exec provider path.',
+          decisions: ['Use codex_exec behind the provider contract.'],
+          todos: ['Document setup expectations.'],
+          openQuestions: [],
+          memoryCandidates: [{ key: 'provider', content: 'codex_exec is available.' }],
+          sourceEventCount: 1,
+          metadata: { synthetic: true },
+        }),
+      };
+    },
+  });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-codex',
+    sessionId: 'codex-session',
+    role: 'user',
+    content: 'Decision: test codex_exec with synthetic raw events.',
+  });
+
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-codex',
+    sessionId: 'codex-session',
+  });
+
+  assert.equal(checkpoint.provider, 'codex_exec');
+  assert.equal(checkpoint.sourceEventCount, 1);
+  assert.equal(checkpoint.metadata.providerMetadata.synthetic, true);
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.command, 'codex-fake');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.model, 'gpt-test');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.timeoutMs, 1234);
+  assert.match(invocation.prompt, /Return exactly one JSON object/);
+  assert.deepEqual(invocation.args.slice(0, 2), ['exec', '--skip-git-repo-check']);
+  assert.ok(invocation.args.includes('--output-schema'));
+  assert.ok(invocation.args.includes('--output-last-message'));
+  assert.equal(invocation.timeoutMs, 1234);
+
+  const runs = app.listDistillRuns({
+    scope: 'repo',
+    scopeKey: 'repo-codex',
+    sessionId: 'codex-session',
+  });
+  assert.equal(runs[0].status, 'succeeded');
+});
+
+test('codex_exec parse failures preserve raw evidence', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'codex_exec',
+    },
+    cwd: process.cwd(),
+    codexExecRunner: async () => ({ stdout: 'not json' }),
+  });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-codex-fail',
+    sessionId: 'codex-fail-session',
+    role: 'assistant',
+    content: 'Raw evidence should survive codex_exec parse failures.',
+  });
+
+  await assert.rejects(
+    () =>
+      app.distillCheckpoint({
+        scope: 'repo',
+        scopeKey: 'repo-codex-fail',
+        sessionId: 'codex-fail-session',
+      }),
+    /valid JSON/,
+  );
+
+  const info = app.dbInfo();
+  assert.equal(info.tables.rawEvents, 1);
+  assert.equal(info.tables.checkpoints, 0);
+  assert.equal(info.tables.distillRuns, 1);
+
+  const runs = app.listDistillRuns({
+    scope: 'repo',
+    scopeKey: 'repo-codex-fail',
+    sessionId: 'codex-fail-session',
+  });
+  assert.equal(runs[0].status, 'failed');
+  assert.equal(runs[0].outputMetadata.providerFailed, true);
+});
+
 test('CLI supports the v0 workflow with synthetic data', async () => {
   const dataDir = await makeTempDir();
   const env = { ...process.env, CONTEXTFORGE_DATA_DIR: dataDir };


### PR DESCRIPTION
## Summary

- adds a built-in `codex_exec` distillation provider that shells out to `codex exec` with a strict output schema
- wires provider config for command, model, sandbox, timeout, raw input budget, and working directory
- preserves raw evidence on provider failures while recording concise distill run failure metadata
- documents setup expectations, failure modes, and updates roadmap/status language for the first real provider

Refs #6.

## Validation

- `npm test` (9 passing)
- `npm pack --dry-run`
- `npm audit --audit-level=moderate`
- `git diff --check`
- public-safety search for private names, paths, and secret-bearing terms
- live CLI smoke: appended a synthetic raw event and ran `CONTEXTFORGE_DISTILL_PROVIDER=codex_exec node src/cli.js distillCheckpoint --scope repo --scopeKey smoke-codex-exec --sessionId smoke-codex-exec-20260422`; it produced checkpoint `1556d273-d11c-4536-a0a9-5bae20bf8e36` with provider `codex_exec`
- live failure-path proof: the first smoke attempt failed on strict schema requirements, remained recorded as a failed `distill_runs` row, and the same raw evidence was retried successfully after the schema fix
