### PR TITLE
Add codex_exec reasoning effort option

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,9 @@ Optional environment variables:
 - `CONTEXTFORGE_CODEX_EXEC_COMMAND`: Codex executable name or path. Default:
   `codex`.
 - `CONTEXTFORGE_CODEX_EXEC_MODEL`: model passed to `codex exec --model`.
+- `CONTEXTFORGE_CODEX_EXEC_REASONING_EFFORT`: optional reasoning effort passed
+  through `codex exec -c model_reasoning_effort="..."`. Use `low` for routine
+  checkpoint distillation unless your prompt needs deeper synthesis.
 - `CONTEXTFORGE_CODEX_EXEC_SANDBOX`: sandbox passed to `codex exec --sandbox`.
   Default: `read-only`.
 - `CONTEXTFORGE_CODEX_EXEC_TIMEOUT_MS`: provider timeout. Default: `120000`.

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -162,6 +162,7 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
     codexExec: {
       command: env.CONTEXTFORGE_CODEX_EXEC_COMMAND || 'codex',
       model: env.CONTEXTFORGE_CODEX_EXEC_MODEL || null,
+      reasoningEffort: env.CONTEXTFORGE_CODEX_EXEC_REASONING_EFFORT || null,
       sandbox: env.CONTEXTFORGE_CODEX_EXEC_SANDBOX || 'read-only',
       cwd: env.CONTEXTFORGE_CODEX_EXEC_CWD ? path.resolve(cwd, env.CONTEXTFORGE_CODEX_EXEC_CWD) : cwd,
       timeoutMs: parsePositiveInteger(

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -268,7 +268,13 @@ async function checkCommandAvailable({ runner, command, cwd, timeoutMs }) {
   };
 }
 
-async function runLiveSmoke({ runner, command, model, sandbox, cwd, timeoutMs }) {
+function appendReasoningEffortConfig(args, reasoningEffort) {
+  if (reasoningEffort) {
+    args.push('-c', `model_reasoning_effort="${reasoningEffort}"`);
+  }
+}
+
+async function runLiveSmoke({ runner, command, model, reasoningEffort, sandbox, cwd, timeoutMs }) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'contextforge-codex-doctor-'));
   const schemaPath = path.join(tempDir, 'doctor.schema.json');
   const outputPath = path.join(tempDir, 'doctor.json');
@@ -290,6 +296,7 @@ async function runLiveSmoke({ runner, command, model, sandbox, cwd, timeoutMs })
     if (model) {
       args.push('--model', model);
     }
