### PR TITLE
[codex] Add remote storage mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,18 @@ LLM-backed distillation.
 
 ## Storage Modes
 
-- `local`: default single-machine SQLite storage.
-- `project-local`: repo-bound storage in a gitignored directory.
+- `project-local`: repo-bound SQLite storage in a gitignored directory. This is
+  the default v0 mode.
+- `local`: single-machine SQLite storage under the user's home directory.
 - `remote`: first-class VPS or server-backed canonical memory for multiple
   machines.
 
-ContextForge starts local for zero-friction setup, but remote mode is a
+ContextForge starts project-local for zero-friction setup, but remote mode is a
 first-class canonical deployment model for users who work from multiple machines
-or want several agents to share the same source of truth.
+or want several agents to share the same source of truth. Set
+`CONTEXTFORGE_STORAGE_MODE=local` to use home-directory storage, or
+`CONTEXTFORGE_STORAGE_MODE=remote` with `CONTEXTFORGE_REMOTE_URL` to use a
+server-backed store.
 
 See [docs/architecture.md](docs/architecture.md) for the full product model and
 [docs/roadmap.md](docs/roadmap.md) for the implementation roadmap.
@@ -74,6 +78,47 @@ node src/cli.js dbInfo
 By default, runtime data is stored in `.contextforge/contextforge.db` under the
 current working directory. This directory and SQLite sidecar files are ignored by
 git. To use another location, set `CONTEXTFORGE_DATA_DIR`.
+
+## Remote Mode
+
+Run a ContextForge server on the machine that should own canonical memory:
+
+```bash
+CONTEXTFORGE_REMOTE_TOKEN=change-me \
+node src/cli.js serve --host 127.0.0.1 --port 8765
+```
+
+Point a client at that server:
+
+```bash
+CONTEXTFORGE_STORAGE_MODE=remote \
+CONTEXTFORGE_REMOTE_URL=http://127.0.0.1:8765 \
+CONTEXTFORGE_REMOTE_TOKEN=change-me \
+node src/cli.js search \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --query "sqlite runtime"
+```
+
+Remote mode uses the same JSON CLI/core surface as local mode. The server owns
+reads and writes for `shared`, `repo`, and `local` scopes, and the client sends
+the requested scope explicitly with each operation. If a token is configured on
+the server, clients must send it with `CONTEXTFORGE_REMOTE_TOKEN`.
+
+Current v0 remote behavior is deliberately simple:
+
+- `CONTEXTFORGE_STORAGE_MODE=remote` delegates core calls to
+  `CONTEXTFORGE_REMOTE_URL`.
+- `CONTEXTFORGE_STORAGE_MODE=project-local` stores data under `.contextforge/`.
+- `CONTEXTFORGE_STORAGE_MODE=local` stores data under `~/.contextforge/`.
+- No automatic offline cache or fallback writes are performed yet. If the
+  remote server is unavailable, commands fail rather than silently writing to a
+  different canonical store.
+- Distillation runs server-side in remote mode, so provider configuration and
+  credentials belong on the server for now.
+
+Do not point git at live SQLite or raw runtime data. Use git only for source,
+docs, examples, migrations, and reviewed exports.
 
 ## v0 CLI Workflow
 
@@ -181,7 +226,7 @@ non-zero, times out, or returns malformed JSON, ContextForge records a failed
 ## Status
 
 Early v0 core. The current implementation includes SQLite migrations, scoped
-durable memories, raw event capture, lexical search with match reasons, and mock
-checkpoint distillation. The first real provider, `codex_exec`, is available for
-local Codex CLI-backed checkpoint distillation. MCP/agent adapters and additional
-providers are future work.
+durable memories, raw event capture, lexical search with match reasons, mock
+checkpoint distillation, `codex_exec` checkpoint distillation, and a minimal
+remote HTTP mode for server-backed canonical memory. MCP/agent adapters and
+additional providers are future work.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,19 +31,22 @@ Do not replace built-in memory. Add a scoped, searchable project memory sidecar.
 
 ContextForge supports three storage modes.
 
