### PR TITLE
Add session distill status policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,25 @@ events are captured when callers use `appendRaw`, and checkpoints are produced
 only when a caller invokes `distillCheckpoint` or the MCP `distill_checkpoint`
 tool. This keeps cost and model usage explicit.
 
+Agents can call `sessionStatus` or the MCP `session_status` tool to inspect
+whether a session has enough new raw evidence to justify a checkpoint. The
+status response includes raw event counts, raw character counts, the latest
+checkpoint, events and characters since that checkpoint, configured thresholds,
+`shouldDistill`, and machine-readable reasons.
+
 Recommended cadence depends on the agent workflow:
 
 - Run distillation at session end when an agent finishes a coherent task.
 - Run it every 10 to 30 minutes for long-running interactive sessions.
 - Avoid distilling after every raw event unless the raw stream is very small.
 - Retry failed distill runs after fixing the provider; raw evidence is retained.
+
+Default distill recommendation thresholds are:
+
+- `CONTEXTFORGE_DISTILL_MIN_EVENTS`: `5`
+- `CONTEXTFORGE_DISTILL_MIN_INTERVAL_MS`: `600000`
+- `CONTEXTFORGE_DISTILL_CHAR_THRESHOLD`: 80% of
+  `CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS`, which defaults to `9600`
 
 Use an external scheduler if you want unattended checkpoints. For example, a
 systemd timer or cron job can call:
@@ -242,6 +255,15 @@ node src/cli.js appendRaw \
   --content "Decision: keep v0 retrieval lexical and explainable."
 ```
 
+Inspect whether the session is ready for distillation:
+
+```bash
+node src/cli.js sessionStatus \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --sessionId demo-session
+```
+
 Distill a checkpoint with the mock provider:
 
 ```bash
@@ -323,6 +345,7 @@ contextforge-mcp
 The MCP server exposes a narrow tool surface over the same core API:
 
 - `begin_session`
+- `session_status`
 - `search`
 - `get_memory`
 - `remember`

--- a/src/cli.js
+++ b/src/cli.js
@@ -64,6 +64,9 @@ function toCoreOptions(options) {
     checkpointId: options.checkpointId,
     reason: options.reason,
     live: options.live === true || options.live === 'true',
+    minEvents: options.minEvents == null ? undefined : Number(options.minEvents),
+    minIntervalMs: options.minIntervalMs == null ? undefined : Number(options.minIntervalMs),
+    charThreshold: options.charThreshold == null ? undefined : Number(options.charThreshold),
   };
 }
 
@@ -79,6 +82,7 @@ async function main() {
         'dbInfo',
         'doctorCodexExec',
         'beginSession',
+        'sessionStatus',
         'remember',
         'promoteMemory',
         'correctMemory',
@@ -113,6 +117,8 @@ async function main() {
     printJson(await app.checkCodexExec(coreOptions));
   } else if (command === 'beginSession') {
     printJson(await app.beginSession(coreOptions));
+  } else if (command === 'sessionStatus') {
+    printJson(await app.sessionStatus(coreOptions));
   } else if (command === 'remember') {
     printJson(await app.remember(coreOptions));
   } else if (command === 'promoteMemory') {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -141,6 +141,11 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
   if (!VALID_SCOPES.has(defaultScope)) {
     throw new Error(`Invalid CONTEXTFORGE_DEFAULT_SCOPE: ${defaultScope}`);
   }
+  const codexExecMaxInputChars = parsePositiveInteger(
+    env.CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS,
+    'CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS',
+    12000,
+  );
 
   return {
     storageMode,
@@ -170,10 +175,19 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
         'CONTEXTFORGE_CODEX_EXEC_TIMEOUT_MS',
         120000,
       ),
-      maxInputChars: parsePositiveInteger(
-        env.CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS,
-        'CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS',
-        12000,
+      maxInputChars: codexExecMaxInputChars,
+    },
+    distillPolicy: {
+      minEvents: parsePositiveInteger(env.CONTEXTFORGE_DISTILL_MIN_EVENTS, 'CONTEXTFORGE_DISTILL_MIN_EVENTS', 5),
+      minIntervalMs: parsePositiveInteger(
+        env.CONTEXTFORGE_DISTILL_MIN_INTERVAL_MS,
+        'CONTEXTFORGE_DISTILL_MIN_INTERVAL_MS',
+        10 * 60 * 1000,
+      ),
+      charThreshold: parsePositiveInteger(
+        env.CONTEXTFORGE_DISTILL_CHAR_THRESHOLD,
+        'CONTEXTFORGE_DISTILL_CHAR_THRESHOLD',
+        Math.floor(codexExecMaxInputChars * 0.8),
       ),
     },
   };

--- a/src/core.js
+++ b/src/core.js
@@ -14,6 +14,13 @@ function requireOption(value, name) {
   }
 }
 
