### PR TITLE
[codex] Support shared plus repo retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,24 @@ node src/cli.js search \
   --query "sqlite runtime"
 ```
 
+Search repo memory together with shared rules:
+
+```bash
+node src/cli.js search \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --searchScopes repo+shared \
+  --sharedScopeKey global \
+  --query "retrieval policy"
+```
+
+`--searchScopes` accepts `scope`, `repo`, `shared`, `repo+shared`, or `local`.
+The default, `scope`, searches only the explicit `--scope` and `--scopeKey`.
+`repo+shared` searches the repo scope plus shared durable memory while leaving
+`local` memory out. Local memory appears only when `--scope local` or
+`--searchScopes local` is requested. If `--sharedScopeKey` is omitted,
+ContextForge uses `CONTEXTFORGE_SHARED_SCOPE_KEY` or `global`.
+
 Fetch one memory by key:
 
 ```bash
@@ -228,5 +246,6 @@ non-zero, times out, or returns malformed JSON, ContextForge records a failed
 Early v0 core. The current implementation includes SQLite migrations, scoped
 durable memories, raw event capture, lexical search with match reasons, mock
 checkpoint distillation, `codex_exec` checkpoint distillation, and a minimal
-remote HTTP mode for server-backed canonical memory. MCP/agent adapters and
+remote HTTP mode for server-backed canonical memory. Search can combine repo and
+shared memory while keeping local memory opt-in. MCP/agent adapters and
 additional providers are future work.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,6 +109,11 @@ Scopes are intentionally explicit.
 should not leak into shared or remote scopes by default. Promotion from `local`
 or checkpoint content into durable `repo` or `shared` memory should be explicit.
 
+The default shared scope key is `global` unless configured with
+`CONTEXTFORGE_SHARED_SCOPE_KEY`. Combined retrieval should include source
+metadata for every result so callers can explain whether a memory came from the
+current repo, shared durable memory, or an explicitly requested local scope.
+
 ## Memory Layers
 
 ContextForge separates memory into layers.
@@ -234,6 +239,18 @@ Avoid:
 
 The default runtime should minimize prompt bloat by preloading only tiny
 bootstrap context, then using `search` and `getMemory` for detail.
+
+Search modes:
+
+- `scope`: search only the explicit scope and scope key
+- `repo`: search the repo scope
+- `shared`: search shared durable memory
+- `repo+shared`: search repo memory and shared durable memory together
+- `local`: search local memory only when explicitly requested
+
+When `repo+shared` is used, exact repo memory should rank ahead of equally
+relevant shared memory. Shared memory is still returned when relevant, and local
+memory is excluded unless requested.
 
 ## Adapter Strategy
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -61,12 +61,22 @@ Initial implementation:
 
 Tracking issue: #7.
 
+Status: initial implementation in progress.
+
 Goals:
 
 - allow querying `repo` and `shared` together
 - keep `local` opt-in
 - provide result source metadata
 - favor exact repo memory while including useful shared rules
+
+Initial implementation:
+
+- `searchScopes` option for `scope`, `repo`, `shared`, `repo+shared`, and
+  `local`
+- `sharedScopeKey` option with `CONTEXTFORGE_SHARED_SCOPE_KEY` fallback
+- result `source` metadata describing the returned scope and role
+- local memory remains excluded from `repo+shared`
 
 ## Milestone 4: First Real Distill Provider
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -45,6 +45,8 @@ function toCoreOptions(options) {
     importance: options.importance == null ? 0 : Number(options.importance),
     query: options.query,
     limit: options.limit == null ? 10 : Number(options.limit),
+    searchScopes: options.searchScopes,
+    sharedScopeKey: options.sharedScopeKey,
     sessionId: options.sessionId,
     conversationId: options.conversationId,
     role: options.role,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -38,6 +38,7 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
     dataDir,
     defaultScope,
     defaultScopeKey: env.CONTEXTFORGE_DEFAULT_SCOPE_KEY || null,
+    defaultSharedScopeKey: env.CONTEXTFORGE_SHARED_SCOPE_KEY || 'global',
     distillProvider: env.CONTEXTFORGE_DISTILL_PROVIDER || 'mock',
     remote: {
       url: env.CONTEXTFORGE_REMOTE_URL || null,

--- a/src/core.js
+++ b/src/core.js
@@ -91,6 +91,8 @@ export function createContextForge(options = {}) {
           ...scope,
           query: options.query,
           limit: options.limit,
+          searchScopes: options.searchScopes,
+          sharedScopeKey: options.sharedScopeKey || config.defaultSharedScopeKey,
         }),
       );
     },

--- a/src/retrieval/search.js
+++ b/src/retrieval/search.js
@@ -35,24 +35,68 @@ function scoreMemory(memory, queryTokens) {
   };
 }
 
