### PR TITLE
Resolve repo scopes from client paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Scoped CLI and MCP calls can now pass `repoPath` or `cwd` so repo memory is
+  resolved for a target checkout even when the agent process starts elsewhere.
+- MCP instructions now call out intentional durable memory writes with
+  `remember` and reviewed checkpoint promotion with `promote_memory`.
 - Remote HTTP requests that exceed `CONTEXTFORGE_REMOTE_MAX_BODY_BYTES` now
   return `413 Payload Too Large` instead of a generic `500` response.
 - `sessionStatus` no longer recommends the first checkpoint from event count

--- a/README.md
+++ b/README.md
@@ -395,12 +395,16 @@ codex mcp add contextforge \
 
 Do not pin the MCP server `cwd` to one project when the same registration should
 serve many repositories. Repo scope keys are inferred from the active git
-checkout when possible, and can be passed explicitly with `scopeKey` when the
-client cannot provide a useful working directory.
+checkout when possible. If an agent is launched outside the repository but is
+working on a specific checkout, pass `repoPath` or `cwd` on scoped tool calls so
+the client can resolve that checkout before talking to the remote store. Pass an
+explicit `scopeKey` when the client cannot provide a useful working directory.
 
 Agents should use `search` for scoped retrieval on demand, call `get_memory`
 only when they know the durable key they need, append raw evidence for later
-distillation, and call `promote_memory` only after a checkpoint candidate or
+distillation, and call `remember` when the user or agent intentionally decides
+that an important fact, preference, decision, or runbook note should become
+durable memory. Use `promote_memory` only after a checkpoint candidate or
 decision has been reviewed. Use `correct_memory` to preserve the previous value
 while changing a durable key, and `deactivate_memory` to remove stale memories
 from retrieval without deleting their history.