-ContextForge starts local for zero-friction setup, but remote mode is a
-first-class canonical deployment model. Local mode is the easiest entry point
-and a useful fallback/cache shape; remote mode is the power-user path for
-multi-machine and multi-agent workflows.
+ContextForge starts project-local for zero-friction setup, but remote mode is a
+first-class canonical deployment model. Local mode is a single-machine
+home-directory store; project-local mode keeps a repo-bound store near one
+checkout; remote mode is the power-user path for multi-machine and multi-agent
+workflows.
 
 ### Local
 
-Default mode for most users.
+Single-machine home-directory mode.
 
 - SQLite on the local machine
 - no server required
 - simple install
 - best for one developer on one machine
+- configured with `CONTEXTFORGE_STORAGE_MODE=local`
+- default path: `~/.contextforge/contextforge.db`
 
 ### Project-Local
 
@@ -51,6 +54,7 @@ Repo-bound storage in a gitignored directory.
 
 - useful when memory should stay near one checkout
 - default v0 path: `.contextforge/`
+- default v0 storage mode
 - live DB files must not be committed
 
 ### Remote
@@ -64,9 +68,34 @@ users.
 - useful for sharing memory between Codex, Claude Code, Cursor, and custom
   agents
 - should be considered an early product path, not a distant enterprise add-on
+- configured on clients with `CONTEXTFORGE_STORAGE_MODE=remote`,
+  `CONTEXTFORGE_REMOTE_URL`, and optional `CONTEXTFORGE_REMOTE_TOKEN`
+- served by `contextforge-server` or `node src/cli.js serve`
 
 Do not use git as the live storage backend for SQLite or raw runtime data. Git
 can hold source, docs, migrations, example exports, and reviewed snapshots.
+
+### Remote Client/Server Boundary
+
+The v0 remote boundary is intentionally narrow:
+
+- the client keeps no canonical SQLite database when `storageMode=remote`
+- the client sends JSON requests to `/v0/<method>`
+- the server executes the same core methods as local mode
+- bearer-token auth is optional but recommended for every networked server
+- scope type and scope key are part of every read/write request, so remote mode
+  does not change `shared`, `repo`, or `local` semantics
+
+Remote distillation currently runs server-side. This keeps raw evidence and
+provider run metadata in the canonical store and avoids split-brain checkpoint
+writes. Client-side provider execution may be added later for providers that
+must use client-local credentials or tools, but such writes still need to go
+through the remote canonical API.
+
+There is no automatic offline cache or write fallback in v0. If a remote client
+cannot reach the server, the operation should fail visibly. Users may configure
+`project-local` or `local` as an explicit fallback profile, but ContextForge
+should not silently fork canonical memory.
 
 ## Scope Model
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,6 +35,8 @@ Goals:
 
 Tracking issue: #8.
 
+Status: initial implementation in progress.
+
 Remote mode is an early first-class path for users whose canonical work already
 lives on a VPS or server. Local mode remains the zero-friction install and a
 useful fallback/cache shape.
@@ -46,6 +48,14 @@ Goals:
 - multi-machine sync
 - local fallback behavior
 - clear shared/repo/local write policy
+
+Initial implementation:
+
+- JSON HTTP server for the stable core methods
+- remote client mode selected by `CONTEXTFORGE_STORAGE_MODE=remote`
+- bearer token auth with `CONTEXTFORGE_REMOTE_TOKEN`
+- visible failure when remote is unavailable instead of silent local fallback
+- server-side distillation for canonical checkpoint writes
 
 ## Milestone 3: Shared + Repo Retrieval
 
@@ -61,6 +71,8 @@ Goals:
 ## Milestone 4: First Real Distill Provider
 
 Tracking issue: #6.
+
+Status: merged in PR #13.
 
 Selected first provider: `codex_exec`.
 
@@ -127,8 +139,8 @@ Keep vector search as a retrieval surface, not the canonical source of truth.
 
 - What exact default should repo scope keys use: git remote URL, normalized
   `owner/repo`, absolute path hash, or explicit user config?
