### PR TITLE
Improve retrieval ranking with FTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ The default, `scope`, searches only the explicit `--scope` and `--scopeKey`.
 `--searchScopes local` is requested. If `--sharedScopeKey` is omitted,
 ContextForge uses `CONTEXTFORGE_SHARED_SCOPE_KEY` or `global`.
 
+Search uses a SQLite FTS5 index as an explainable retrieval surface over the
+canonical `memories` table. Results include `why` match metadata and
+`retrieval` rank metadata so callers can debug why an item was returned.
+
 Fetch one memory by key:
 
 ```bash
@@ -340,7 +344,7 @@ non-zero, times out, or returns malformed JSON, ContextForge records a failed
 ## Status
 
 Early v0 core. The current implementation includes SQLite migrations, scoped
-durable memories, raw event capture, lexical search with match reasons, mock
+durable memories, raw event capture, FTS-backed explainable search, mock
 checkpoint distillation, `codex_exec` checkpoint distillation, and a minimal
 remote HTTP mode for server-backed canonical memory. Search can combine repo and
 shared memory while keeping local memory opt-in. MCP stdio integration and an

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,6 +114,19 @@ The default shared scope key is `global` unless configured with
 metadata for every result so callers can explain whether a memory came from the
 current repo, shared durable memory, or an explicitly requested local scope.
 
+## Retrieval Quality
+
+Durable memory remains canonical in the `memories` table. SQLite FTS5 is a
+retrieval index over that table, not a second source of truth. The index is
+rebuilt during startup migration and updated when durable memories are
+remembered, corrected, promoted, or deactivated.
+
+Search results should stay explainable. Each result includes lexical `why`
+metadata describing matched query tokens, fields, and match types, plus
+retrieval metadata such as the FTS rank and method. This keeps better ranking
+debuggable and leaves room for future vector search as another retrieval
+surface, not canonical storage.
+
 ## Memory Layers
 
 ContextForge separates memory into layers.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -156,6 +156,8 @@ Initial implementation:
 
 Tracking issue: #9.
 
+Status: initial implementation in progress.
+
 Possible improvements:
 
 - SQLite FTS
@@ -165,6 +167,14 @@ Possible improvements:
 - stale memory warnings
 
 Keep vector search as a retrieval surface, not the canonical source of truth.
+
+Initial implementation:
+
+- SQLite FTS5 index over active durable memories
+- canonical memory remains in `memories`; FTS is rebuilt/updated as a retrieval index
+- weighted FTS rank is combined with explainable lexical scoring
+- result metadata includes `why` token/field/match-type details and `retrieval.ftsRank`
+- inactive memories remain excluded from search
 
 ## Open Decisions
 

--- a/src/retrieval/search.js
+++ b/src/retrieval/search.js
@@ -9,6 +9,19 @@ function unique(values) {
   return [...new Set(values)];
 }
 
+function toFtsQuery(tokens) {
+  return tokens
+    .map((token) => token.replace(/"/g, '').replace(/[^a-z0-9_]+/g, ' '))
+    .flatMap((token) => token.split(/\s+/).filter(Boolean))
+    .map((token) => `"${token}"*`)
+    .join(' OR ');
+}
+
+function ftsScore(rank) {
+  if (rank == null) return 0;
+  return Math.max(0, Math.round(Math.abs(Number(rank)) * 1000000));
+}
+
 function scoreMemory(memory, queryTokens) {
   const fields = {
     key: memory.key,
@@ -20,12 +33,33 @@ function scoreMemory(memory, queryTokens) {
   let score = 0;
   const matched = [];
   for (const token of queryTokens) {
-    const hitFields = Object.entries(fields)
-      .filter(([, value]) => String(value || '').toLowerCase().includes(token))
-      .map(([name]) => name);
+    const hitFields = [];
+    for (const [name, value] of Object.entries(fields)) {
+      const fieldTokens = tokenize(value);
+      const lowerValue = String(value || '').toLowerCase();
+      const matchType = fieldTokens.some((fieldToken) => fieldToken === token)
+        ? 'exact'
+        : fieldTokens.some((fieldToken) => fieldToken.startsWith(token))
+          ? 'prefix'
+          : lowerValue.includes(token)
+            ? 'substring'
+            : null;
+      if (matchType) {
+        hitFields.push({ name, matchType });
+      }
+    }
     if (hitFields.length > 0) {
-      score += hitFields.includes('content') ? 2 : 1;
-      matched.push({ token, fields: hitFields });
+      const fieldScore = hitFields.reduce((sum, field) => {
+        const fieldWeight = field.name === 'key' ? 4 : field.name === 'content' ? 2 : 1;
+        const matchWeight = field.matchType === 'exact' ? 3 : field.matchType === 'prefix' ? 2 : 1;
+        return sum + fieldWeight * matchWeight;
+      }, 0);
+      score += fieldScore;
+      matched.push({
+        token,
+        fields: hitFields.map((field) => field.name),
+        matchTypes: [...new Set(hitFields.map((field) => field.matchType))],
+      });
     }
   }
 
@@ -72,15 +106,37 @@ export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, 
   }
 
   const scopes = normalizeSearchScopes({ scopeType, scopeKey, searchScopes, sharedScopeKey });
+  const ftsQuery = toFtsQuery(queryTokens);
 
   return scopes
-    .flatMap((source) =>
-      store.listMemories(source).map((memory) => {
+    .flatMap((source) => {
+      const ftsMatches = store.searchMemoryIndex
+        ? store.searchMemoryIndex({
+            scopeType: source.scopeType,
+            scopeKey: source.scopeKey,
+            ftsQuery,
+            limit: Math.max(limit * 4, 50),
+          })
+        : [];
+      const ftsById = new Map(ftsMatches.map((match) => [match.memory.id, match]));
+      const ftsIds = new Set(ftsById.keys());
+      const memoriesById = new Map([
+        ...store.listMemories(source).map((memory) => [memory.id, memory]),
+        ...ftsMatches.map((match) => [match.memory.id, match.memory]),
+      ]);
+
+      return [...memoriesById.values()].map((memory) => {
         const match = scoreMemory(memory, queryTokens);
+        const ftsMatch = ftsById.get(memory.id);
+        const score = match.score + ftsScore(ftsMatch?.ftsRank);
         return {
           type: 'memory',
-          score: match.score,
+          score,
           why: match.matched,
+          retrieval: {
+            method: ftsIds.has(memory.id) ? 'fts5+lexical' : 'lexical',
+            ftsRank: ftsMatch?.ftsRank ?? null,
+          },
           source: {
             scopeType: source.scopeType,
             scopeKey: source.scopeKey,
@@ -88,8 +144,8 @@ export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, 
           },
           memory,
         };
-      }),
-    )
+      });
+    })
     .filter((result) => result.score > 0)
     .sort(
       (a, b) =>

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import Database from 'better-sqlite3';
 
-const SCHEMA_VERSION = 3;
+const SCHEMA_VERSION = 4;
 
 function nowIso() {
   return new Date().toISOString();
@@ -110,6 +110,10 @@ function hydrateMemoryEvent(row) {
   };
 }
 
+function ftsValue(value) {
+  return String(value || '').replace(/\0/g, ' ');
+}
+
 export class ContextForgeStore {
   constructor({ dataDir }) {
     this.dataDir = dataDir;
@@ -211,6 +215,16 @@ export class ContextForgeStore {
         FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE CASCADE
       );
 
+      CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+        memory_id UNINDEXED,
+        scope_type UNINDEXED,
+        scope_key UNINDEXED,
+        memory_key,
+        category,
+        content,
+        tags
+      );
+
       CREATE INDEX IF NOT EXISTS idx_memories_scope
         ON memories(scope_type, scope_key);
       CREATE INDEX IF NOT EXISTS idx_raw_events_session
@@ -226,6 +240,7 @@ export class ContextForgeStore {
     this.ensureColumn('memories', 'status', "TEXT NOT NULL DEFAULT 'active'");
     this.ensureColumn('memories', 'supersedes_memory_id', 'TEXT');
     this.ensureColumn('memories', 'deactivated_at', 'TEXT');
+    this.rebuildMemoryFts();
 
     this.db
       .prepare(`