-export function searchMemories(store, { scopeType, scopeKey, query, limit = 10 }) {
+function normalizeSearchScopes({ scopeType, scopeKey, searchScopes, sharedScopeKey }) {
+  const mode = searchScopes || 'scope';
+  if (mode === 'scope') {
+    return [{ scopeType, scopeKey, role: scopeType }];
+  }
+  if (mode === 'repo') {
+    return [{ scopeType: 'repo', scopeKey, role: 'repo' }];
+  }
+  if (mode === 'shared') {
+    return [{ scopeType: 'shared', scopeKey: sharedScopeKey || scopeKey, role: 'shared' }];
+  }
+  if (mode === 'repo+shared') {
+    return [
+      { scopeType: 'repo', scopeKey, role: 'repo' },
+      { scopeType: 'shared', scopeKey: sharedScopeKey, role: 'shared' },
+    ];
+  }
+  if (mode === 'local') {
+    return [{ scopeType: 'local', scopeKey, role: 'local' }];
+  }
+
+  throw new Error('searchScopes must be one of: scope, repo, shared, repo+shared, local.');
+}
+
+function scopeBoost(source) {
+  if (source.role === 'repo') return 1000;
+  if (source.role === 'shared') return 100;
+  return 0;
+}
+
+export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, searchScopes, sharedScopeKey }) {
   const queryTokens = unique(tokenize(query));
   if (queryTokens.length === 0) {
     return [];
   }
 
-  return store
-    .listMemories({ scopeType, scopeKey })
-    .map((memory) => {
-      const match = scoreMemory(memory, queryTokens);
-      return {
-        type: 'memory',
-        score: match.score,
-        why: match.matched,
-        memory,
-      };
-    })
+  const scopes = normalizeSearchScopes({ scopeType, scopeKey, searchScopes, sharedScopeKey });
+
+  return scopes
+    .flatMap((source) =>
+      store.listMemories(source).map((memory) => {
+        const match = scoreMemory(memory, queryTokens);
+        return {
+          type: 'memory',
+          score: match.score,
+          why: match.matched,
+          source: {
+            scopeType: source.scopeType,
+            scopeKey: source.scopeKey,
+            role: source.role,
+          },
+          memory,
+        };
+      }),
+    )
     .filter((result) => result.score > 0)
-    .sort((a, b) => b.score - a.score || b.memory.importance - a.memory.importance)
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        scopeBoost(b.source) - scopeBoost(a.source) ||
+        b.memory.importance - a.memory.importance ||
+        b.memory.updatedAt.localeCompare(a.memory.updatedAt),
+    )
     .slice(0, limit);
 }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -59,6 +59,95 @@ test('remember, getMemory, and search use explicit scopes', async () => {
   assert.ok(results[0].why.some((hit) => hit.token === 'sqlite'));
 });
 
+test('search can combine repo and shared scopes while excluding local by default', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'repo-combined',
+    key: 'repo-rule',
+    content: 'Always inspect repository code before changing retrieval behavior.',
+    category: 'decision',
+    importance: 1,
+  });
+  app.remember({
+    scope: 'shared',
+    scopeKey: 'global',
+    key: 'shared-rule',
+    content: 'Always keep retrieval explanations visible.',
+    category: 'policy',
+    importance: 10,
+  });
+  app.remember({
+    scope: 'local',
+    scopeKey: 'machine-a',
+    key: 'local-rule',
+    content: 'Always keep this local-only retrieval note private to this machine.',
+    category: 'note',
+    importance: 99,
+  });
+
+  const combined = app.search({
+    scope: 'repo',
+    scopeKey: 'repo-combined',
+    searchScopes: 'repo+shared',
+    query: 'always retrieval',
+  });
+
+  assert.deepEqual(
+    combined.map((result) => result.memory.key),
+    ['repo-rule', 'shared-rule'],
+  );
+  assert.deepEqual(
+    combined.map((result) => result.source.role),
+    ['repo', 'shared'],
+  );
+  assert.ok(combined.every((result) => result.source.scopeType !== 'local'));
+  assert.ok(combined.every((result) => result.why.some((hit) => hit.token === 'retrieval')));
+
+  const local = app.search({
+    scope: 'local',
+    scopeKey: 'machine-a',
+    searchScopes: 'local',
+    query: 'retrieval',
+  });
+  assert.equal(local.length, 1);
+  assert.equal(local[0].memory.key, 'local-rule');
+  assert.equal(local[0].source.role, 'local');
+});
+
+test('search supports shared-only retrieval with an explicit shared scope key', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'repo-shared-only',
+    key: 'repo-rule',
+    content: 'Repo retrieval should not appear in a shared-only query.',
+  });
+  app.remember({
+    scope: 'shared',
+    scopeKey: 'team',
+    key: 'team-rule',
+    content: 'Shared retrieval can be requested independently.',
+  });
+
+  const results = app.search({
+    scope: 'repo',
+    scopeKey: 'repo-shared-only',
+    searchScopes: 'shared',
+    sharedScopeKey: 'team',
+    query: 'retrieval',
+  });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].memory.key, 'team-rule');
+  assert.equal(results[0].source.scopeType, 'shared');
+  assert.equal(results[0].source.scopeKey, 'team');
+});
+
 test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });


### PR DESCRIPTION
## Summary

- adds `searchScopes` for `scope`, `repo`, `shared`, `repo+shared`, and `local` retrieval modes
- adds `sharedScopeKey` plus `CONTEXTFORGE_SHARED_SCOPE_KEY` fallback for shared durable memory
- returns `source` metadata on search results so callers can explain where a memory came from
- keeps local memory excluded from `repo+shared` unless local retrieval is explicitly requested
- ranks equally relevant repo memories ahead of shared memories while still returning relevant shared rules
- documents CLI usage and retrieval policy

Refs #7.

## Validation

- `npm test` (13 passing)
- `npm pack --dry-run`
- `npm audit --audit-level=moderate`
- `git diff --check`
- CLI smoke: created synthetic repo/shared/local memories in a temp data dir, then ran `node src/cli.js search --scope repo --scopeKey cli-combined --searchScopes repo+shared --query retrieval`; output returned repo and shared results with `source` metadata and excluded local
- public-safety search for private names, paths, and secret-bearing terms; hits were expected docs/tests/code references only
