### PR TITLE
Infer default repo scope keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ By default, runtime data is stored in `.contextforge/contextforge.db` under the
 current working directory. This directory and SQLite sidecar files are ignored by
 git. To use another location, set `CONTEXTFORGE_DATA_DIR`.
 
+Repo scope keys default to the current git checkout when possible. ContextForge
+normalizes common GitHub origin remotes to `github.com/owner/repo`; outside a
+git checkout it falls back to a deterministic `path:<hash>:<name>` key. Pass
+`--scopeKey` or set `CONTEXTFORGE_DEFAULT_SCOPE_KEY` when you want an explicit
+scope key.
+
 ## Remote Mode
 
 Run a ContextForge server on the machine that should own canonical memory:
@@ -127,7 +133,6 @@ Create or update a durable memory:
 ```bash
 node src/cli.js remember \
   --scope repo \
-  --scopeKey github.com/example/contextforge \
   --key storage-mode \
   --category decision \
   --tag storage \
@@ -139,7 +144,6 @@ Search durable memories:
 ```bash
 node src/cli.js search \
   --scope repo \
-  --scopeKey github.com/example/contextforge \
   --query "sqlite runtime"
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,6 +114,12 @@ The default shared scope key is `global` unless configured with
 metadata for every result so callers can explain whether a memory came from the
 current repo, shared durable memory, or an explicitly requested local scope.
 
+Repo scope keys should be stable without being surprising. Explicit `scopeKey`
+arguments and `CONTEXTFORGE_DEFAULT_SCOPE_KEY` always win. Otherwise, repo scope
+defaults to the current git checkout: common GitHub origin remotes normalize to
+`github.com/owner/repo`, and directories without a usable git remote fall back
+to a deterministic `path:<hash>:<name>` key.
+
 ## Retrieval Quality
 
 Durable memory remains canonical in the `memories` table. SQLite FTS5 is a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -178,8 +178,9 @@ Initial implementation:
 
 ## Open Decisions
 
-- What exact default should repo scope keys use: git remote URL, normalized
-  `owner/repo`, absolute path hash, or explicit user config?
+- Default repo scope keys now infer from git remotes when possible, normalize
+  common GitHub remotes to `github.com/owner/repo`, and fall back to
+  deterministic path keys. Explicit user config still wins.
 - Which remote provider types should eventually support client-side execution
   while still writing checkpoints through the remote canonical API?
 - How should provider prompts be versioned?
@@ -199,5 +200,6 @@ Each milestone after v0 has a focused tracking issue:
 - #4: MCP server surface
 - #10: explicit memory promotion workflow
 - #9: retrieval quality improvements
+- #19: default repo scope key inference
 
 Those issues should stay narrow enough to produce reviewable PRs.

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,5 +1,7 @@
 import path from 'node:path';
 import os from 'node:os';
+import fs from 'node:fs';
+import { createHash } from 'node:crypto';
 
 const VALID_SCOPES = new Set(['shared', 'repo', 'local']);
 const VALID_STORAGE_MODES = new Set(['local', 'project-local', 'remote']);
@@ -14,6 +16,113 @@ function parsePositiveInteger(value, name, fallback) {
     throw new Error(`${name} must be a positive integer.`);
   }
   return parsed;