-- In remote mode, should distillation providers run client-side, server-side, or
-  both depending on provider type?
+- Which remote provider types should eventually support client-side execution
+  while still writing checkpoints through the remote canonical API?
 - How should provider prompts be versioned?
 - Should checkpoint memory candidates require explicit human approval or allow a
   configurable auto-promote policy?

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "better-sqlite3": "^12.9.0"
       },
       "bin": {
-        "contextforge": "src/cli.js"
+        "contextforge": "src/cli.js",
+        "contextforge-server": "src/server.js"
       },
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Self-hosted memory and distillation runtime for coding agents.",
   "type": "module",
   "bin": {
-    "contextforge": "src/cli.js"
+    "contextforge": "src/cli.js",
+    "contextforge-server": "src/server.js"
   },
   "files": [
     "src",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { createContextForge } from './core.js';
+import { startContextForgeServer } from './server.js';
 
 function parseArgs(argv) {
   const command = argv[2];
@@ -69,8 +70,17 @@ async function main() {
         'appendRaw',
         'distillCheckpoint',
         'listDistillRuns',
+        'serve',
       ],
     });
+    return;
+  }
+
+  if (command === 'serve') {
+    const host = options.host || process.env.CONTEXTFORGE_REMOTE_HOST || '127.0.0.1';
+    const port = options.port == null ? Number(process.env.CONTEXTFORGE_REMOTE_PORT || 8765) : Number(options.port);
+    const server = await startContextForgeServer({ host, port });
+    printJson({ listening: server.url });
     return;
   }
 