@@ -252,6 +267,59 @@ export class ContextForgeStore {
         memoryEvents: count('memory_events'),
       },
     };
+  }
+
+  rebuildMemoryFts() {
+    this.db.prepare('DELETE FROM memory_fts').run();
+    const rows = this.db
+      .prepare(`
+        SELECT * FROM memories
+        WHERE status = 'active'
+      `)
+      .all();
+    const insert = this.db.prepare(`
+      INSERT INTO memory_fts (
+        memory_id, scope_type, scope_key, memory_key, category, content, tags
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+    const transaction = this.db.transaction((memories) => {
+      for (const row of memories) {
+        insert.run(
+          row.id,
+          row.scope_type,
+          row.scope_key,
+          ftsValue(row.memory_key),
+          ftsValue(row.category),
+          ftsValue(row.content),
+          ftsValue(parseJson(row.tags_json, []).join(' ')),
+        );
+      }
+    });
+    transaction(rows);
+  }
+
+  upsertMemoryFts(memory) {
+    this.db.prepare('DELETE FROM memory_fts WHERE memory_id = ?').run(memory.id);
+    if (memory.status !== 'active') {
+      return;
+    }
+    this.db
+      .prepare(`
+        INSERT INTO memory_fts (
+          memory_id, scope_type, scope_key, memory_key, category, content, tags
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `)
+      .run(
+        memory.id,
+        memory.scopeType,
+        memory.scopeKey,
+        ftsValue(memory.key),
+        ftsValue(memory.category),
+        ftsValue(memory.content),
+        ftsValue(memory.tags.join(' ')),
+      );
   }
 
   rememberMemory({
@@ -315,7 +383,9 @@ export class ContextForgeStore {
       `)
       .run(randomUUID(), row.id, eventType, json(eventMetadata || { key }, {}), nowIso());
 
-    return hydrateMemory(row);
+    const memory = hydrateMemory(row);
+    this.upsertMemoryFts(memory);
+    return memory;
   }
 
   getMemory({ scopeType, scopeKey, key }) {
@@ -326,6 +396,32 @@ export class ContextForgeStore {
       `)
       .get(scopeType, scopeKey, key);
     return hydrateMemory(row);
+  }
+
+  searchMemoryIndex({ scopeType, scopeKey, ftsQuery, limit = 50 }) {
+    if (!ftsQuery) {
+      return [];
+    }
+
+    return this.db
+      .prepare(`
+        SELECT
+          memories.*,
+          bm25(memory_fts, 0.0, 0.0, 0.0, 8.0, 2.0, 5.0, 1.0) AS fts_rank
+        FROM memory_fts
+        JOIN memories ON memories.id = memory_fts.memory_id
+        WHERE memory_fts MATCH ?
+          AND memory_fts.scope_type = ?
+          AND memory_fts.scope_key = ?
+          AND memories.status = 'active'
+        ORDER BY fts_rank ASC, memories.importance DESC, memories.updated_at DESC
+        LIMIT ?
+      `)
+      .all(ftsQuery, scopeType, scopeKey, limit)
+      .map((row) => ({
+        memory: hydrateMemory(row),
+        ftsRank: row.fts_rank,
+      }));
   }
 
   listMemories({ scopeType, scopeKey }) {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -22,7 +22,7 @@ test('dbInfo initializes a fresh SQLite store', async () => {
 
   const info = app.dbInfo();
 
-  assert.equal(info.schemaVersion, 3);
+  assert.equal(info.schemaVersion, 4);
   assert.equal(info.tables.memories, 0);
   assert.match(info.dbPath, /contextforge\.db$/);
 });
@@ -352,6 +352,50 @@ test('search supports shared-only retrieval with an explicit shared scope key', 
   assert.equal(results[0].source.scopeKey, 'team');
 });
 
+test('search uses explainable FTS-backed ranking while keeping durable memory canonical', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'repo-quality',
+    key: 'retrieval-quality',
+    content: 'Use SQLite FTS for explainable retrieval ranking.',
+    category: 'decision',
+    tags: ['search'],
+    importance: 1,
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'repo-quality',
+    key: 'general-note',
+    content: 'Retrieval can mention ranking in a lower priority note.',
+    category: 'note',
+    tags: [],
+    importance: 10,
+  });
+
+  const results = app.search({
+    scope: 'repo',
+    scopeKey: 'repo-quality',
+    query: 'retriev qual',
+  });
+
+  assert.equal(results.length, 2);
+  assert.equal(results[0].memory.key, 'retrieval-quality');
+  assert.equal(results[0].retrieval.method, 'fts5+lexical');
+  assert.ok(results[0].why.some((hit) => hit.token === 'retriev' && hit.matchTypes.includes('prefix')));
+  assert.ok(results[0].why.some((hit) => hit.fields.includes('key')));
+  assert.ok(results.every((result) => result.retrieval.ftsRank != null));
+
+  const fetched = app.getMemory({
+    scope: 'repo',
+    scopeKey: 'repo-quality',
+    key: 'retrieval-quality',
+  });
+  assert.equal(fetched.content, 'Use SQLite FTS for explainable retrieval ranking.');
+});
+
 test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
@@ -608,7 +652,7 @@ test('CLI supports the v0 workflow with synthetic data', async () => {
   const env = { ...process.env, CONTEXTFORGE_DATA_DIR: dataDir };
 
   const dbInfo = await execFileAsync('node', ['src/cli.js', 'dbInfo'], { env });
-  assert.match(dbInfo.stdout, /"schemaVersion": 3/);
+  assert.match(dbInfo.stdout, /"schemaVersion": 4/);
 
   await execFileAsync(
     'node',


### PR DESCRIPTION
## Summary

- add a SQLite FTS5 retrieval index over active durable memories
- keep canonical memory in `memories`; FTS is rebuilt/updated as a retrieval surface
- combine weighted FTS rank with explainable lexical scoring
- include `why` match types and `retrieval.ftsRank` metadata in search results
- document retrieval quality behavior and roadmap status

Closes #9

## Validation

- `npm test`
- `npm pack --dry-run`
- `npm audit --audit-level=moderate`
- `git diff --check`