+    appendReasoningEffortConfig(args, reasoningEffort);
     args.push('-');
 
     const prompt = [
@@ -325,6 +332,7 @@ export async function checkCodexExecProvider(options = {}) {
   const runner = options.runner || runCodexExecCommand;
   const command = options.command || 'codex';
   const model = options.model || null;
+  const reasoningEffort = options.reasoningEffort || null;
   const sandbox = options.sandbox || 'read-only';
   const cwd = options.cwd || process.cwd();
   const timeoutMs = options.timeoutMs || 120000;
@@ -334,6 +342,7 @@ export async function checkCodexExecProvider(options = {}) {
     provider: 'codex_exec',
     command,
     model,
+    reasoningEffort,
     sandbox,
     cwd,
     timeoutMs,
@@ -350,7 +359,7 @@ export async function checkCodexExecProvider(options = {}) {
     result.version = commandCheck.version;
 
     if (live) {
-      result.smoke = await runLiveSmoke({ runner, command, model, sandbox, cwd, timeoutMs });
+      result.smoke = await runLiveSmoke({ runner, command, model, reasoningEffort, sandbox, cwd, timeoutMs });
     }
 
     result.ok = true;
@@ -371,6 +380,7 @@ export function createCodexExecProvider(options = {}) {
   const runner = options.runner || runCodexExecCommand;
   const command = options.command || 'codex';
   const model = options.model || null;
+  const reasoningEffort = options.reasoningEffort || null;
   const sandbox = options.sandbox || 'read-only';
   const cwd = options.cwd || process.cwd();
   const timeoutMs = options.timeoutMs || 120000;
@@ -407,6 +417,7 @@ export function createCodexExecProvider(options = {}) {
     if (model) {
       args.push('--model', model);
     }
+    appendReasoningEffortConfig(args, reasoningEffort);
     args.push('-');
 
     try {
@@ -431,6 +442,7 @@ export function createCodexExecProvider(options = {}) {
             ...providerMetadata,
             command,
             model,
+            reasoningEffort,
             sandbox,
             timeoutMs,
             elapsedMs: Date.now() - startedAt,

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -583,6 +583,7 @@ test('codex_exec provider distills synthetic raw events through a runner', async
       CONTEXTFORGE_DISTILL_PROVIDER: 'codex_exec',
       CONTEXTFORGE_CODEX_EXEC_COMMAND: 'codex-fake',
       CONTEXTFORGE_CODEX_EXEC_MODEL: 'gpt-test',
+      CONTEXTFORGE_CODEX_EXEC_REASONING_EFFORT: 'low',
       CONTEXTFORGE_CODEX_EXEC_TIMEOUT_MS: '1234',
       CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS: '5000',
     },
@@ -623,6 +624,7 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.equal(checkpoint.metadata.providerMetadata.synthetic, true);
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.command, 'codex-fake');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.model, 'gpt-test');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.reasoningEffort, 'low');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.timeoutMs, 1234);
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v1');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.outputSchemaVersion, 'contextforge.checkpoint.v1');
@@ -630,6 +632,8 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.deepEqual(invocation.args.slice(0, 2), ['exec', '--skip-git-repo-check']);
   assert.ok(invocation.args.includes('--output-schema'));
   assert.ok(invocation.args.includes('--output-last-message'));
+  assert.ok(invocation.args.includes('-c'));
+  assert.ok(invocation.args.includes('model_reasoning_effort="low"'));
   assert.equal(invocation.timeoutMs, 1234);
 
   const runs = app.listDistillRuns({
@@ -651,6 +655,7 @@ test('codex_exec doctor reports dry and live smoke readiness through a runner', 
       CONTEXTFORGE_DATA_DIR: dataDir,
       CONTEXTFORGE_CODEX_EXEC_COMMAND: 'codex-fake',
       CONTEXTFORGE_CODEX_EXEC_MODEL: 'gpt-test',
+      CONTEXTFORGE_CODEX_EXEC_REASONING_EFFORT: 'low',
       CONTEXTFORGE_CODEX_EXEC_TIMEOUT_MS: '1234',
     },
     cwd: process.cwd(),
@@ -676,6 +681,7 @@ test('codex_exec doctor reports dry and live smoke readiness through a runner', 
   assert.equal(dry.live, false);
   assert.equal(dry.command, 'codex-fake');
   assert.equal(dry.model, 'gpt-test');
+  assert.equal(dry.reasoningEffort, 'low');
   assert.equal(invocations.length, 1);
 
   const live = await app.checkCodexExec({ live: true });
@@ -684,6 +690,7 @@ test('codex_exec doctor reports dry and live smoke readiness through a runner', 
   assert.equal(live.smoke.output.provider, 'codex_exec');
   assert.ok(invocations[1].args.includes('--version'));
   assert.ok(invocations[2].args.includes('--output-schema'));
+  assert.ok(invocations[2].args.includes('model_reasoning_effort="low"'));
   assert.equal(invocations[2].timeoutMs, 1234);
 });
 


### PR DESCRIPTION
## Summary
- add CONTEXTFORGE_CODEX_EXEC_REASONING_EFFORT for codex_exec
- pass reasoning effort through codex exec config for distill and live doctor smoke
- document low as the recommended routine checkpoint setting

## Validation
- npm test
- npm pack --dry-run
- npm audit --audit-level=moderate
- git diff --check
- live remote doctor: gpt-5.4-mini with reasoningEffort low