### PR TITLE
Harden remote runtime operations

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -98,17 +98,30 @@ export function createContextForge(options = {}) {
     return createRemoteContextForge(config, { fetchImpl: options.fetchImpl });
   }
 
+  const sharedStore = options.store || (options.reuseStore ? new ContextForgeStore({ dataDir: config.dataDir }) : null);
   const distillProviders = options.distillProviders || {};
   const codexExec = {
     ...config.codexExec,
     runner: options.codexExecRunner,
   };
+  const useStore = (fn) => {
+    if (sharedStore) {
+      return fn(sharedStore);
+    }
+    return withStore(config, fn);
+  };
 
   return {
     config,
 
+    close() {
+      if (sharedStore) {
+        sharedStore.close();
+      }
+    },
+
     dbInfo() {
-      return withStore(config, (store) => store.dbInfo());
+      return useStore((store) => store.dbInfo());
     },
 
     checkCodexExec(options = {}) {
@@ -146,7 +159,7 @@ export function createContextForge(options = {}) {
           'charThreshold',
         ),
       };
-      return withStore(config, (store) =>
+      return useStore((store) =>
         buildSessionStatus({
           scope,
           sessionId: options.sessionId,
@@ -159,7 +172,7 @@ export function createContextForge(options = {}) {
 
     remember(options) {
       const scope = normalizeScopeOptions(options, config);
-      return withStore(config, (store) =>
+      return useStore((store) =>
         store.rememberMemory({
           ...scope,
           key: options.key,
@@ -176,7 +189,7 @@ export function createContextForge(options = {}) {
       requireOption(options.key, 'key');
       requireOption(options.content, 'content');
 
-      return withStore(config, (store) =>
+      return useStore((store) =>
         store.rememberMemory({
           ...scope,
           key: options.key,
@@ -202,7 +215,7 @@ export function createContextForge(options = {}) {
       requireOption(options.key, 'key');
       requireOption(options.content, 'content');
 
-      return withStore(config, (store) => {
+      return useStore((store) => {
         const previous = store.getMemory({ ...scope, key: options.key });
         if (!previous) {
           throw new Error(`Memory not found: ${options.key}`);
@@ -230,7 +243,7 @@ export function createContextForge(options = {}) {
     deactivateMemory(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.key, 'key');
-      return withStore(config, (store) =>
+      return useStore((store) =>
         store.deactivateMemory({
           ...scope,
           key: options.key,
@@ -242,7 +255,7 @@ export function createContextForge(options = {}) {
     listMemoryEvents(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.key, 'key');
-      return withStore(config, (store) =>
+      return useStore((store) =>
         store.listMemoryEvents({
           ...scope,
           key: options.key,
@@ -252,7 +265,7 @@ export function createContextForge(options = {}) {
 
     listMemoryCandidates(options) {
       const scope = normalizeScopeOptions(options, config);
-      return withStore(config, (store) =>
+      return useStore((store) =>
         store
           .listCheckpoints({
             ...scope,
@@ -284,7 +297,7 @@ export function createContextForge(options = {}) {
     getMemory(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.key, 'key');
-      return withStore(config, (store) =>
+      return useStore((store) =>
         store.getMemory({
           ...scope,
           key: options.key,
@@ -295,7 +308,7 @@ export function createContextForge(options = {}) {
     search(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.query, 'query');
-      return withStore(config, (store) =>
+      return useStore((store) =>
         searchMemories(store, {
           ...scope,
           query: options.query,
@@ -311,7 +324,7 @@ export function createContextForge(options = {}) {
       requireOption(options.sessionId, 'sessionId');
       requireOption(options.role, 'role');
       requireOption(options.content, 'content');
-      return withStore(config, (store) =>
+      return useStore((store) =>
         store.appendRawEvent({
           ...scope,
           sessionId: options.sessionId,
@@ -331,7 +344,7 @@ export function createContextForge(options = {}) {
       });
       const providerMetadata = provider.metadata || {};
 
-      return withStore(config, async (store) => {
+      return useStore(async (store) => {
         const rawEvents = store.listRawEvents({ ...scope, sessionId: options.sessionId });
         const previousCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId });
         const conversationId =
@@ -436,7 +449,7 @@ export function createContextForge(options = {}) {
     listDistillRuns(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.sessionId, 'sessionId');
-      return withStore(config, (store) =>
+      return useStore((store) =>
         store.listDistillRuns({
           ...scope,
           sessionId: options.sessionId,

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -63,6 +63,8 @@ const DOCTOR_OUTPUT_SCHEMA = {
     message: { type: 'string' },
   },
 };
+const REASONING_EFFORTS = new Set(['minimal', 'low', 'medium', 'high']);
+const KILL_GRACE_MS = 5000;
 
 function truncateText(value, maxChars) {
   const text = String(value || '');
@@ -212,10 +214,32 @@ export function runCodexExecCommand({ command, args, prompt, timeoutMs, cwd, env
     let stdout = '';
     let stderr = '';
     let settled = false;
+    let killTimer = null;
+    function cleanup() {
+      clearTimeout(timer);
+      if (killTimer) {
+        clearTimeout(killTimer);
+      }
+    }
+    function settle(fn) {
+      if (settled) return false;
+      settled = true;
+      cleanup();
+      fn();
+      return true;
+    }
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
       child.kill('SIGTERM');
+      killTimer = setTimeout(() => {
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          // Process may already be gone.
+        }
+      }, KILL_GRACE_MS);
       reject(new Error(`codex_exec timed out after ${timeoutMs}ms.`));
     }, timeoutMs);
 
@@ -226,22 +250,26 @@ export function runCodexExecCommand({ command, args, prompt, timeoutMs, cwd, env
       stderr += chunk.toString();
     });
     child.on('error', (error) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      reject(error);
+      if (settled) {
+        cleanup();
+        return;
+      }
+      settle(() => reject(error));
     });
     child.on('close', (code, signal) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      if (code === 0) {
-        resolve({ stdout, stderr, code, signal });
-      } else {
-        const stderrSummary = summarizeStderr(stderr);
-        const suffix = stderrSummary ? ` ${stderrSummary}` : '';
-        reject(new Error(`codex_exec exited with code ${code}.${suffix}`));
+      if (settled) {
+        cleanup();
+        return;
       }
+      settle(() => {
+        if (code === 0) {
+          resolve({ stdout, stderr, code, signal });
+        } else {
+          const stderrSummary = summarizeStderr(stderr);
+          const suffix = stderrSummary ? ` ${stderrSummary}` : '';
+          reject(new Error(`codex_exec exited with code ${code}.${suffix}`));
+        }
+      });
     });
 
     child.stdin.end(prompt || '');
@@ -270,6 +298,11 @@ async function checkCommandAvailable({ runner, command, cwd, timeoutMs }) {
 
 function appendReasoningEffortConfig(args, reasoningEffort) {
   if (reasoningEffort) {
+    if (!REASONING_EFFORTS.has(reasoningEffort)) {
+      throw new Error(
+        `Invalid codex_exec reasoning effort "${reasoningEffort}". Expected one of: minimal, low, medium, high.`,
+      );
+    }
     args.push('-c', `model_reasoning_effort="${reasoningEffort}"`);
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import crypto from 'node:crypto';
 import http from 'node:http';
 import { createContextForge } from './core.js';
 import { REMOTE_METHODS } from './remote/client.js';
@@ -41,9 +42,24 @@ function readJsonBody(request) {
   });
 }
 
+function isLoopbackHost(host) {
+  return host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === '[::1]';
+}
+
+function timingSafeStringEqual(actual, expected) {
+  const actualBuffer = Buffer.from(String(actual || ''));
+  const expectedBuffer = Buffer.from(String(expected || ''));
+  const maxLength = Math.max(actualBuffer.length, expectedBuffer.length, 1);
+  const paddedActual = Buffer.alloc(maxLength);
+  const paddedExpected = Buffer.alloc(maxLength);
+  actualBuffer.copy(paddedActual);
+  expectedBuffer.copy(paddedExpected);
+  return crypto.timingSafeEqual(paddedActual, paddedExpected) && actualBuffer.length === expectedBuffer.length;
+}
+
 function isAuthorized(request, token) {
   if (!token) return true;
-  return request.headers.authorization === `Bearer ${token}`;
+  return timingSafeStringEqual(request.headers.authorization, `Bearer ${token}`);
 }
 
 function serverStorageEnv(env) {
@@ -55,10 +71,10 @@ function serverStorageEnv(env) {
 }
 
 export function createContextForgeServer({ app, env = process.env } = {}) {
-  const serverApp = app || createContextForge({ env: serverStorageEnv(env) });
+  const serverApp = app || createContextForge({ env: serverStorageEnv(env), reuseStore: true });
   const authToken = env.CONTEXTFORGE_REMOTE_TOKEN || null;
 
-  return http.createServer(async (request, response) => {
+  const server = http.createServer(async (request, response) => {
     const requestUrl = new URL(request.url, 'http://localhost');
 
     if (request.method === 'GET' && requestUrl.pathname === '/healthz') {
@@ -95,9 +111,21 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
       });
     }
   });
+  server.closeContextForge = () => {
+    if (typeof serverApp.close === 'function') {
+      serverApp.close();
+    }
+  };
+  return server;
 }
 
 export function startContextForgeServer({ host = '127.0.0.1', port = 8765, env = process.env, app } = {}) {
+  if (!env.CONTEXTFORGE_REMOTE_TOKEN && !isLoopbackHost(host)) {
+    throw new Error('CONTEXTFORGE_REMOTE_TOKEN is required when binding ContextForge remote server to a non-loopback host.');
+  }
+  if (!env.CONTEXTFORGE_REMOTE_TOKEN) {
+    console.error('Warning: CONTEXTFORGE_REMOTE_TOKEN is not set; remote API is unauthenticated on loopback only.');
+  }
   const server = createContextForgeServer({ app, env });
   return new Promise((resolve, reject) => {
     server.once('error', reject);
@@ -111,8 +139,14 @@ export function startContextForgeServer({ host = '127.0.0.1', port = 8765, env =
         close: () =>
           new Promise((closeResolve, closeReject) => {
             server.close((error) => {
-              if (error) closeReject(error);
-              else closeResolve();
+              try {
+                if (server.closeContextForge) {
+                  server.closeContextForge();
+                }
+              } finally {
+                if (error) closeReject(error);
+                else closeResolve();
+              }
             });
           }),
       });

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -26,6 +26,7 @@ function parseJson(value, fallback) {
 
 function hydrateMemory(row) {
   if (!row) return null;
+  const tags = parseJson(row.tags_json, []);
   return {
     id: row.id,
     scopeType: row.scope_type,
@@ -33,7 +34,7 @@ function hydrateMemory(row) {
     key: row.memory_key,
     category: row.category,
     content: row.content,
-    tags: parseJson(row.tags_json, []),
+    tags: Array.isArray(tags) ? tags : [],
     importance: row.importance,
     status: row.status || 'active',
     supersedesMemoryId: row.supersedes_memory_id,
@@ -112,6 +113,10 @@ function hydrateMemoryEvent(row) {
 
 function ftsValue(value) {
   return String(value || '').replace(/\0/g, ' ');
+}
+
+function normalizeTags(tags) {
+  return Array.isArray(tags) ? tags.map((tag) => String(tag)) : [];
 }
 
 export class ContextForgeStore {
@@ -240,7 +245,7 @@ export class ContextForgeStore {
     this.ensureColumn('memories', 'status', "TEXT NOT NULL DEFAULT 'active'");
     this.ensureColumn('memories', 'supersedes_memory_id', 'TEXT');
     this.ensureColumn('memories', 'deactivated_at', 'TEXT');
-    this.rebuildMemoryFts();
+    this.ensureMemoryFts();
 
     this.db
       .prepare(`
@@ -292,11 +297,22 @@ export class ContextForgeStore {
           ftsValue(row.memory_key),
           ftsValue(row.category),
           ftsValue(row.content),
-          ftsValue(parseJson(row.tags_json, []).join(' ')),
+          ftsValue(normalizeTags(parseJson(row.tags_json, [])).join(' ')),
         );
       }
     });
     transaction(rows);
+  }
+
+  ensureMemoryFts() {
+    const schemaRow = this.db.prepare("SELECT value FROM schema_meta WHERE key = 'schema_version'").get();
+    const activeCount = this.db
+      .prepare("SELECT COUNT(*) AS count FROM memories WHERE status = 'active'")
+      .get().count;
+    const ftsCount = this.db.prepare('SELECT COUNT(*) AS count FROM memory_fts').get().count;
+    if (schemaRow?.value !== String(SCHEMA_VERSION) || (activeCount > 0 && ftsCount === 0)) {
+      this.rebuildMemoryFts();
+    }
   }
 
   upsertMemoryFts(memory) {
@@ -318,7 +334,7 @@ export class ContextForgeStore {
         ftsValue(memory.key),
         ftsValue(memory.category),
         ftsValue(memory.content),
-        ftsValue(memory.tags.join(' ')),
+        ftsValue(normalizeTags(memory.tags).join(' ')),
       );
   }
 
@@ -338,6 +354,7 @@ export class ContextForgeStore {
   }) {
     if (!key) throw new Error('memory key is required.');
     if (!content) throw new Error('memory content is required.');
+    const normalizedTags = normalizeTags(tags);
 
     const id = randomUUID();
     const timestamp = nowIso();
@@ -367,7 +384,7 @@ export class ContextForgeStore {
         key,
         category,
         content,
-        json(tags, []),
+        json(normalizedTags, []),
         Number(importance),
         status,
         supersedesMemoryId,
@@ -474,7 +491,9 @@ export class ContextForgeStore {
         nowIso(),
       );
 
-    return hydrateMemory(row);
+    const memory = hydrateMemory(row);
+    this.upsertMemoryFts(memory);
+    return memory;
   }
 
   listMemoryEvents({ scopeType, scopeKey, key }) {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -716,6 +716,37 @@ test('codex_exec doctor reports dry and live smoke readiness through a runner', 
   assert.equal(invocations[2].timeoutMs, 1234);
 });
 
+test('codex_exec rejects unsupported reasoning effort values', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'codex_exec',
+      CONTEXTFORGE_CODEX_EXEC_REASONING_EFFORT: 'low\" other=\"x',
+    },
+    cwd: process.cwd(),
+    codexExecRunner: async () => ({ stdout: '{}' }),
+  });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-invalid-reasoning',
+    sessionId: 'invalid-reasoning-session',
+    role: 'user',
+    content: 'This should fail before codex exec receives invalid config.',
+  });
+
+  await assert.rejects(
+    () =>
+      app.distillCheckpoint({
+        scope: 'repo',
+        scopeKey: 'repo-invalid-reasoning',
+        sessionId: 'invalid-reasoning-session',
+      }),
+    /Invalid codex_exec reasoning effort/,
+  );
+});
+
 test('codex_exec doctor returns structured errors', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({
@@ -734,6 +765,27 @@ test('codex_exec doctor returns structured errors', async () => {
   assert.equal(result.commandAvailable, false);
   assert.equal(result.command, 'codex-missing');
   assert.match(result.error.message, /ENOENT/);
+});
+
+test('memory tags are normalized before FTS indexing', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  const memory = app.remember({
+    scope: 'repo',
+    scopeKey: 'repo-tags',
+    key: 'string-tags',
+    content: 'String tags should not break memory indexing.',
+    tags: 'not-an-array',
+  });
+
+  assert.deepEqual(memory.tags, []);
+  const results = app.search({
+    scope: 'repo',
+    scopeKey: 'repo-tags',
+    query: 'indexing',
+  });
+  assert.equal(results[0].memory.key, 'string-tags');
 });
 
 test('codex_exec parse failures preserve raw evidence', async () => {
@@ -1100,6 +1152,20 @@ test('remote storage mode rejects unauthorized writes', async () => {
   } finally {
     await remote.close();
   }
+});
+
+test('remote server requires a token on non-loopback hosts', async () => {
+  assert.throws(
+    () =>
+      startContextForgeServer({
+        host: '0.0.0.0',
+        port: 0,
+        env: {
+          CONTEXTFORGE_DATA_DIR: '/tmp/contextforge-token-required',
+        },
+      }),
+    /CONTEXTFORGE_REMOTE_TOKEN is required/,
+  );
 });
 
 test('runtime database artifacts are ignored by git rules', async () => {


### PR DESCRIPTION
## Summary
- reuse a persistent store for the HTTP server and avoid unconditional FTS rebuilds
- use timing-safe bearer comparison and require tokens for non-loopback binds
- validate codex_exec reasoning effort values and add SIGKILL timeout fallback
- normalize memory tags before FTS indexing

## Issue
Addresses the High-priority items from #28 and one related tags robustness item.

## Validation
- npm test
- npm pack --dry-run
- npm audit --audit-level=moderate
- git diff --check