### PR TITLE
Polish remote scope path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Scoped CLI and MCP calls can now pass `repoPath` or `cwd` so repo memory is
   resolved for a target checkout even when the agent process starts elsewhere.
+- Remote clients strip `repoPath` and `cwd` after resolving scope keys so local
+  filesystem paths are not sent to the remote server.
 - MCP instructions now call out intentional durable memory writes with
   `remember` and reviewed checkpoint promotion with `promote_memory`.
 - Remote HTTP requests that exceed `CONTEXTFORGE_REMOTE_MAX_BODY_BYTES` now

--- a/README.md
+++ b/README.md
@@ -397,8 +397,9 @@ Do not pin the MCP server `cwd` to one project when the same registration should
 serve many repositories. Repo scope keys are inferred from the active git
 checkout when possible. If an agent is launched outside the repository but is
 working on a specific checkout, pass `repoPath` or `cwd` on scoped tool calls so
-the client can resolve that checkout before talking to the remote store. Pass an
-explicit `scopeKey` when the client cannot provide a useful working directory.
+the client can resolve that checkout before talking to the remote store.
+`repoPath` takes precedence when both are provided. Pass an explicit `scopeKey`
+when the client cannot provide a useful working directory.
 
 Agents should use `search` for scoped retrieval on demand, call `get_memory`
 only when they know the durable key they need, append raw evidence for later

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -30,7 +30,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     },
     {
       instructions:
-        'Use ContextForge for scoped memory retrieval on demand. Prefer search before loading exact memories. If working on a repository while the MCP process cwd is elsewhere, pass repoPath or cwd so repo scope resolves to that checkout. Use remember for reviewed durable facts the user or assistant intentionally wants saved, and promote checkpoint candidates only when durable memory is intentional. Keep local scope opt-in.',
+        'Use ContextForge for scoped memory retrieval on demand. Prefer search before loading exact memories. If working on a repository while the MCP process cwd is elsewhere, pass repoPath or cwd so repo scope resolves to that checkout; repoPath takes precedence when both are provided. Use remember for reviewed durable facts the user or assistant intentionally wants saved, and promote checkpoint candidates only when durable memory is intentional. Keep local scope opt-in.',
     },
   );
 
@@ -39,7 +39,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Begin Session',
       description:
-        'Create a ContextForge session id for a scoped agent run. Pass repoPath or cwd when the active repository differs from the MCP process cwd.',
+        'Create a ContextForge session id for a scoped agent run. Pass repoPath or cwd when the active repository differs from the MCP process cwd; repoPath takes precedence.',
       inputSchema: {
         ...scopedSchema,
         sessionId: z.string().optional(),
@@ -80,7 +80,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Search Memory',
       description:
-        'Search durable ContextForge memories in the requested scope. Pass repoPath or cwd to retrieve repo memories for a checkout outside the MCP process cwd.',
+        'Search durable ContextForge memories in the requested scope. Pass repoPath or cwd to retrieve repo memories for a checkout outside the MCP process cwd; repoPath takes precedence.',
       inputSchema: {
         ...scopedSchema,
         query: z.string(),

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -18,21 +18,7 @@ const REMOTE_METHODS = [
   'listDistillRuns',
 ];
 
-const SCOPED_REMOTE_METHODS = new Set([
-  'beginSession',
-  'sessionStatus',
-  'remember',
-  'promoteMemory',
-  'correctMemory',
-  'deactivateMemory',
-  'listMemoryEvents',
-  'listMemoryCandidates',
-  'getMemory',
-  'search',
-  'appendRaw',
-  'distillCheckpoint',
-  'listDistillRuns',
-]);
+const UNSCOPED_REMOTE_METHODS = new Set(['dbInfo', 'checkCodexExec']);
 
 function remoteUrl(baseUrl, method) {
   const url = new URL(baseUrl);
@@ -105,12 +91,13 @@ export function createRemoteContextForge(config, options = {}) {
 
   for (const method of REMOTE_METHODS) {
     api[method] = (callOptions = {}) => {
-      if (!SCOPED_REMOTE_METHODS.has(method)) {
+      if (UNSCOPED_REMOTE_METHODS.has(method)) {
         return client.call(method, callOptions);
       }
+      const { cwd, repoPath, ...remoteOptions } = callOptions;
       const scope = normalizeScopeOptions(callOptions, config);
       return client.call(method, {
-        ...callOptions,
+        ...remoteOptions,
         scope: scope.scopeType,
         scopeType: scope.scopeType,
         scopeKey: scope.scopeKey,

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1390,6 +1390,47 @@ test('remote storage mode resolves repoPath before sending scoped calls', async 
   }
 });
 
+test('remote storage mode strips local path hints after resolving scope', async () => {
+  const appCwd = await makeTempDir();
+  const repoPath = await makeGitRepo('https://github.com/example/remote-strip-repo.git');
+  let postedBody = null;
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_STORAGE_MODE: 'remote',
+      CONTEXTFORGE_REMOTE_URL: 'https://memory.example.test',
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+    },
+    cwd: appCwd,
+    fetchImpl: async (_url, request) => {
+      postedBody = JSON.parse(request.body);
+      return {
+        ok: true,
+        text: async () =>
+          JSON.stringify({
+            result: {
+              key: postedBody.key,
+              scopeType: postedBody.scopeType,
+              scopeKey: postedBody.scopeKey,
+            },
+          }),
+      };
+    },
+  });
+
+  const memory = await app.remember({
+    scope: 'repo',
+    repoPath,
+    cwd: appCwd,
+    key: 'remote-strip-paths',
+    content: 'Remote payloads should not include local paths.',
+  });
+
+  assert.equal(memory.scopeKey, 'github.com/example/remote-strip-repo');
+  assert.equal(postedBody.scopeKey, 'github.com/example/remote-strip-repo');
+  assert.equal(postedBody.repoPath, undefined);
+  assert.equal(postedBody.cwd, undefined);
+});
+
 test('remote storage mode rejects unauthorized writes', async () => {
   const dataDir = await makeTempDir();
   const remote = await startContextForgeServer({


### PR DESCRIPTION
## Summary
- replace the scoped remote method allowlist with an unscoped-method denylist to avoid future normalization omissions
- strip cwd/repoPath from remote payloads after client-side scope resolution
- document repoPath precedence in README and MCP tool guidance

## Tests
- npm test
- git diff --check
- npm pack --dry-run
- npm audit --audit-level=moderate