@@ -78,21 +88,21 @@ async function main() {
   const coreOptions = toCoreOptions(options);
 
   if (command === 'dbInfo') {
-    printJson(app.dbInfo());
+    printJson(await app.dbInfo());
   } else if (command === 'beginSession') {
-    printJson(app.beginSession(coreOptions));
+    printJson(await app.beginSession(coreOptions));
   } else if (command === 'remember') {
-    printJson(app.remember(coreOptions));
+    printJson(await app.remember(coreOptions));
   } else if (command === 'search') {
-    printJson(app.search(coreOptions));
+    printJson(await app.search(coreOptions));
   } else if (command === 'getMemory') {
-    printJson(app.getMemory(coreOptions));
+    printJson(await app.getMemory(coreOptions));
   } else if (command === 'appendRaw') {
-    printJson(app.appendRaw(coreOptions));
+    printJson(await app.appendRaw(coreOptions));
   } else if (command === 'distillCheckpoint') {
     printJson(await app.distillCheckpoint(coreOptions));
   } else if (command === 'listDistillRuns') {
-    printJson(app.listDistillRuns(coreOptions));
+    printJson(await app.listDistillRuns(coreOptions));
   } else {
     throw new Error(`Unknown command: ${command}`);
   }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,6 +1,8 @@
 import path from 'node:path';
+import os from 'node:os';
 
 const VALID_SCOPES = new Set(['shared', 'repo', 'local']);
+const VALID_STORAGE_MODES = new Set(['local', 'project-local', 'remote']);
 
 function parsePositiveInteger(value, name, fallback) {
   if (value == null || value === '') {
@@ -15,8 +17,15 @@ function parsePositiveInteger(value, name, fallback) {
 }
 
 export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
+  const storageMode = env.CONTEXTFORGE_STORAGE_MODE || (env.CONTEXTFORGE_REMOTE_URL ? 'remote' : 'project-local');
+  if (!VALID_STORAGE_MODES.has(storageMode)) {
+    throw new Error(`Invalid CONTEXTFORGE_STORAGE_MODE: ${storageMode}`);
+  }
+
   const dataDir = env.CONTEXTFORGE_DATA_DIR
     ? path.resolve(cwd, env.CONTEXTFORGE_DATA_DIR)
+    : storageMode === 'local'
+      ? path.join(env.HOME || os.homedir(), '.contextforge')
     : path.join(cwd, '.contextforge');
 
   const defaultScope = env.CONTEXTFORGE_DEFAULT_SCOPE || 'repo';
@@ -25,10 +34,20 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
   }
 
   return {
+    storageMode,
     dataDir,
     defaultScope,
     defaultScopeKey: env.CONTEXTFORGE_DEFAULT_SCOPE_KEY || null,
     distillProvider: env.CONTEXTFORGE_DISTILL_PROVIDER || 'mock',
+    remote: {
+      url: env.CONTEXTFORGE_REMOTE_URL || null,
+      token: env.CONTEXTFORGE_REMOTE_TOKEN || null,
+      timeoutMs: parsePositiveInteger(
+        env.CONTEXTFORGE_REMOTE_TIMEOUT_MS,
+        'CONTEXTFORGE_REMOTE_TIMEOUT_MS',
+        30000,
+      ),
+    },
     codexExec: {
       command: env.CONTEXTFORGE_CODEX_EXEC_COMMAND || 'codex',
       model: env.CONTEXTFORGE_CODEX_EXEC_MODEL || null,

--- a/src/core.js
+++ b/src/core.js
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { loadConfig } from './config/index.js';
 import { createDistillProvider } from './distill/index.js';
 import { validateDistillOutput } from './distill/validate.js';
+import { createRemoteContextForge } from './remote/client.js';
 import { searchMemories } from './retrieval/search.js';
 import { normalizeScopeOptions } from './scopes/index.js';
 import { ContextForgeStore } from './storage/sqlite.js';
@@ -29,6 +30,10 @@ function withStore(config, fn) {
 
 export function createContextForge(options = {}) {
   const config = loadConfig(options);
+  if (config.storageMode === 'remote') {
+    return createRemoteContextForge(config, { fetchImpl: options.fetchImpl });
+  }
+
   const distillProviders = options.distillProviders || {};
   const codexExec = {
     ...config.codexExec,

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -1,0 +1,88 @@
+const REMOTE_METHODS = [
+  'dbInfo',
+  'beginSession',
+  'remember',
+  'getMemory',
+  'search',
+  'appendRaw',
+  'distillCheckpoint',
+  'listDistillRuns',
+];
+
+function remoteUrl(baseUrl, method) {
+  const url = new URL(baseUrl);
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/v0/${method}`;
+  return url;
+}
+
+function makeRemoteError(method, status, body) {
+  const message = body?.error?.message || body?.message || `Remote ${method} failed with HTTP ${status}.`;
+  const error = new Error(message);
+  error.status = status;
+  error.remote = true;
+  error.details = body?.error || body;
+  return error;
+}
+
+export class RemoteContextForgeClient {
+  constructor({ config, fetchImpl = globalThis.fetch }) {
+    if (!config.remote.url) {
+      throw new Error('CONTEXTFORGE_REMOTE_URL is required when CONTEXTFORGE_STORAGE_MODE=remote.');
+    }
+    if (typeof fetchImpl !== 'function') {
+      throw new Error('Remote storage mode requires a fetch implementation.');
+    }
+
+    this.config = config;
+    this.fetchImpl = fetchImpl;
+  }
+
+  async call(method, options = {}) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.config.remote.timeoutMs);
+    const headers = {
+      'content-type': 'application/json',
+    };
+    if (this.config.remote.token) {
+      headers.authorization = `Bearer ${this.config.remote.token}`;
+    }
+
+    try {
+      const response = await this.fetchImpl(remoteUrl(this.config.remote.url, method), {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(options || {}),
+        signal: controller.signal,
+      });
+      const text = await response.text();
+      const body = text ? JSON.parse(text) : {};
+      if (!response.ok) {
+        throw makeRemoteError(method, response.status, body);
+      }
+      return body.result;
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        throw new Error(`Remote ${method} timed out after ${this.config.remote.timeoutMs}ms.`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+export function createRemoteContextForge(config, options = {}) {
+  const client = new RemoteContextForgeClient({
+    config,
+    fetchImpl: options.fetchImpl,
+  });
+  const api = { config };
+
+  for (const method of REMOTE_METHODS) {
+    api[method] = (callOptions = {}) => client.call(method, callOptions);
+  }
+
+  return api;
+}
+
+export { REMOTE_METHODS };

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+import http from 'node:http';
+import { createContextForge } from './core.js';
+import { REMOTE_METHODS } from './remote/client.js';
+
+const METHOD_SET = new Set(REMOTE_METHODS);
+const MAX_BODY_BYTES = 1024 * 1024;
+
+function sendJson(response, statusCode, body) {
+  response.writeHead(statusCode, {
+    'content-type': 'application/json',
+  });
+  response.end(`${JSON.stringify(body, null, 2)}\n`);
+}
+
+function readJsonBody(request) {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    let body = '';
+    request.on('data', (chunk) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new Error('Request body is too large.'));
+        request.destroy();
+        return;
+      }
+      body += chunk.toString();
+    });
+    request.on('error', reject);
+    request.on('end', () => {
+      if (!body.trim()) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(body));
+      } catch {
+        reject(new Error('Request body must be valid JSON.'));
+      }
+    });
+  });
+}
+
+function isAuthorized(request, token) {
+  if (!token) return true;
+  return request.headers.authorization === `Bearer ${token}`;
+}
+
+function serverStorageEnv(env) {
+  const storageMode = env.CONTEXTFORGE_SERVER_STORAGE_MODE || env.CONTEXTFORGE_STORAGE_MODE;
+  return {
+    ...env,
+    CONTEXTFORGE_STORAGE_MODE: storageMode === 'remote' || !storageMode ? 'project-local' : storageMode,
+  };
+}
+
+export function createContextForgeServer({ app, env = process.env } = {}) {
+  const serverApp = app || createContextForge({ env: serverStorageEnv(env) });
+  const authToken = env.CONTEXTFORGE_REMOTE_TOKEN || null;
+
+  return http.createServer(async (request, response) => {
+    const requestUrl = new URL(request.url, 'http://localhost');
+
+    if (request.method === 'GET' && requestUrl.pathname === '/healthz') {
+      sendJson(response, 200, { ok: true });
+      return;
+    }
+
+    if (request.method !== 'POST' || !requestUrl.pathname.startsWith('/v0/')) {
+      sendJson(response, 404, { error: { message: 'Not found.' } });
+      return;
+    }
+
+    if (!isAuthorized(request, authToken)) {
+      sendJson(response, 401, { error: { message: 'Unauthorized.' } });
+      return;
+    }
+
+    const method = requestUrl.pathname.slice('/v0/'.length);
+    if (!METHOD_SET.has(method) || typeof serverApp[method] !== 'function') {
+      sendJson(response, 404, { error: { message: `Unknown method: ${method}` } });
+      return;
+    }
+
+    try {
+      const options = await readJsonBody(request);
+      const result = await serverApp[method](options);
+      sendJson(response, 200, { result });
+    } catch (error) {
+      sendJson(response, 500, {
+        error: {
+          message: error.message,
+          name: error.name,
+        },
+      });
+    }
+  });
+}
+
+export function startContextForgeServer({ host = '127.0.0.1', port = 8765, env = process.env, app } = {}) {
+  const server = createContextForgeServer({ app, env });
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => {
+      const address = server.address();
+      resolve({
+        server,
+        host,
+        port: address.port,
+        url: `http://${host}:${address.port}`,
+        close: () =>
+          new Promise((closeResolve, closeReject) => {
+            server.close((error) => {
+              if (error) closeReject(error);
+              else closeResolve();
+            });
+          }),
+      });
+    });
+  });
+}
+
+async function main() {
+  const port = Number(process.env.CONTEXTFORGE_REMOTE_PORT || 8765);
+  const host = process.env.CONTEXTFORGE_REMOTE_HOST || '127.0.0.1';
+  const instance = await startContextForgeServer({ host, port });
+  console.log(JSON.stringify({ listening: instance.url }, null, 2));
+}
+
+if (process.argv[1] && import.meta.url === new URL(process.argv[1], 'file:').href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import test from 'node:test';
 import { createContextForge } from '../src/core.js';
+import { startContextForgeServer } from '../src/server.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -392,6 +393,106 @@ test('CLI supports the v0 workflow with synthetic data', async () => {
     { env },
   );
   assert.match(runs.stdout, /"status": "succeeded"/);
+});
+
+test('remote storage mode delegates core calls and preserves scope semantics', async () => {
+  const dataDir = await makeTempDir();
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+    },
+  });
+
+  try {
+    const app = createContextForge({
+      env: {
+        CONTEXTFORGE_STORAGE_MODE: 'remote',
+        CONTEXTFORGE_REMOTE_URL: remote.url,
+        CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+      },
+      cwd: process.cwd(),
+    });
+
+    await app.remember({
+      scope: 'repo',
+      scopeKey: 'repo-remote',
+      key: 'storage-mode',
+      content: 'Remote repo memory stays in repo scope.',
+      category: 'decision',
+    });
+    await app.remember({
+      scope: 'shared',
+      scopeKey: 'global',
+      key: 'storage-mode',
+      content: 'Shared memory stays in shared scope.',
+      category: 'policy',
+    });
+
+    const repoMemory = await app.getMemory({
+      scope: 'repo',
+      scopeKey: 'repo-remote',
+      key: 'storage-mode',
+    });
+    const sharedMemory = await app.getMemory({
+      scope: 'shared',
+      scopeKey: 'global',
+      key: 'storage-mode',
+    });
+    assert.equal(repoMemory.scopeType, 'repo');
+    assert.equal(repoMemory.content, 'Remote repo memory stays in repo scope.');
+    assert.equal(sharedMemory.scopeType, 'shared');
+    assert.equal(sharedMemory.content, 'Shared memory stays in shared scope.');
+
+    const repoResults = await app.search({
+      scope: 'repo',
+      scopeKey: 'repo-remote',
+      query: 'remote scope',
+    });
+    assert.equal(repoResults.length, 1);
+    assert.equal(repoResults[0].memory.scopeType, 'repo');
+
+    const info = await app.dbInfo();
+    assert.equal(info.tables.memories, 2);
+  } finally {
+    await remote.close();
+  }
+});
+
+test('remote storage mode rejects unauthorized writes', async () => {
+  const dataDir = await makeTempDir();
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+    },
+  });
+
+  try {
+    const app = createContextForge({
+      env: {
+        CONTEXTFORGE_STORAGE_MODE: 'remote',
+        CONTEXTFORGE_REMOTE_URL: remote.url,
+        CONTEXTFORGE_REMOTE_TOKEN: 'wrong-token',
+      },
+      cwd: process.cwd(),
+    });
+
+    await assert.rejects(
+      () =>
+        app.remember({
+          scope: 'repo',
+          scopeKey: 'repo-remote',
+          key: 'unauthorized',
+          content: 'This should not be written.',
+        }),
+      /Unauthorized/,
+    );
+  } finally {
+    await remote.close();
+  }
 });
 
 test('runtime database artifacts are ignored by git rules', async () => {


### PR DESCRIPTION
## Summary

- adds `CONTEXTFORGE_STORAGE_MODE` with `project-local`, `local`, and `remote` modes
- adds a remote HTTP client that delegates the stable core API to `/v0/<method>`
- adds a minimal ContextForge server with optional bearer-token auth and `serve` CLI entrypoint
- keeps remote scope semantics explicit for `shared`, `repo`, and `local` requests
- documents remote client/server boundaries, server-side distillation, and the no-silent-fallback policy

Refs #8.

## Validation

- `npm test` (11 passing)
- `npm pack --dry-run`
- `npm audit --audit-level=moderate`
- `git diff --check`
- `node --check src/server.js`
- CLI smoke: `timeout 3 env CONTEXTFORGE_DATA_DIR=/tmp/contextforge-remote-smoke CONTEXTFORGE_REMOTE_TOKEN=smoke node src/cli.js serve --host 127.0.0.1 --port 0` printed a listening URL
- public-safety search for private names, paths, and secret-bearing terms; hits were expected docs/tests/code references only
