### PR TITLE
Add codex_exec provider doctor check

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,20 @@ from retrieval without deleting their history.
 Use the Codex CLI as the distillation backend:
 
 ```bash
+node src/cli.js doctorCodexExec
+```
+
+That dry check verifies the configured Codex command without making a model
+call. To prove the logged-in Codex CLI can complete a structured `codex exec`
+request, run the opt-in live smoke:
+
+```bash
+node src/cli.js doctorCodexExec --live
+```
+
+Then enable the provider:
+
+```bash
 CONTEXTFORGE_DISTILL_PROVIDER=codex_exec \
 node src/cli.js distillCheckpoint \
   --scope repo \

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -185,6 +185,8 @@ Initial implementation:
   while still writing checkpoints through the remote canonical API?
 - Provider prompt/schema versions are now recorded for `codex_exec` distill
   runs; future providers should expose the same metadata contract.
+- `codex_exec` can be checked with a dry doctor command and an opt-in live
+  structured smoke before users enable it as the distillation provider.
 - Should checkpoint memory candidates require explicit human approval or allow a
   configurable auto-promote policy?
 - What is the minimum auth model for remote mode?

--- a/src/cli.js
+++ b/src/cli.js
@@ -63,6 +63,7 @@ function toCoreOptions(options) {
     sourceCandidateIndex: options.sourceCandidateIndex == null ? undefined : Number(options.sourceCandidateIndex),
     checkpointId: options.checkpointId,
     reason: options.reason,
+    live: options.live === true || options.live === 'true',
   };
 }
 
@@ -76,6 +77,7 @@ async function main() {
     printJson({
       commands: [
         'dbInfo',
+        'doctorCodexExec',
         'beginSession',
         'remember',
         'promoteMemory',
@@ -107,6 +109,8 @@ async function main() {
 
   if (command === 'dbInfo') {
     printJson(await app.dbInfo());
+  } else if (command === 'doctorCodexExec') {
+    printJson(await app.checkCodexExec(coreOptions));
   } else if (command === 'beginSession') {
     printJson(await app.beginSession(coreOptions));
   } else if (command === 'remember') {

--- a/src/core.js
+++ b/src/core.js
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { loadConfig } from './config/index.js';
 import { createDistillProvider } from './distill/index.js';
+import { checkCodexExecProvider } from './distill/providers/codex_exec.js';
 import { validateDistillOutput } from './distill/validate.js';
 import { createRemoteContextForge } from './remote/client.js';
 import { searchMemories } from './retrieval/search.js';
@@ -45,6 +46,13 @@ export function createContextForge(options = {}) {
 
     dbInfo() {
       return withStore(config, (store) => store.dbInfo());
+    },
+
+    checkCodexExec(options = {}) {
+      return checkCodexExecProvider({
+        ...codexExec,
+        live: Boolean(options.live),
+      });
     },
 
     beginSession(options = {}) {

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -53,6 +53,17 @@ const OUTPUT_SCHEMA = {
   },
 };
 
+const DOCTOR_OUTPUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['ok', 'provider', 'message'],
+  properties: {
+    ok: { type: 'boolean' },
+    provider: { type: 'string' },
+    message: { type: 'string' },
+  },
+};
+
 function truncateText(value, maxChars) {
   const text = String(value || '');
   if (text.length <= maxChars) {
@@ -233,8 +244,127 @@ export function runCodexExecCommand({ command, args, prompt, timeoutMs, cwd, env
       }
     });
 
-    child.stdin.end(prompt);
+    child.stdin.end(prompt || '');
   });
+}
+
+function firstLine(text) {
+  return String(text || '').trim().split(/\r?\n/).find(Boolean) || '';
+}
+
+async function checkCommandAvailable({ runner, command, cwd, timeoutMs }) {
+  const result = await runner({
+    command,
+    args: ['--version'],
+    prompt: '',
+    timeoutMs,
+    cwd,
+    env: process.env,
+  });
+
+  return {
+    ok: true,
+    version: firstLine(result.stdout) || firstLine(result.stderr) || null,
+  };
+}
+
+async function runLiveSmoke({ runner, command, model, sandbox, cwd, timeoutMs }) {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'contextforge-codex-doctor-'));
+  const schemaPath = path.join(tempDir, 'doctor.schema.json');
+  const outputPath = path.join(tempDir, 'doctor.json');
+  try {
+    await fs.writeFile(schemaPath, `${JSON.stringify(DOCTOR_OUTPUT_SCHEMA, null, 2)}\n`, 'utf8');
+    const args = [
+      'exec',
+      '--skip-git-repo-check',
+      '--ephemeral',
+      '--sandbox',
+      sandbox,
+      '--cd',
+      cwd,
+      '--output-schema',
+      schemaPath,
+      '--output-last-message',
+      outputPath,
+    ];
+    if (model) {
+      args.push('--model', model);
+    }
+    args.push('-');
+
+    const prompt = [
+      'Return exactly one JSON object with these fields:',
+      '{"ok": true, "provider": "codex_exec", "message": "codex_exec smoke ok"}',
+      'No Markdown or surrounding text.',
+    ].join('\n');
+
+    const result = await runner({
+      command,
+      args,
+      prompt,
+      timeoutMs,
+      cwd,
+      env: process.env,
+    });
+    const outputText = (await readTextIfPresent(outputPath)) || result.stdout || '';
+    const output = parseCodexExecJson(outputText);
+    if (output.ok !== true || output.provider !== 'codex_exec') {
+      throw new Error('codex_exec smoke returned JSON but did not confirm provider readiness.');
+    }
+
+    return {
+      ok: true,
+      output,
+    };
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+export async function checkCodexExecProvider(options = {}) {
+  const runner = options.runner || runCodexExecCommand;
+  const command = options.command || 'codex';
+  const model = options.model || null;
+  const sandbox = options.sandbox || 'read-only';
+  const cwd = options.cwd || process.cwd();
+  const timeoutMs = options.timeoutMs || 120000;
+  const live = Boolean(options.live);
+  const result = {
+    ok: false,
+    provider: 'codex_exec',
+    command,
+    model,
+    sandbox,
+    cwd,
+    timeoutMs,
+    live,
+    promptVersion: CODEX_EXEC_PROMPT_VERSION,
+    outputSchemaVersion: CODEX_EXEC_OUTPUT_SCHEMA_VERSION,
+    commandAvailable: false,
+    version: null,
+  };
+
+  try {
+    const commandCheck = await checkCommandAvailable({ runner, command, cwd, timeoutMs });
+    result.commandAvailable = commandCheck.ok;
+    result.version = commandCheck.version;
+
+    if (live) {
+      result.smoke = await runLiveSmoke({ runner, command, model, sandbox, cwd, timeoutMs });
+    }
+
+    result.ok = true;
+    return result;
+  } catch (error) {
+    return {
+      ...result,
+      ok: false,
+      error: {
+        message: error.message,
+        name: error.name,
+      },
+    };
+  }
 }
 
 export function createCodexExecProvider(options = {}) {

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -1,5 +1,6 @@
 const REMOTE_METHODS = [
   'dbInfo',
+  'checkCodexExec',
   'beginSession',
   'remember',
   'promoteMemory',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -643,6 +643,70 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v1');
 });
 
+test('codex_exec doctor reports dry and live smoke readiness through a runner', async () => {
+  const dataDir = await makeTempDir();
+  const invocations = [];
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_CODEX_EXEC_COMMAND: 'codex-fake',
+      CONTEXTFORGE_CODEX_EXEC_MODEL: 'gpt-test',
+      CONTEXTFORGE_CODEX_EXEC_TIMEOUT_MS: '1234',
+    },
+    cwd: process.cwd(),
+    codexExecRunner: async (args) => {
+      invocations.push(args);
+      if (args.args.includes('--version')) {
+        return { stdout: 'codex-fake 1.2.3\n' };
+      }
+      return {
+        stdout: JSON.stringify({
+          ok: true,
+          provider: 'codex_exec',
+          message: 'codex_exec smoke ok',
+        }),
+      };
+    },
+  });
+
+  const dry = await app.checkCodexExec();
+  assert.equal(dry.ok, true);
+  assert.equal(dry.commandAvailable, true);
+  assert.equal(dry.version, 'codex-fake 1.2.3');
+  assert.equal(dry.live, false);
+  assert.equal(dry.command, 'codex-fake');
+  assert.equal(dry.model, 'gpt-test');
+  assert.equal(invocations.length, 1);
+
+  const live = await app.checkCodexExec({ live: true });
+  assert.equal(live.ok, true);
+  assert.equal(live.live, true);
+  assert.equal(live.smoke.output.provider, 'codex_exec');
+  assert.ok(invocations[1].args.includes('--version'));
+  assert.ok(invocations[2].args.includes('--output-schema'));
+  assert.equal(invocations[2].timeoutMs, 1234);
+});
+
+test('codex_exec doctor returns structured errors', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_CODEX_EXEC_COMMAND: 'codex-missing',
+    },
+    cwd: process.cwd(),
+    codexExecRunner: async () => {
+      throw new Error('spawn codex-missing ENOENT');
+    },
+  });
+
+  const result = await app.checkCodexExec({ live: true });
+  assert.equal(result.ok, false);
+  assert.equal(result.commandAvailable, false);
+  assert.equal(result.command, 'codex-missing');
+  assert.match(result.error.message, /ENOENT/);
+});
+
 test('codex_exec parse failures preserve raw evidence', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({


### PR DESCRIPTION
## Summary

- add `doctorCodexExec` CLI/core check for the logged-in Codex CLI path
- dry mode verifies the configured Codex command and reports config metadata without a model call
- `--live` runs an opt-in structured `codex exec` smoke using the configured command/model/sandbox
- return structured JSON for success and failures
- document the dry/live checks before enabling `CONTEXTFORGE_DISTILL_PROVIDER=codex_exec`

Closes #23

## Validation

- `npm test`
- `npm pack --dry-run`
- `npm audit --audit-level=moderate`
- `git diff --check`
- `node src/cli.js doctorCodexExec`
- `CONTEXTFORGE_CODEX_EXEC_TIMEOUT_MS=90000 node src/cli.js doctorCodexExec --live`