### PR TITLE
Version distillation provider prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ bring-your-own distillation providers, such as:
 The v0 implementation ships with a deterministic `mock` provider and a
 `codex_exec` provider. The `codex_exec` provider shells out to `codex exec`,
 requests JSON-only output with a schema, validates the result, and records
-provider run metadata.
+provider run metadata, including prompt and output schema versions.
 
 ## Quick Start
 
@@ -337,6 +337,8 @@ Optional environment variables:
 Failure modes are preserved as distillation runs. If `codex exec` exits
 non-zero, times out, or returns malformed JSON, ContextForge records a failed
 `distill_runs` row and leaves raw events untouched for retry or debugging.
+Failed and successful runs include provider prompt/schema version metadata so
+operators can tell which prompt contract produced the result.
 
 ## Public Repo Hygiene
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -220,6 +220,12 @@ Provider outputs should include:
 Memory candidates must not automatically become durable memories unless the
 caller explicitly chooses that policy.
 
+Provider prompts and output schemas should be versioned. Distill run input
+metadata records the provider prompt/schema version before execution, and
+successful or failed output metadata keeps the same version context for later
+debugging. A provider prompt change that can affect checkpoint shape or meaning
+should bump the provider prompt version.
+
 ## Promotion Policy
 
 Checkpoint memory candidates are review inputs, not canonical facts. A caller

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -183,7 +183,8 @@ Initial implementation:
   deterministic path keys. Explicit user config still wins.
 - Which remote provider types should eventually support client-side execution
   while still writing checkpoints through the remote canonical API?
-- How should provider prompts be versioned?
+- Provider prompt/schema versions are now recorded for `codex_exec` distill
+  runs; future providers should expose the same metadata contract.
 - Should checkpoint memory candidates require explicit human approval or allow a
   configurable auto-promote policy?
 - What is the minimum auth model for remote mode?
@@ -201,5 +202,6 @@ Each milestone after v0 has a focused tracking issue:
 - #10: explicit memory promotion workflow
 - #9: retrieval quality improvements
 - #19: default repo scope key inference
+- #21: distillation provider prompt versioning
 
 Those issues should stay narrow enough to produce reviewable PRs.

--- a/src/core.js
+++ b/src/core.js
@@ -230,6 +230,7 @@ export function createContextForge(options = {}) {
       const provider = createDistillProvider(options.provider || config.distillProvider, distillProviders, {
         codexExec,
       });
+      const providerMetadata = provider.metadata || {};
 
       return withStore(config, async (store) => {
         const rawEvents = store.listRawEvents({ ...scope, sessionId: options.sessionId });
@@ -257,6 +258,7 @@ export function createContextForge(options = {}) {
             rawEventIds: rawEvents.map((event) => event.id),
             previousCheckpointId: previousCheckpoint?.id || null,
             requestedOutputSchema,
+            providerMetadata,
           },
         });
 
@@ -278,6 +280,7 @@ export function createContextForge(options = {}) {
             error,
             outputMetadata: {
               providerFailed: true,
+              providerMetadata,
             },
           });
           throw error;
@@ -293,6 +296,7 @@ export function createContextForge(options = {}) {
             outputMetadata: {
               validationFailed: true,
               receivedType: Array.isArray(rawOutput) ? 'array' : typeof rawOutput,
+              providerMetadata,
             },
           });
           throw error;

--- a/src/distill/index.js
+++ b/src/distill/index.js
@@ -17,9 +17,11 @@ export function createDistillProvider(name, overrides = {}, options = {}) {
   }
 
   if (name === 'codex_exec') {
+    const distill = createCodexExecProvider(options.codexExec);
     return {
       name,
-      distill: createCodexExecProvider(options.codexExec),
+      distill,
+      metadata: distill.metadata,
     };
   }
 

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -3,7 +3,11 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v1';
+export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v1';
+
 const OUTPUT_SCHEMA = {
+  $id: CODEX_EXEC_OUTPUT_SCHEMA_VERSION,
   type: 'object',
   additionalProperties: false,
   required: [
@@ -128,6 +132,9 @@ export function buildCodexExecPrompt(input, options = {}) {
       JSON.stringify(payload, null, 2),
     ].join('\n'),
     metadata: {
+      provider: 'codex_exec',
+      promptVersion: CODEX_EXEC_PROMPT_VERSION,
+      outputSchemaVersion: CODEX_EXEC_OUTPUT_SCHEMA_VERSION,
       rawEventCount: rawPayload.events.length,
       inputTruncated: rawPayload.truncated,
       maxInputChars,
@@ -239,7 +246,13 @@ export function createCodexExecProvider(options = {}) {
   const timeoutMs = options.timeoutMs || 120000;
   const maxInputChars = options.maxInputChars || 12000;
 
-  return async function distillWithCodexExecProvider(input) {
+  const providerMetadata = {
+    provider: 'codex_exec',
+    promptVersion: CODEX_EXEC_PROMPT_VERSION,
+    outputSchemaVersion: CODEX_EXEC_OUTPUT_SCHEMA_VERSION,
+  };
+
+  async function distillWithCodexExecProvider(input) {
     const startedAt = Date.now();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'contextforge-codex-exec-'));
     const schemaPath = path.join(tempDir, 'checkpoint.schema.json');
@@ -285,6 +298,7 @@ export function createCodexExecProvider(options = {}) {
         metadata: {
           ...(output.metadata || {}),
           codexExec: {
+            ...providerMetadata,
             command,
             model,
             sandbox,
@@ -297,5 +311,8 @@ export function createCodexExecProvider(options = {}) {
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
-  };
+  }
+
+  distillWithCodexExecProvider.metadata = providerMetadata;
+  return distillWithCodexExecProvider;
 }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -624,6 +624,8 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.command, 'codex-fake');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.model, 'gpt-test');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.timeoutMs, 1234);
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v1');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.outputSchemaVersion, 'contextforge.checkpoint.v1');
   assert.match(invocation.prompt, /Return exactly one JSON object/);
   assert.deepEqual(invocation.args.slice(0, 2), ['exec', '--skip-git-repo-check']);
   assert.ok(invocation.args.includes('--output-schema'));
@@ -636,6 +638,9 @@ test('codex_exec provider distills synthetic raw events through a runner', async
     sessionId: 'codex-session',
   });
   assert.equal(runs[0].status, 'succeeded');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v1');
+  assert.equal(runs[0].inputMetadata.providerMetadata.outputSchemaVersion, 'contextforge.checkpoint.v1');
+  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v1');
 });
 
 test('codex_exec parse failures preserve raw evidence', async () => {
@@ -679,6 +684,8 @@ test('codex_exec parse failures preserve raw evidence', async () => {
   });
   assert.equal(runs[0].status, 'failed');
   assert.equal(runs[0].outputMetadata.providerFailed, true);
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v1');
+  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v1');
 });
 
 test('CLI supports the v0 workflow with synthetic data', async () => {


### PR DESCRIPTION
## Summary

- add `codex_exec` prompt and output schema version constants
- include provider version metadata in distill run input metadata before execution
- preserve provider version metadata on provider failures and validation failures
- include prompt/schema versions in successful checkpoint provider metadata
- document provider prompt versioning policy

Closes #21

## Validation

- `npm test`
- `npm pack --dry-run`
- `npm audit --audit-level=moderate`
- `git diff --check`