### PR TITLE
Clean up low priority review items

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -35,6 +35,14 @@ function parseArgs(argv) {
 
 function toCoreOptions(options) {
   const tags = options.tag || options.tags;
+  let metadata = {};
+  if (options.metadata) {
+    try {
+      metadata = JSON.parse(options.metadata);
+    } catch (error) {
+      throw new Error(`Invalid --metadata JSON: ${error.message}`);
+    }
+  }
   return {
     scope: options.scope,
     scopeKey: options.scopeKey,
@@ -51,7 +59,7 @@ function toCoreOptions(options) {
     conversationId: options.conversationId,
     role: options.role,
     provider: options.provider,
-    metadata: options.metadata ? JSON.parse(options.metadata) : {},
+    metadata,
     sourceCheckpointId: options.sourceCheckpointId,
     sourceSessionId: options.sourceSessionId,
     sourceRawEventIds: options.sourceRawEventIds
@@ -76,26 +84,27 @@ function printJson(value) {
 
 async function main() {
   const { command, options } = parseArgs(process.argv);
+  const commands = {
+    dbInfo: (app) => app.dbInfo(),
+    doctorCodexExec: (app, coreOptions) => app.checkCodexExec(coreOptions),
+    beginSession: (app, coreOptions) => app.beginSession(coreOptions),
+    sessionStatus: (app, coreOptions) => app.sessionStatus(coreOptions),
+    remember: (app, coreOptions) => app.remember(coreOptions),
+    promoteMemory: (app, coreOptions) => app.promoteMemory(coreOptions),
+    correctMemory: (app, coreOptions) => app.correctMemory(coreOptions),
+    deactivateMemory: (app, coreOptions) => app.deactivateMemory(coreOptions),
+    listMemoryEvents: (app, coreOptions) => app.listMemoryEvents(coreOptions),
+    listMemoryCandidates: (app, coreOptions) => app.listMemoryCandidates(coreOptions),
+    search: (app, coreOptions) => app.search(coreOptions),
+    getMemory: (app, coreOptions) => app.getMemory(coreOptions),
+    appendRaw: (app, coreOptions) => app.appendRaw(coreOptions),
+    distillCheckpoint: (app, coreOptions) => app.distillCheckpoint(coreOptions),
+    listDistillRuns: (app, coreOptions) => app.listDistillRuns(coreOptions),
+  };
+
   if (!command || command === 'help' || command === '--help') {
     printJson({
-      commands: [
-        'dbInfo',
-        'doctorCodexExec',
-        'beginSession',
-        'sessionStatus',
-        'remember',
-        'promoteMemory',
-        'correctMemory',
-        'deactivateMemory',
-        'listMemoryEvents',
-        'listMemoryCandidates',
-        'search',
-        'getMemory',
-        'appendRaw',
-        'distillCheckpoint',
-        'listDistillRuns',
-        'serve',
-      ],
+      commands: [...Object.keys(commands), 'serve'],
     });
     return;
   }
@@ -110,40 +119,11 @@ async function main() {
 
   const app = createContextForge();
   const coreOptions = toCoreOptions(options);
-
-  if (command === 'dbInfo') {
-    printJson(await app.dbInfo());
-  } else if (command === 'doctorCodexExec') {
-    printJson(await app.checkCodexExec(coreOptions));
-  } else if (command === 'beginSession') {
-    printJson(await app.beginSession(coreOptions));
-  } else if (command === 'sessionStatus') {
-    printJson(await app.sessionStatus(coreOptions));
-  } else if (command === 'remember') {
-    printJson(await app.remember(coreOptions));
-  } else if (command === 'promoteMemory') {
-    printJson(await app.promoteMemory(coreOptions));
-  } else if (command === 'correctMemory') {
-    printJson(await app.correctMemory(coreOptions));
-  } else if (command === 'deactivateMemory') {
-    printJson(await app.deactivateMemory(coreOptions));
-  } else if (command === 'listMemoryEvents') {
-    printJson(await app.listMemoryEvents(coreOptions));
-  } else if (command === 'listMemoryCandidates') {
-    printJson(await app.listMemoryCandidates(coreOptions));
-  } else if (command === 'search') {
-    printJson(await app.search(coreOptions));
-  } else if (command === 'getMemory') {
-    printJson(await app.getMemory(coreOptions));
-  } else if (command === 'appendRaw') {
-    printJson(await app.appendRaw(coreOptions));
-  } else if (command === 'distillCheckpoint') {
-    printJson(await app.distillCheckpoint(coreOptions));
-  } else if (command === 'listDistillRuns') {
-    printJson(await app.listDistillRuns(coreOptions));
-  } else {
+  const handler = commands[command];
+  if (!handler) {
     throw new Error(`Unknown command: ${command}`);
   }
+  printJson(await handler(app, coreOptions));
 }
 
 main().catch((error) => {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -106,6 +106,16 @@ function pathScopeKey(cwd) {
   return `path:${digest}:${path.basename(resolved) || 'root'}`;
 }
 
+function defaultScopeKeyFor(scope, cwd, sharedScopeKey) {
+  if (scope === 'repo') {
+    return inferRepoScopeKey(cwd);
+  }
+  if (scope === 'shared') {
+    return sharedScopeKey;
+  }
+  return pathScopeKey(cwd);
+}
+
 function inferRepoScopeKey(cwd) {
   const gitRoot = findGitRoot(cwd);
   if (!gitRoot) {
@@ -134,8 +144,8 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
   const dataDir = env.CONTEXTFORGE_DATA_DIR
     ? path.resolve(cwd, env.CONTEXTFORGE_DATA_DIR)
     : storageMode === 'local'
-      ? path.join(env.HOME || os.homedir(), '.contextforge')
-    : path.join(cwd, '.contextforge');
+        ? path.join(env.HOME || os.homedir(), '.contextforge')
+        : path.join(cwd, '.contextforge');
 
   const defaultScope = env.CONTEXTFORGE_DEFAULT_SCOPE || 'repo';
   if (!VALID_SCOPES.has(defaultScope)) {
@@ -146,14 +156,16 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
     'CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS',
     12000,
   );
+  const defaultSharedScopeKey = env.CONTEXTFORGE_SHARED_SCOPE_KEY || 'global';
+  const defaultScopeKey =
+    env.CONTEXTFORGE_DEFAULT_SCOPE_KEY || defaultScopeKeyFor(defaultScope, cwd, defaultSharedScopeKey);
 
   return {
     storageMode,
     dataDir,
     defaultScope,
-    defaultScopeKey:
-      env.CONTEXTFORGE_DEFAULT_SCOPE_KEY || (defaultScope === 'repo' ? inferRepoScopeKey(cwd) : null),
-    defaultSharedScopeKey: env.CONTEXTFORGE_SHARED_SCOPE_KEY || 'global',
+    defaultScopeKey,
+    defaultSharedScopeKey,
     distillProvider: env.CONTEXTFORGE_DISTILL_PROVIDER || 'mock',
     remote: {
       url: env.CONTEXTFORGE_REMOTE_URL || null,

--- a/src/distill/validate.js
+++ b/src/distill/validate.js
@@ -1,20 +1,26 @@
 const ARRAY_FIELDS = ['decisions', 'todos', 'openQuestions', 'memoryCandidates'];
 
+function receivedType(value) {
+  if (Array.isArray(value)) return 'array';
+  if (value === null) return 'null';
+  return typeof value;
+}
+
 function assertString(value, field) {
   if (typeof value !== 'string' || value.trim() === '') {
-    throw new Error(`Provider output field "${field}" must be a non-empty string.`);
+    throw new Error(`Provider output field "${field}" must be a non-empty string; received ${receivedType(value)}.`);
   }
 }
 
 function assertArray(value, field) {
   if (!Array.isArray(value)) {
-    throw new Error(`Provider output field "${field}" must be an array.`);
+    throw new Error(`Provider output field "${field}" must be an array; received ${receivedType(value)}.`);
   }
 }
 
 export function validateDistillOutput(output) {
   if (!output || typeof output !== 'object' || Array.isArray(output)) {
-    throw new Error('Provider output must be an object.');
+    throw new Error(`Provider output must be an object; received ${receivedType(output)}.`);
   }
 
   assertString(output.summaryShort, 'summaryShort');
@@ -28,15 +34,23 @@ export function validateDistillOutput(output) {
     output.sourceEventCount != null &&
     (!Number.isInteger(output.sourceEventCount) || output.sourceEventCount < 0)
   ) {
-    throw new Error('Provider output field "sourceEventCount" must be a non-negative integer.');
+    throw new Error(
+      `Provider output field "sourceEventCount" must be a non-negative integer; received ${receivedType(
+        output.sourceEventCount,
+      )}.`,
+    );
   }
 
   if (output.provider != null && typeof output.provider !== 'string') {
-    throw new Error('Provider output field "provider" must be a string when present.');
+    throw new Error(
+      `Provider output field "provider" must be a string when present; received ${receivedType(output.provider)}.`,
+    );
   }
 
   if (output.metadata != null && (typeof output.metadata !== 'object' || Array.isArray(output.metadata))) {
-    throw new Error('Provider output field "metadata" must be an object when present.');
+    throw new Error(
+      `Provider output field "metadata" must be an object when present; received ${receivedType(output.metadata)}.`,
+    );
   }
 
   return {

--- a/src/retrieval/search.js
+++ b/src/retrieval/search.js
@@ -94,6 +94,7 @@ function normalizeSearchScopes({ scopeType, scopeKey, searchScopes, sharedScopeK
 }
 
 function scopeBoost(source) {
+  // Scope boost is intentionally a tie-breaker after lexical/FTS relevance.
   if (source.role === 'repo') return 1000;
   if (source.role === 'shared') return 100;
   return 0;

--- a/src/server.js
+++ b/src/server.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 import crypto from 'node:crypto';
 import http from 'node:http';
+import { pathToFileURL } from 'node:url';
 import { createContextForge } from './core.js';
 import { REMOTE_METHODS } from './remote/client.js';
 
 const METHOD_SET = new Set(REMOTE_METHODS);
-const MAX_BODY_BYTES = 1024 * 1024;
+const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
 
 function sendJson(response, statusCode, body) {
   response.writeHead(statusCode, {
@@ -14,21 +15,38 @@ function sendJson(response, statusCode, body) {
   response.end(`${JSON.stringify(body, null, 2)}\n`);
 }
 
-function readJsonBody(request) {
+function parseMaxBodyBytes(env) {
+  const value = env.CONTEXTFORGE_REMOTE_MAX_BODY_BYTES;
+  if (value == null || value === '') {
+    return DEFAULT_MAX_BODY_BYTES;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error('CONTEXTFORGE_REMOTE_MAX_BODY_BYTES must be a positive integer.');
+  }
+  return parsed;
+}
+
+function readJsonBody(request, { maxBodyBytes = DEFAULT_MAX_BODY_BYTES } = {}) {
   return new Promise((resolve, reject) => {
     let size = 0;
     let body = '';
+    let tooLarge = false;
     request.on('data', (chunk) => {
       size += chunk.length;
-      if (size > MAX_BODY_BYTES) {
+      if (size > maxBodyBytes) {
+        if (tooLarge) return;
+        tooLarge = true;
         reject(new Error('Request body is too large.'));
-        request.destroy();
         return;
       }
       body += chunk.toString();
     });
     request.on('error', reject);
     request.on('end', () => {
+      if (tooLarge) {
+        return;
+      }
       if (!body.trim()) {
         resolve({});
         return;
@@ -73,6 +91,7 @@ function serverStorageEnv(env) {
 export function createContextForgeServer({ app, env = process.env } = {}) {
   const serverApp = app || createContextForge({ env: serverStorageEnv(env), reuseStore: true });
   const authToken = env.CONTEXTFORGE_REMOTE_TOKEN || null;
+  const maxBodyBytes = parseMaxBodyBytes(env);
 
   const server = http.createServer(async (request, response) => {
     const requestUrl = new URL(request.url, 'http://localhost');
@@ -99,7 +118,7 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
     }
 
     try {
-      const options = await readJsonBody(request);
+      const options = await readJsonBody(request, { maxBodyBytes });
       const result = await serverApp[method](options);
       sendJson(response, 200, { result });
     } catch (error) {
@@ -161,7 +180,7 @@ async function main() {
   console.log(JSON.stringify({ listening: instance.url }, null, 2));
 }
 
-if (process.argv[1] && import.meta.url === new URL(process.argv[1], 'file:').href) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((error) => {
     console.error(error.message);
     process.exitCode = 1;

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import Database from 'better-sqlite3';
 
-const SCHEMA_VERSION = 4;
+export const SCHEMA_VERSION = 4;
 
 function nowIso() {
   return new Date().toISOString();

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -8,8 +8,10 @@ import test from 'node:test';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { createContextForge } from '../src/core.js';
+import { validateDistillOutput } from '../src/distill/validate.js';
 import { searchMemories } from '../src/retrieval/search.js';
 import { startContextForgeServer } from '../src/server.js';
+import { SCHEMA_VERSION } from '../src/storage/sqlite.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -23,7 +25,7 @@ test('dbInfo initializes a fresh SQLite store', async () => {
 
   const info = app.dbInfo();
 
-  assert.equal(info.schemaVersion, 4);
+  assert.equal(info.schemaVersion, SCHEMA_VERSION);
   assert.equal(info.tables.memories, 0);
   assert.match(info.dbPath, /contextforge\.db$/);
 });
@@ -60,6 +62,33 @@ test('repo scope key falls back to a deterministic path key outside git', async 
     content: 'Explicit repo scope keys still win.',
   });
   assert.equal(explicit.scopeKey, 'explicit/repo');
+});
+
+test('default shared and local scopes get usable default keys', async () => {
+  const cwd = await makeTempDir();
+  const sharedApp = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: path.join(cwd, 'shared-data'),
+      CONTEXTFORGE_DEFAULT_SCOPE: 'shared',
+      CONTEXTFORGE_SHARED_SCOPE_KEY: 'team',
+    },
+    cwd,
+  });
+  const sharedMemory = sharedApp.remember({
+    key: 'shared-default',
+    content: 'Shared scope has a default key.',
+  });
+  assert.equal(sharedMemory.scopeType, 'shared');
+  assert.equal(sharedMemory.scopeKey, 'team');
+
+  const localApp = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: path.join(cwd, 'local-data'),
+      CONTEXTFORGE_DEFAULT_SCOPE: 'local',
+    },
+    cwd,
+  });
+  assert.match(localApp.config.defaultScopeKey, /^path:[a-f0-9]{16}:contextforge-test-/);
 });
 
 test('remember, getMemory, and search use explicit scopes', async () => {
@@ -296,6 +325,36 @@ test('CLI supports promoteMemory', async () => {
     { env },
   );
   assert.match(fetched.stdout, /Promoted memories are durable/);
+});
+
+test('CLI reports invalid metadata JSON clearly', async () => {
+  const dataDir = await makeTempDir();
+  const env = { ...process.env, CONTEXTFORGE_DATA_DIR: dataDir };
+
+  await assert.rejects(
+    () =>
+      execFileAsync(
+        'node',
+        [
+          'src/cli.js',
+          'appendRaw',
+          '--scope',
+          'repo',
+          '--scopeKey',
+          'cli-repo',
+          '--sessionId',
+          'cli-session',
+          '--role',
+          'user',
+          '--content',
+          'Invalid metadata should fail clearly.',
+          '--metadata',
+          '{bad',
+        ],
+        { env },
+      ),
+    /Invalid --metadata JSON/,
+  );
 });
 
 test('search can combine repo and shared scopes while excluding local by default', async () => {
@@ -585,6 +644,22 @@ test('distillCheckpoint rejects malformed provider output and preserves raw evid
   });
   assert.equal(runs[0].status, 'failed');
   assert.equal(runs[0].outputMetadata.validationFailed, true);
+});
+
+test('distill output validation includes received types', () => {
+  assert.throws(() => validateDistillOutput(null), /received null/);
+  assert.throws(
+    () =>
+      validateDistillOutput({
+        summaryShort: 'Invalid checkpoint.',
+        summaryText: 'Array fields are not valid here.',
+        decisions: 'not-array',
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [],
+      }),
+    /decisions.*received string/,
+  );
 });
 
 test('distillCheckpoint records provider failures without deleting raw evidence', async () => {
@@ -917,7 +992,7 @@ test('CLI supports the v0 workflow with synthetic data', async () => {
   const env = { ...process.env, CONTEXTFORGE_DATA_DIR: dataDir };
 
   const dbInfo = await execFileAsync('node', ['src/cli.js', 'dbInfo'], { env });
-  assert.match(dbInfo.stdout, /"schemaVersion": 4/);
+  assert.match(dbInfo.stdout, new RegExp(`"schemaVersion": ${SCHEMA_VERSION}`));
 
   await execFileAsync(
     'node',
@@ -1247,6 +1322,34 @@ test('remote server requires a token on non-loopback hosts', async () => {
       }),
     /CONTEXTFORGE_REMOTE_TOKEN is required/,
   );
+});
+
+test('remote server supports configurable request body limits', async () => {
+  const dataDir = await makeTempDir();
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+      CONTEXTFORGE_REMOTE_MAX_BODY_BYTES: '8',
+    },
+  });
+
+  try {
+    const response = await fetch(`${remote.url}/v0/dbInfo`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json',
+      },
+      body: '{"tooLarge":true}',
+    });
+    const body = await response.json();
+    assert.equal(response.status, 500);
+    assert.match(body.error.message, /too large/);
+  } finally {
+    await remote.close();
+  }
 });
 
 test('runtime database artifacts are ignored by git rules', async () => {


### PR DESCRIPTION
## Summary
- clean up config default scope keys and data-dir ternary formatting
- improve CLI metadata JSON errors and replace if/else dispatch with a handler map
- make remote server request body limit configurable and use pathToFileURL for entrypoint detection
- add received type context to distill validation errors
- document search scope boost as an intentional tie-breaker
- export SCHEMA_VERSION for tests instead of hardcoding it

## Issue
Completes the Low-priority cleanup items from #28.

## Validation
- npm test
- npm pack --dry-run
- npm audit --audit-level=moderate
- git diff --check