### PR TITLE
Polish final review follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## Unreleased
+
+- Remote HTTP requests that exceed `CONTEXTFORGE_REMOTE_MAX_BODY_BYTES` now
+  return `413 Payload Too Large` instead of a generic `500` response.
+- `sessionStatus` no longer recommends the first checkpoint from event count
+  alone. Initial checkpoint recommendations now require the raw character
+  threshold; after a checkpoint exists, event count is still paired with the
+  interval threshold.

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -144,8 +144,8 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
   const dataDir = env.CONTEXTFORGE_DATA_DIR
     ? path.resolve(cwd, env.CONTEXTFORGE_DATA_DIR)
     : storageMode === 'local'
-        ? path.join(env.HOME || os.homedir(), '.contextforge')
-        : path.join(cwd, '.contextforge');
+      ? path.join(env.HOME || os.homedir(), '.contextforge')
+      : path.join(cwd, '.contextforge');
 
   const defaultScope = env.CONTEXTFORGE_DEFAULT_SCOPE || 'repo';
   if (!VALID_SCOPES.has(defaultScope)) {

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,14 @@ import { REMOTE_METHODS } from './remote/client.js';
 const METHOD_SET = new Set(REMOTE_METHODS);
 const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
 
+class RequestBodyTooLargeError extends Error {
+  constructor() {
+    super('Request body is too large.');
+    this.name = 'RequestBodyTooLargeError';
+    this.statusCode = 413;
+  }
+}
+
 function sendJson(response, statusCode, body) {
   response.writeHead(statusCode, {
     'content-type': 'application/json',
@@ -37,7 +45,7 @@ function readJsonBody(request, { maxBodyBytes = DEFAULT_MAX_BODY_BYTES } = {}) {
       if (size > maxBodyBytes) {
         if (tooLarge) return;
         tooLarge = true;
-        reject(new Error('Request body is too large.'));
+        reject(new RequestBodyTooLargeError());
         return;
       }
       body += chunk.toString();
@@ -122,7 +130,7 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
       const result = await serverApp[method](options);
       sendJson(response, 200, { result });
     } catch (error) {
-      sendJson(response, 500, {
+      sendJson(response, error.statusCode || 500, {
         error: {
           message: error.message,
           name: error.name,

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1345,7 +1345,8 @@ test('remote server supports configurable request body limits', async () => {
       body: '{"tooLarge":true}',
     });
     const body = await response.json();
-    assert.equal(response.status, 500);
+    assert.equal(response.status, 413);
+    assert.equal(body.error.name, 'RequestBodyTooLargeError');
     assert.match(body.error.message, /too large/);
   } finally {
     await remote.close();


### PR DESCRIPTION
## Summary
- return 413 Payload Too Large for remote request bodies over the configured limit
- add CHANGELOG notes for the sessionStatus recommendation change and 413 behavior
- tidy the config data-dir ternary formatting

## Validation
- npm test
- npm pack --dry-run
- npm audit --audit-level=moderate
- git diff --check