+function positiveNumber(value, name) {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive number.`);
+  }
+  return value;
+}
+
 function withStore(config, fn) {
   const store = new ContextForgeStore({ dataDir: config.dataDir });
   try {
@@ -27,6 +34,62 @@ function withStore(config, fn) {
     store.close();
     throw error;
   }
+}
+
+function rawCharCount(events) {
+  return events.reduce((total, event) => total + String(event.content || '').length, 0);
+}
+
+function checkpointTimestamp(checkpoint) {
+  return checkpoint?.createdAt ? Date.parse(checkpoint.createdAt) : null;
+}
+
+function eventsAfterCheckpoint(events, checkpoint) {
+  const checkpointTime = checkpointTimestamp(checkpoint);
+  if (!checkpointTime) return events;
+  return events.filter((event) => Date.parse(event.createdAt) > checkpointTime);
+}
+
+function buildSessionStatus({ scope, sessionId, rawEvents, latestCheckpoint, policy, now = new Date() }) {
+  const eventsSinceLastCheckpoint = eventsAfterCheckpoint(rawEvents, latestCheckpoint);
+  const rawEventCount = rawEvents.length;
+  const rawCharTotal = rawCharCount(rawEvents);
+  const charsSinceLastCheckpoint = rawCharCount(eventsSinceLastCheckpoint);
+  const latestCheckpointTime = checkpointTimestamp(latestCheckpoint);
+  const elapsedMs = latestCheckpointTime ? Math.max(0, now.getTime() - latestCheckpointTime) : null;
+  const reasons = [];
+
+  if (rawEventCount === 0) {
+    reasons.push('no_raw_events');
+  }
+  if (!latestCheckpoint && rawEventCount >= policy.minEvents) {
+    reasons.push('initial_event_threshold');
+  }
+  if (!latestCheckpoint && rawCharTotal >= policy.charThreshold) {
+    reasons.push('initial_char_threshold');
+  }
+  if (latestCheckpoint && eventsSinceLastCheckpoint.length >= policy.minEvents && elapsedMs >= policy.minIntervalMs) {
+    reasons.push('events_and_interval_since_checkpoint');
+  }
+  if (latestCheckpoint && charsSinceLastCheckpoint >= policy.charThreshold) {
+    reasons.push('char_threshold_since_checkpoint');
+  }
+
+  return {
+    sessionId,
+    scopeType: scope.scopeType,
+    scopeKey: scope.scopeKey,
+    rawEventCount,
+    rawCharCount: rawCharTotal,
+    latestCheckpointId: latestCheckpoint?.id || null,
+    latestCheckpointAt: latestCheckpoint?.createdAt || null,
+    eventsSinceLastCheckpoint: eventsSinceLastCheckpoint.length,
+    charsSinceLastCheckpoint,
+    elapsedSinceLastCheckpointMs: elapsedMs,
+    thresholds: policy,
+    shouldDistill: reasons.some((reason) => reason !== 'no_raw_events'),
+    reasons,
+  };
 }
 
 export function createContextForge(options = {}) {
@@ -64,6 +127,34 @@ export function createContextForge(options = {}) {
         scopeKey: scope.scopeKey,
         createdAt: new Date().toISOString(),
       };
+    },
+
+    sessionStatus(options) {
+      const scope = normalizeScopeOptions(options, config);
+      requireOption(options.sessionId, 'sessionId');
+      const policy = {
+        minEvents: positiveNumber(
+          options.minEvents == null ? config.distillPolicy.minEvents : Number(options.minEvents),
+          'minEvents',
+        ),
+        minIntervalMs: positiveNumber(
+          options.minIntervalMs == null ? config.distillPolicy.minIntervalMs : Number(options.minIntervalMs),
+          'minIntervalMs',
+        ),
+        charThreshold: positiveNumber(
+          options.charThreshold == null ? config.distillPolicy.charThreshold : Number(options.charThreshold),
+          'charThreshold',
+        ),
+      };
+      return withStore(config, (store) =>
+        buildSessionStatus({
+          scope,
+          sessionId: options.sessionId,
+          rawEvents: store.listRawEvents({ ...scope, sessionId: options.sessionId }),
+          latestCheckpoint: store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId }),
+          policy,
+        }),
+      );
     },
 
     remember(options) {

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -52,6 +52,27 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
   );
 
   server.registerTool(
+    'session_status',
+    {
+      title: 'Session Status',
+      description: 'Inspect raw evidence and checkpoint thresholds for a session before deciding whether to distill.',
+      inputSchema: z.object({
+        ...scopedSchema,
+        sessionId: z.string(),
+        minEvents: z.number().int().positive().optional(),
+        minIntervalMs: z.number().int().positive().optional(),
+        charThreshold: z.number().int().positive().optional(),
+      }),
+      annotations: {
+        title: 'Session Status',
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.sessionStatus(args)),
+  );
+
+  server.registerTool(
     'search',
     {
       title: 'Search Memory',

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -2,6 +2,7 @@ const REMOTE_METHODS = [
   'dbInfo',
   'checkCodexExec',
   'beginSession',
+  'sessionStatus',
   'remember',
   'promoteMemory',
   'correctMemory',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -450,6 +450,18 @@ test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
     content: 'Next implement the provider contract and CLI command.',
   });
 
+  const statusBefore = app.sessionStatus({
+    scope: 'repo',
+    scopeKey: 'repo-a',
+    sessionId: session.sessionId,
+    minEvents: 2,
+  });
+  assert.equal(statusBefore.rawEventCount, 2);
+  assert.equal(statusBefore.eventsSinceLastCheckpoint, 2);
+  assert.equal(statusBefore.latestCheckpointId, null);
+  assert.equal(statusBefore.shouldDistill, true);
+  assert.ok(statusBefore.reasons.includes('initial_event_threshold'));
+
   const checkpoint = await app.distillCheckpoint({
     scope: 'repo',
     scopeKey: 'repo-a',
@@ -476,6 +488,16 @@ test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
   assert.equal(runs.length, 1);
   assert.equal(runs[0].status, 'succeeded');
   assert.equal(runs[0].outputMetadata.checkpointId, checkpoint.id);
+
+  const statusAfter = app.sessionStatus({
+    scope: 'repo',
+    scopeKey: 'repo-a',
+    sessionId: session.sessionId,
+    minEvents: 1,
+  });
+  assert.equal(statusAfter.latestCheckpointId, checkpoint.id);
+  assert.equal(statusAfter.eventsSinceLastCheckpoint, 0);
+  assert.equal(statusAfter.shouldDistill, false);
 });
 
 test('distillCheckpoint rejects malformed provider output and preserves raw evidence', async () => {
@@ -827,6 +849,22 @@ test('CLI supports the v0 workflow with synthetic data', async () => {
   );
   assert.match(checkpoint.stdout, /"provider": "mock"/);
 
+  const status = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'sessionStatus',
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'cli-repo',
+      '--sessionId',
+      'cli-session',
+    ],
+    { env },
+  );
+  assert.match(status.stdout, /"latestCheckpointId":/);
+
   const runs = await execFileAsync(
     'node',
     [
@@ -874,6 +912,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'promote_memory',
       'remember',
       'search',
+      'session_status',
     ]);
 
     const rememberResult = await client.callTool({
@@ -897,6 +936,38 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       },
     });
     assert.equal(searchResult.structuredContent.result[0].memory.key, 'mcp-rule');
+
+    const sessionResult = await client.callTool({
+      name: 'begin_session',
+      arguments: {
+        scope: 'repo',
+        scopeKey: 'mcp-repo',
+        sessionId: 'mcp-session',
+      },
+    });
+    assert.equal(sessionResult.structuredContent.result.sessionId, 'mcp-session');
+
+    await client.callTool({
+      name: 'append_raw',
+      arguments: {
+        scope: 'repo',
+        scopeKey: 'mcp-repo',
+        sessionId: 'mcp-session',
+        role: 'user',
+        content: 'Decision: MCP agents should inspect session status before distilling.',
+      },
+    });
+
+    const statusResult = await client.callTool({
+      name: 'session_status',
+      arguments: {
+        scope: 'repo',
+        scopeKey: 'mcp-repo',
+        sessionId: 'mcp-session',
+        minEvents: 1,
+      },
+    });
+    assert.equal(statusResult.structuredContent.result.shouldDistill, true);
 
     const promotedResult = await client.callTool({
       name: 'promote_memory',
@@ -972,6 +1043,22 @@ test('remote storage mode delegates core calls and preserves scope semantics', a
     });
     assert.equal(repoResults.length, 1);
     assert.equal(repoResults[0].memory.scopeType, 'repo');
+
+    await app.appendRaw({
+      scope: 'repo',
+      scopeKey: 'repo-remote',
+      sessionId: 'remote-session',
+      role: 'user',
+      content: 'Remote clients can inspect whether a session should distill.',
+    });
+    const status = await app.sessionStatus({
+      scope: 'repo',
+      scopeKey: 'repo-remote',
+      sessionId: 'remote-session',
+      minEvents: 1,
+    });
+    assert.equal(status.shouldDistill, true);
+    assert.equal(status.rawEventCount, 1);
 
     const info = await app.dbInfo();
     assert.equal(info.tables.memories, 2);


### PR DESCRIPTION
## Summary
- add sessionStatus core/CLI/remote API and MCP session_status tool
- report raw counts, checkpoint deltas, thresholds, shouldDistill, and reasons
- document agent-driven distill policy and default thresholds

## Validation
- npm test
- npm pack --dry-run
- npm audit --audit-level=moderate
- git diff --check