--- a/src/cli.js
+++ b/src/cli.js
@@ -46,6 +46,8 @@ function toCoreOptions(options) {
   return {
     scope: options.scope,
     scopeKey: options.scopeKey,
+    cwd: options.cwd,
+    repoPath: options.repoPath,
     key: options.key,
     content: options.content,
     category: options.category,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -116,7 +116,7 @@ function defaultScopeKeyFor(scope, cwd, sharedScopeKey) {
   return pathScopeKey(cwd);
 }
 
-function inferRepoScopeKey(cwd) {
+export function inferRepoScopeKey(cwd) {
   const gitRoot = findGitRoot(cwd);
   if (!gitRoot) {
     return pathScopeKey(cwd);
@@ -136,16 +136,17 @@ function inferRepoScopeKey(cwd) {
 }
 
 export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
+  const resolvedCwd = path.resolve(cwd);
   const storageMode = env.CONTEXTFORGE_STORAGE_MODE || (env.CONTEXTFORGE_REMOTE_URL ? 'remote' : 'project-local');
   if (!VALID_STORAGE_MODES.has(storageMode)) {
     throw new Error(`Invalid CONTEXTFORGE_STORAGE_MODE: ${storageMode}`);
   }
 
   const dataDir = env.CONTEXTFORGE_DATA_DIR
-    ? path.resolve(cwd, env.CONTEXTFORGE_DATA_DIR)
+    ? path.resolve(resolvedCwd, env.CONTEXTFORGE_DATA_DIR)
     : storageMode === 'local'
       ? path.join(env.HOME || os.homedir(), '.contextforge')
-      : path.join(cwd, '.contextforge');
+      : path.join(resolvedCwd, '.contextforge');
 
   const defaultScope = env.CONTEXTFORGE_DEFAULT_SCOPE || 'repo';
   if (!VALID_SCOPES.has(defaultScope)) {
@@ -158,10 +159,11 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
   );
   const defaultSharedScopeKey = env.CONTEXTFORGE_SHARED_SCOPE_KEY || 'global';
   const defaultScopeKey =
-    env.CONTEXTFORGE_DEFAULT_SCOPE_KEY || defaultScopeKeyFor(defaultScope, cwd, defaultSharedScopeKey);
+    env.CONTEXTFORGE_DEFAULT_SCOPE_KEY || defaultScopeKeyFor(defaultScope, resolvedCwd, defaultSharedScopeKey);
 
   return {
     storageMode,
+    cwd: resolvedCwd,
     dataDir,
     defaultScope,
     defaultScopeKey,
@@ -181,7 +183,9 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
       model: env.CONTEXTFORGE_CODEX_EXEC_MODEL || null,
       reasoningEffort: env.CONTEXTFORGE_CODEX_EXEC_REASONING_EFFORT || null,
       sandbox: env.CONTEXTFORGE_CODEX_EXEC_SANDBOX || 'read-only',
-      cwd: env.CONTEXTFORGE_CODEX_EXEC_CWD ? path.resolve(cwd, env.CONTEXTFORGE_CODEX_EXEC_CWD) : cwd,
+      cwd: env.CONTEXTFORGE_CODEX_EXEC_CWD
+        ? path.resolve(resolvedCwd, env.CONTEXTFORGE_CODEX_EXEC_CWD)
+        : resolvedCwd,
       timeoutMs: parsePositiveInteger(
         env.CONTEXTFORGE_CODEX_EXEC_TIMEOUT_MS,
         'CONTEXTFORGE_CODEX_EXEC_TIMEOUT_MS',

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -11,6 +11,8 @@ const optionalTags = z.array(z.string()).optional();
 const scopedSchema = {
   scope: scopeSchema.optional(),
   scopeKey: z.string().optional(),
+  cwd: z.string().optional(),
+  repoPath: z.string().optional(),
 };
 
 function jsonResult(result) {
@@ -28,7 +30,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     },
     {
       instructions:
-        'Use ContextForge for scoped memory retrieval on demand. Prefer search before loading exact memories, keep local scope opt-in, and promote checkpoint candidates only when durable memory is intentional.',
+        'Use ContextForge for scoped memory retrieval on demand. Prefer search before loading exact memories. If working on a repository while the MCP process cwd is elsewhere, pass repoPath or cwd so repo scope resolves to that checkout. Use remember for reviewed durable facts the user or assistant intentionally wants saved, and promote checkpoint candidates only when durable memory is intentional. Keep local scope opt-in.',
     },
   );
 
@@ -36,7 +38,8 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     'begin_session',
     {
       title: 'Begin Session',
-      description: 'Create a ContextForge session id for a scoped agent run.',
+      description:
+        'Create a ContextForge session id for a scoped agent run. Pass repoPath or cwd when the active repository differs from the MCP process cwd.',
       inputSchema: {
         ...scopedSchema,
         sessionId: z.string().optional(),
@@ -76,7 +79,8 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     'search',
     {
       title: 'Search Memory',
-      description: 'Search durable ContextForge memories in the requested scope.',
+      description:
+        'Search durable ContextForge memories in the requested scope. Pass repoPath or cwd to retrieve repo memories for a checkout outside the MCP process cwd.',
       inputSchema: {
         ...scopedSchema,
         query: z.string(),
@@ -115,7 +119,8 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     'remember',
     {
       title: 'Remember',
-      description: 'Create or update a durable memory in an explicit scope.',
+      description:
+        'Create or update an intentional durable memory in the requested scope; use for important facts, decisions, preferences, or runbook notes that should outlive the session.',
       inputSchema: {
         ...scopedSchema,
         key: z.string(),
@@ -216,7 +221,8 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     'promote_memory',
     {
       title: 'Promote Memory',
-      description: 'Promote a checkpoint candidate or reviewed fact into durable memory with provenance metadata.',
+      description:
+        'Promote a checkpoint candidate or reviewed fact into intentional durable memory with provenance metadata.',
       inputSchema: {
         ...scopedSchema,
         key: z.string(),

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -1,3 +1,5 @@
+import { normalizeScopeOptions } from '../scopes/index.js';
+
 const REMOTE_METHODS = [
   'dbInfo',
   'checkCodexExec',
@@ -15,6 +17,22 @@ const REMOTE_METHODS = [
   'distillCheckpoint',
   'listDistillRuns',
 ];
+
+const SCOPED_REMOTE_METHODS = new Set([
+  'beginSession',
+  'sessionStatus',
+  'remember',
+  'promoteMemory',
+  'correctMemory',
+  'deactivateMemory',
+  'listMemoryEvents',
+  'listMemoryCandidates',
+  'getMemory',
+  'search',
+  'appendRaw',
+  'distillCheckpoint',
+  'listDistillRuns',
+]);
 
 function remoteUrl(baseUrl, method) {
   const url = new URL(baseUrl);
@@ -86,7 +104,18 @@ export function createRemoteContextForge(config, options = {}) {
   const api = { config };
 
   for (const method of REMOTE_METHODS) {
-    api[method] = (callOptions = {}) => client.call(method, callOptions);
+    api[method] = (callOptions = {}) => {
+      if (!SCOPED_REMOTE_METHODS.has(method)) {
+        return client.call(method, callOptions);
+      }
+      const scope = normalizeScopeOptions(callOptions, config);
+      return client.call(method, {
+        ...callOptions,
+        scope: scope.scopeType,
+        scopeType: scope.scopeType,
+        scopeKey: scope.scopeKey,
+      });
+    };
   }
 
   return api;

--- a/src/scopes/index.js
+++ b/src/scopes/index.js
@@ -1,3 +1,6 @@
+import path from 'node:path';
+import { inferRepoScopeKey } from '../config/index.js';
+
 const VALID_SCOPE_TYPES = new Set(['shared', 'repo', 'local']);
 
 export function validateScope(scopeType, scopeKey) {
@@ -14,6 +17,15 @@ export function validateScope(scopeType, scopeKey) {
 
 export function normalizeScopeOptions(options, config) {
   const scopeType = options.scopeType || options.scope || config.defaultScope;
-  const scopeKey = options.scopeKey || config.defaultScopeKey;
+  let scopeKey = options.scopeKey;
+  if (!scopeKey && scopeType === 'repo' && (options.repoPath || options.cwd)) {
+    scopeKey = inferRepoScopeKey(path.resolve(config.cwd || process.cwd(), options.repoPath || options.cwd));
+  }
+  if (!scopeKey && scopeType === 'shared') {
+    scopeKey = config.defaultSharedScopeKey || config.defaultScopeKey;
+  }
+  if (!scopeKey) {
+    scopeKey = config.defaultScopeKey;
+  }
   return validateScope(scopeType, scopeKey);
 }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -19,6 +19,13 @@ async function makeTempDir() {
   return fs.mkdtemp(path.join(os.tmpdir(), 'contextforge-test-'));
 }
 
+async function makeGitRepo(remoteUrl = 'git@github.com:example/contextforge.git') {
+  const cwd = await makeTempDir();
+  await fs.mkdir(path.join(cwd, '.git'), { recursive: true });
+  await fs.writeFile(path.join(cwd, '.git', 'config'), `[remote "origin"]\n\turl = ${remoteUrl}\n`);
+  return cwd;
+}
+
 test('dbInfo initializes a fresh SQLite store', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
@@ -31,12 +38,7 @@ test('dbInfo initializes a fresh SQLite store', async () => {
 });
 
 test('repo scope key defaults to normalized GitHub origin remote', async () => {
-  const cwd = await makeTempDir();
-  await fs.mkdir(path.join(cwd, '.git'), { recursive: true });
-  await fs.writeFile(
-    path.join(cwd, '.git', 'config'),
-    '[remote "origin"]\n\turl = git@github.com:example/contextforge.git\n',
-  );
+  const cwd = await makeGitRepo();
   const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: path.join(cwd, 'data') }, cwd });
 
   assert.equal(app.config.defaultScopeKey, 'github.com/example/contextforge');
@@ -60,6 +62,38 @@ test('repo scope key falls back to a deterministic path key outside git', async 
     scopeKey: 'explicit/repo',
     key: 'explicit-scope',
     content: 'Explicit repo scope keys still win.',
+  });
+  assert.equal(explicit.scopeKey, 'explicit/repo');
+});
+
+test('repoPath and cwd resolve repo scope independently of the app cwd', async () => {
+  const appCwd = await makeTempDir();
+  const repoPath = await makeGitRepo('https://github.com/example/target-repo.git');
+  const repoSubdir = path.join(repoPath, 'src');
+  await fs.mkdir(repoSubdir);
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: path.join(appCwd, 'data') }, cwd: appCwd });
+
+  const fromRepoPath = app.remember({
+    scope: 'repo',
+    repoPath,
+    key: 'repo-path-memory',
+    content: 'Repo path selects the target checkout.',
+  });
+  assert.equal(fromRepoPath.scopeKey, 'github.com/example/target-repo');
+
+  const fromCwd = app.beginSession({
+    scope: 'repo',
+    cwd: repoSubdir,
+    sessionId: 'repo-cwd-session',
+  });
+  assert.equal(fromCwd.scopeKey, 'github.com/example/target-repo');
+
+  const explicit = app.remember({
+    scope: 'repo',
+    scopeKey: 'explicit/repo',
+    repoPath,
+    key: 'explicit-wins',
+    content: 'Explicit scopeKey still wins over repoPath.',
   });
   assert.equal(explicit.scopeKey, 'explicit/repo');
 });
@@ -325,6 +359,31 @@ test('CLI supports promoteMemory', async () => {
     { env },
   );
   assert.match(fetched.stdout, /Promoted memories are durable/);
+});
+
+test('CLI accepts repoPath for repo-scoped memory', async () => {
+  const dataDir = await makeTempDir();
+  const appCwd = await makeTempDir();
+  const repoPath = await makeGitRepo('git@github.com:example/cli-repo.git');
+  const env = { ...process.env, CONTEXTFORGE_DATA_DIR: dataDir };
+
+  const remembered = await execFileAsync(
+    'node',
+    [
+      path.resolve('src/cli.js'),
+      'remember',
+      '--scope',
+      'repo',
+      '--repoPath',
+      repoPath,
+      '--key',
+      'repo-path-cli',
+      '--content',
+      'CLI repoPath resolves repo scope.',
+    ],
+    { cwd: appCwd, env },
+  );
+  assert.match(remembered.stdout, /"scopeKey": "github.com\/example\/cli-repo"/);
 });
 
 test('CLI reports invalid metadata JSON clearly', async () => {
@@ -1090,6 +1149,7 @@ test('CLI supports the v0 workflow with synthetic data', async () => {
 
 test('MCP stdio server exposes core tools for synthetic integration', async () => {
   const dataDir = await makeTempDir();
+  const repoPath = await makeGitRepo('git@github.com:example/mcp-repo.git');
   const client = new Client({ name: 'contextforge-test-client', version: '0.0.0' }, { capabilities: {} });
   const transport = new StdioClientTransport({
     command: 'node',
@@ -1120,6 +1180,9 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'search',
       'session_status',
     ]);
+    const rememberTool = toolList.tools.find((tool) => tool.name === 'remember');
+    assert.ok(rememberTool.inputSchema.properties.repoPath);
+    assert.ok(rememberTool.inputSchema.properties.cwd);
 
     const rememberResult = await client.callTool({
       name: 'remember',
@@ -1142,6 +1205,17 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       },
     });
     assert.equal(searchResult.structuredContent.result[0].memory.key, 'mcp-rule');
+
+    const repoPathResult = await client.callTool({
+      name: 'remember',
+      arguments: {
+        scope: 'repo',
+        repoPath,
+        key: 'mcp-repo-path-rule',
+        content: 'MCP repoPath resolves the target checkout.',
+      },
+    });
+    assert.equal(repoPathResult.structuredContent.result.scopeKey, 'github.com/example/mcp-repo');
 
     const sessionResult = await client.callTool({
       name: 'begin_session',
@@ -1270,6 +1344,47 @@ test('remote storage mode delegates core calls and preserves scope semantics', a
 
     const info = await app.dbInfo();
     assert.equal(info.tables.memories, 2);
+  } finally {
+    await remote.close();
+  }
+});
+
+test('remote storage mode resolves repoPath before sending scoped calls', async () => {
+  const dataDir = await makeTempDir();
+  const appCwd = await makeTempDir();
+  const repoPath = await makeGitRepo('https://github.com/example/remote-client-repo.git');
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+    },
+  });
+
+  try {
+    const app = createContextForge({
+      env: {
+        CONTEXTFORGE_STORAGE_MODE: 'remote',
+        CONTEXTFORGE_REMOTE_URL: remote.url,
+        CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+      },
+      cwd: appCwd,
+    });
+
+    const memory = await app.remember({
+      scope: 'repo',
+      repoPath,
+      key: 'remote-client-repo-path',
+      content: 'Remote clients resolve repoPath locally before posting.',
+    });
+    assert.equal(memory.scopeKey, 'github.com/example/remote-client-repo');
+
+    const fetched = await app.getMemory({
+      scope: 'repo',
+      scopeKey: 'github.com/example/remote-client-repo',
+      key: 'remote-client-repo-path',
+    });
+    assert.equal(fetched.content, 'Remote clients resolve repoPath locally before posting.');
   } finally {
     await remote.close();
   }


### PR DESCRIPTION
## Summary
- add cwd/repoPath scoped options so CLI and MCP callers can resolve a target checkout even when their process cwd is elsewhere
- normalize repo scope client-side before remote calls, preserving explicit scopeKey precedence
- update MCP instructions and README guidance for intentional remember/promote_memory writes

## Tests
- npm test
- git diff --check
- npm pack --dry-run
- npm audit --audit-level=moderate