### PR TITLE
Refine medium runtime review items

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,13 @@ Default distill recommendation thresholds are:
 - `CONTEXTFORGE_DISTILL_CHAR_THRESHOLD`: 80% of
   `CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS`, which defaults to `9600`
 
+Before the first checkpoint, `sessionStatus` recommends distillation only when
+the raw character threshold is reached. The event threshold is combined with the
+character threshold for diagnostics, but it does not trigger an initial
+checkpoint by itself. After a checkpoint exists, the event threshold is paired
+with the interval threshold, and the character threshold can trigger on its own
+to avoid overrunning the provider input budget.
+
 Use an external scheduler if you want unattended checkpoints. For example, a
 systemd timer or cron job can call:
 

--- a/src/core.js
+++ b/src/core.js
@@ -62,11 +62,11 @@ function buildSessionStatus({ scope, sessionId, rawEvents, latestCheckpoint, pol
   if (rawEventCount === 0) {
     reasons.push('no_raw_events');
   }
-  if (!latestCheckpoint && rawEventCount >= policy.minEvents) {
-    reasons.push('initial_event_threshold');
-  }
   if (!latestCheckpoint && rawCharTotal >= policy.charThreshold) {
     reasons.push('initial_char_threshold');
+  }
+  if (!latestCheckpoint && rawEventCount >= policy.minEvents && rawCharTotal >= policy.charThreshold) {
+    reasons.push('initial_event_and_char_threshold');
   }
   if (latestCheckpoint && eventsSinceLastCheckpoint.length >= policy.minEvents && elapsedMs >= policy.minIntervalMs) {
     reasons.push('events_and_interval_since_checkpoint');

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -173,15 +173,19 @@ function stripJsonFence(text) {
 }
 
 export function parseCodexExecJson(text) {
+  return parseCodexExecJsonResult(text).output;
+}
+
+function parseCodexExecJsonResult(text) {
   const stripped = stripJsonFence(text);
   try {
-    return JSON.parse(stripped);
+    return { output: JSON.parse(stripped), jsonRecovery: null };
   } catch {
     const start = stripped.indexOf('{');
     const end = stripped.lastIndexOf('}');
     if (start !== -1 && end > start) {
       try {
-        return JSON.parse(stripped.slice(start, end + 1));
+        return { output: JSON.parse(stripped.slice(start, end + 1)), jsonRecovery: 'brace-fallback' };
       } catch {
         throw new Error('Codex exec did not return valid JSON.');
       }
@@ -347,7 +351,7 @@ async function runLiveSmoke({ runner, command, model, reasoningEffort, sandbox, 
       env: process.env,
     });
     const outputText = (await readTextIfPresent(outputPath)) || result.stdout || '';
-    const output = parseCodexExecJson(outputText);
+    const { output } = parseCodexExecJsonResult(outputText);
     if (output.ok !== true || output.provider !== 'codex_exec') {
       throw new Error('codex_exec smoke returned JSON but did not confirm provider readiness.');
     }
@@ -463,7 +467,7 @@ export function createCodexExecProvider(options = {}) {
         env: process.env,
       });
       const outputText = (await readTextIfPresent(outputPath)) || result.stdout || '';
-      const output = parseCodexExecJson(outputText);
+      const { output, jsonRecovery } = parseCodexExecJsonResult(outputText);
 
       return {
         ...output,
@@ -480,6 +484,7 @@ export function createCodexExecProvider(options = {}) {
             timeoutMs,
             elapsedMs: Date.now() - startedAt,
             ...prompt.metadata,
+            ...(jsonRecovery ? { jsonRecovery } : {}),
           },
         },
       };

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -37,11 +37,11 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Begin Session',
       description: 'Create a ContextForge session id for a scoped agent run.',
-      inputSchema: z.object({
+      inputSchema: {
         ...scopedSchema,
         sessionId: z.string().optional(),
         conversationId: z.string().optional(),
-      }),
+      },
       annotations: {
         title: 'Begin Session',
         readOnlyHint: false,
@@ -56,13 +56,13 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Session Status',
       description: 'Inspect raw evidence and checkpoint thresholds for a session before deciding whether to distill.',
-      inputSchema: z.object({
+      inputSchema: {
         ...scopedSchema,
         sessionId: z.string(),
         minEvents: z.number().int().positive().optional(),
         minIntervalMs: z.number().int().positive().optional(),
         charThreshold: z.number().int().positive().optional(),
-      }),
+      },
       annotations: {
         title: 'Session Status',
         readOnlyHint: true,
@@ -77,13 +77,13 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Search Memory',
       description: 'Search durable ContextForge memories in the requested scope.',
-      inputSchema: z.object({
+      inputSchema: {
         ...scopedSchema,
         query: z.string(),
         limit: z.number().int().positive().optional(),
         searchScopes: z.enum(['scope', 'repo', 'shared', 'repo+shared', 'local']).optional(),
         sharedScopeKey: z.string().optional(),
-      }),
+      },
       annotations: {
         title: 'Search Memory',
         readOnlyHint: true,
@@ -98,10 +98,10 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Get Memory',
       description: 'Fetch one durable memory by key from a specific scope.',
-      inputSchema: z.object({
+      inputSchema: {
         ...scopedSchema,
         key: z.string(),
-      }),
+      },
       annotations: {
         title: 'Get Memory',
         readOnlyHint: true,
@@ -116,14 +116,14 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Remember',
       description: 'Create or update a durable memory in an explicit scope.',
-      inputSchema: z.object({
+      inputSchema: {
         ...scopedSchema,
         key: z.string(),
         content: z.string(),
         category: z.string().optional(),
         tags: optionalTags,
         importance: z.number().int().optional(),
-      }),
+      },
       annotations: {
         title: 'Remember',
         readOnlyHint: false,
@@ -138,14 +138,14 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Append Raw Evidence',
       description: 'Append raw scoped evidence for later distillation and debugging.',
-      inputSchema: z.object({
+      inputSchema: {
         ...scopedSchema,
         sessionId: z.string(),
         conversationId: z.string().optional(),
         role: z.string(),
         content: z.string(),
         metadata: metadataSchema.optional(),
-      }),
+      },
       annotations: {
         title: 'Append Raw Evidence',
         readOnlyHint: false,
@@ -160,12 +160,12 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Distill Checkpoint',
       description: 'Distill raw session evidence into a checkpoint with the configured provider.',
-      inputSchema: z.object({
+      inputSchema: {
         ...scopedSchema,
         sessionId: z.string(),
         conversationId: z.string().optional(),
         provider: z.string().optional(),
-      }),
+      },
       annotations: {
         title: 'Distill Checkpoint',
         readOnlyHint: false,
@@ -180,10 +180,10 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'List Memory Events',
       description: 'List provenance events for one durable memory key.',
-      inputSchema: z.object({
+      inputSchema: {
         ...scopedSchema,
         key: z.string(),
-      }),
+      },
       annotations: {
         title: 'List Memory Events',
         readOnlyHint: true,
@@ -198,11 +198,11 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'List Memory Candidates',
       description: 'List memory candidates saved on distilled checkpoints without promoting them.',
-      inputSchema: z.object({
+      inputSchema: {
         ...scopedSchema,
         sessionId: z.string().optional(),
         checkpointId: z.string().optional(),
-      }),
+      },
       annotations: {
         title: 'List Memory Candidates',
         readOnlyHint: true,
@@ -217,7 +217,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Promote Memory',
       description: 'Promote a checkpoint candidate or reviewed fact into durable memory with provenance metadata.',
-      inputSchema: z.object({
+      inputSchema: {
         ...scopedSchema,
         key: z.string(),
         content: z.string(),
@@ -229,7 +229,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
         sourceRawEventIds: z.array(z.string()).optional(),
         sourceCandidateIndex: z.number().int().optional(),
         reason: z.string().optional(),
-      }),
+      },
       annotations: {
         title: 'Promote Memory',
         readOnlyHint: false,
@@ -244,7 +244,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Correct Memory',
       description: 'Correct an existing durable memory while preserving prior content in provenance metadata.',
-      inputSchema: z.object({
+      inputSchema: {
         ...scopedSchema,
         key: z.string(),
         content: z.string(),
@@ -252,7 +252,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
         tags: optionalTags,
         importance: z.number().int().optional(),
         reason: z.string().optional(),
-      }),
+      },
       annotations: {
         title: 'Correct Memory',
         readOnlyHint: false,
@@ -267,11 +267,11 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Deactivate Memory',
       description: 'Mark a durable memory inactive without deleting its provenance.',
-      inputSchema: z.object({
+      inputSchema: {
         ...scopedSchema,
         key: z.string(),
         reason: z.string().optional(),
-      }),
+      },
       annotations: {
         title: 'Deactivate Memory',
         readOnlyHint: false,

--- a/src/retrieval/search.js
+++ b/src/retrieval/search.js
@@ -120,10 +120,9 @@ export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, 
         : [];
       const ftsById = new Map(ftsMatches.map((match) => [match.memory.id, match]));
       const ftsIds = new Set(ftsById.keys());
-      const memoriesById = new Map([
-        ...store.listMemories(source).map((memory) => [memory.id, memory]),
-        ...ftsMatches.map((match) => [match.memory.id, match.memory]),
-      ]);
+      const candidateMemories =
+        ftsMatches.length > 0 ? ftsMatches.map((match) => match.memory) : store.listMemories(source);
+      const memoriesById = new Map(candidateMemories.map((memory) => [memory.id, memory]));
 
       return [...memoriesById.values()].map((memory) => {
         const match = scoreMemory(memory, queryTokens);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -8,6 +8,7 @@ import test from 'node:test';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { createContextForge } from '../src/core.js';
+import { searchMemories } from '../src/retrieval/search.js';
 import { startContextForgeServer } from '../src/server.js';
 
 const execFileAsync = promisify(execFile);
@@ -430,6 +431,35 @@ test('search uses explainable FTS-backed ranking while keeping durable memory ca
   assert.equal(fetched.content, 'Use SQLite FTS for explainable retrieval ranking.');
 });
 
+test('search scores only FTS candidates when the index returns matches', () => {
+  const memory = {
+    id: 'memory-1',
+    key: 'indexed-memory',
+    category: 'decision',
+    content: 'Use indexed candidate search.',
+    tags: [],
+    importance: 1,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+  const results = searchMemories(
+    {
+      searchMemoryIndex: () => [{ memory, ftsRank: -0.0001 }],
+      listMemories: () => {
+        throw new Error('listMemories should not be called when FTS returns candidates.');
+      },
+    },
+    {
+      scopeType: 'repo',
+      scopeKey: 'repo-index',
+      query: 'indexed',
+    },
+  );
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].memory.key, 'indexed-memory');
+  assert.equal(results[0].retrieval.method, 'fts5+lexical');
+});
+
 test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
@@ -459,8 +489,17 @@ test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
   assert.equal(statusBefore.rawEventCount, 2);
   assert.equal(statusBefore.eventsSinceLastCheckpoint, 2);
   assert.equal(statusBefore.latestCheckpointId, null);
-  assert.equal(statusBefore.shouldDistill, true);
-  assert.ok(statusBefore.reasons.includes('initial_event_threshold'));
+  assert.equal(statusBefore.shouldDistill, false);
+
+  const statusWithEnoughContent = app.sessionStatus({
+    scope: 'repo',
+    scopeKey: 'repo-a',
+    sessionId: session.sessionId,
+    minEvents: 2,
+    charThreshold: 1,
+  });
+  assert.equal(statusWithEnoughContent.shouldDistill, true);
+  assert.ok(statusWithEnoughContent.reasons.includes('initial_event_and_char_threshold'));
 
   const checkpoint = await app.distillCheckpoint({
     scope: 'repo',
@@ -667,6 +706,46 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v1');
   assert.equal(runs[0].inputMetadata.providerMetadata.outputSchemaVersion, 'contextforge.checkpoint.v1');
   assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v1');
+});
+
+test('codex_exec records JSON brace fallback recovery metadata', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'codex_exec',
+    },
+    cwd: process.cwd(),
+    codexExecRunner: async () => ({
+      stdout: `prefix ${JSON.stringify({
+        summaryShort: 'Recovered checkpoint.',
+        summaryText: 'The provider output needed brace fallback recovery.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [],
+        sourceEventCount: 1,
+        provider: 'codex_exec',
+        metadata: { providerNotes: 'synthetic recovery' },
+      })} suffix`,
+    }),
+  });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-json-recovery',
+    sessionId: 'json-recovery-session',
+    role: 'assistant',
+    content: 'Provider output may include recoverable surrounding text.',
+  });
+
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-json-recovery',
+    sessionId: 'json-recovery-session',
+  });
+
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.jsonRecovery, 'brace-fallback');
 });
 
 test('codex_exec doctor reports dry and live smoke readiness through a runner', async () => {
@@ -1017,6 +1096,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
         scopeKey: 'mcp-repo',
         sessionId: 'mcp-session',
         minEvents: 1,
+        charThreshold: 1,
       },
     });
     assert.equal(statusResult.structuredContent.result.shouldDistill, true);
@@ -1108,6 +1188,7 @@ test('remote storage mode delegates core calls and preserves scope semantics', a
       scopeKey: 'repo-remote',
       sessionId: 'remote-session',
       minEvents: 1,
+      charThreshold: 1,
     });
     assert.equal(status.shouldDistill, true);
     assert.equal(status.rawEventCount, 1);


### PR DESCRIPTION
## Summary
- limit lexical rescoring to FTS candidates when indexed matches exist
- reduce initial sessionStatus eagerness by requiring the character threshold before first checkpoint recommendation
- record codex_exec brace-fallback JSON recovery in provider metadata
- switch MCP input schemas to raw Zod shapes

## Issue
Continues #28 Medium-priority follow-up items.

## Validation
- npm test
- npm pack --dry-run
- npm audit --audit-level=moderate
- git diff --check