+}
+
+function findGitRoot(cwd) {
+  let current = path.resolve(cwd);
+  while (true) {
+    const dotGit = path.join(current, '.git');
+    if (fs.existsSync(dotGit)) {
+      return current;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+function parseGitConfigRemotes(configText) {
+  const remotes = new Map();
+  let currentRemote = null;
+
+  for (const rawLine of configText.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    const section = line.match(/^\[remote "(.+)"\]$/);
+    if (section) {
+      currentRemote = section[1];
+      continue;
+    }
+    if (line.startsWith('[')) {
+      currentRemote = null;
+      continue;
+    }
+    if (!currentRemote) {
+      continue;
+    }
+
+    const entry = line.match(/^url\s*=\s*(.+)$/);
+    if (entry) {
+      remotes.set(currentRemote, entry[1].trim());
+    }
+  }
+
+  return remotes;
+}
+
+function readGitConfig(gitRoot) {
+  const dotGitPath = path.join(gitRoot, '.git');
+  let configPath = path.join(dotGitPath, 'config');
+
+  if (fs.existsSync(dotGitPath) && fs.statSync(dotGitPath).isFile()) {
+    const dotGitContent = fs.readFileSync(dotGitPath, 'utf8');
+    const match = dotGitContent.match(/^gitdir:\s*(.+)$/m);
+    if (match) {
+      const gitDir = path.resolve(gitRoot, match[1].trim());
+      configPath = path.join(gitDir, 'config');
+    }
+  }
+
+  if (!fs.existsSync(configPath)) {
+    return null;
+  }
+  return fs.readFileSync(configPath, 'utf8');
+}
+
+function normalizeGitHubRemote(url) {
+  const trimmed = String(url || '').trim();
+  const patterns = [
+    /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/i,
+    /^ssh:\/\/git@github\.com\/([^/]+)\/(.+?)(?:\.git)?$/i,
+    /^https:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/i,
+    /^http:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = trimmed.match(pattern);
+    if (match) {
+      return `github.com/${match[1]}/${match[2]}`;
+    }
+  }
+
+  return null;
+}
+
+function pathScopeKey(cwd) {
+  const resolved = path.resolve(cwd);
+  const digest = createHash('sha256').update(resolved).digest('hex').slice(0, 16);
+  return `path:${digest}:${path.basename(resolved) || 'root'}`;
+}
+
+function inferRepoScopeKey(cwd) {
+  const gitRoot = findGitRoot(cwd);
+  if (!gitRoot) {
+    return pathScopeKey(cwd);
+  }
+
+  const configText = readGitConfig(gitRoot);
+  if (configText) {
+    const remotes = parseGitConfigRemotes(configText);
+    const preferred = remotes.get('origin') || [...remotes.values()][0];
+    const githubKey = normalizeGitHubRemote(preferred);
+    if (githubKey) {
+      return githubKey;
+    }
+  }
+
+  return pathScopeKey(gitRoot);
 }
 
 export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
@@ -37,7 +146,8 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
     storageMode,
     dataDir,
     defaultScope,
-    defaultScopeKey: env.CONTEXTFORGE_DEFAULT_SCOPE_KEY || null,
+    defaultScopeKey:
+      env.CONTEXTFORGE_DEFAULT_SCOPE_KEY || (defaultScope === 'repo' ? inferRepoScopeKey(cwd) : null),
     defaultSharedScopeKey: env.CONTEXTFORGE_SHARED_SCOPE_KEY || 'global',
     distillProvider: env.CONTEXTFORGE_DISTILL_PROVIDER || 'mock',
     remote: {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -27,6 +27,40 @@ test('dbInfo initializes a fresh SQLite store', async () => {
   assert.match(info.dbPath, /contextforge\.db$/);
 });
 
+test('repo scope key defaults to normalized GitHub origin remote', async () => {
+  const cwd = await makeTempDir();
+  await fs.mkdir(path.join(cwd, '.git'), { recursive: true });
+  await fs.writeFile(
+    path.join(cwd, '.git', 'config'),
+    '[remote "origin"]\n\turl = git@github.com:example/contextforge.git\n',
+  );
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: path.join(cwd, 'data') }, cwd });
+
+  assert.equal(app.config.defaultScopeKey, 'github.com/example/contextforge');
+
+  const memory = app.remember({
+    key: 'default-scope',
+    content: 'Repo scope key can be inferred from origin remote.',
+  });
+  assert.equal(memory.scopeType, 'repo');
+  assert.equal(memory.scopeKey, 'github.com/example/contextforge');
+});
+
+test('repo scope key falls back to a deterministic path key outside git', async () => {
+  const cwd = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: path.join(cwd, 'data') }, cwd });
+
+  assert.match(app.config.defaultScopeKey, /^path:[a-f0-9]{16}:contextforge-test-/);
+
+  const explicit = app.remember({
+    scope: 'repo',
+    scopeKey: 'explicit/repo',
+    key: 'explicit-scope',
+    content: 'Explicit repo scope keys still win.',
+  });
+  assert.equal(explicit.scopeKey, 'explicit/repo');
+});
+
 test('remember, getMemory, and search use explicit scopes', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });


### PR DESCRIPTION
## Summary

- infer repo default scope keys from the current git checkout
- normalize common GitHub origin remotes to `github.com/owner/repo`
- fall back to deterministic `path:<hash>:<name>` keys outside git
- preserve explicit `--scopeKey` and `CONTEXTFORGE_DEFAULT_SCOPE_KEY` overrides
- document the default behavior and update the roadmap decision

Closes #19

## Validation

- `npm test`
- `npm pack --dry-run`
- `npm audit --audit-level=moderate`
- `git diff --check`
- smoke: `CONTEXTFORGE_DATA_DIR=$(mktemp -d) node src/cli.js remember --scope repo --key inferred-scope-smoke --content "Repo scope key inference smoke test."`