### PR TITLE
Expose remote MCP over HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- The remote server now exposes a Streamable HTTP MCP endpoint at `/mcp`, so
+  agents on multiple machines can connect directly to the same canonical memory
+  store without launching a local stdio MCP bridge.
 - Scoped CLI and MCP calls can now pass `repoPath` or `cwd` so repo memory is
   resolved for a target checkout even when the agent process starts elsewhere.
 - Remote clients strip `repoPath` and `cwd` after resolving scope keys so local

--- a/README.md
+++ b/README.md
@@ -337,6 +337,21 @@ Inactive memories are retained for provenance but excluded from search results.
 
 ## MCP Server
 
+ContextForge supports both remote Streamable HTTP MCP and local stdio MCP.
+Use HTTP MCP when multiple machines or agent environments should share the
+same canonical memory. Use stdio MCP for local-only or development setups.
+
+Run the remote server, then register its MCP endpoint:
+
+```bash
+contextforge-server
+codex mcp add contextforge \
+  --url https://memory.example.com/mcp \
+  --bearer-token-env-var CONTEXTFORGE_REMOTE_TOKEN
+```
+
+The HTTP MCP endpoint uses the same bearer token as the remote `/v0/*` API.
+
 Run ContextForge as a local stdio MCP server:
 
 ```bash
@@ -381,8 +396,9 @@ Example MCP client configuration:
 }
 ```
 
-Codex can register ContextForge as a stdio MCP server while still using the
-remote canonical store:
+Codex can also register ContextForge as a stdio MCP server while still using
+the remote canonical store. This is useful when an environment cannot reach the
+HTTP MCP endpoint but can run the local ContextForge package:
 
 ```bash
 codex mcp add contextforge \

--- a/src/server.js
+++ b/src/server.js
@@ -2,7 +2,9 @@
 import crypto from 'node:crypto';
 import http from 'node:http';
 import { pathToFileURL } from 'node:url';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { createContextForge } from './core.js';
+import { createContextForgeMcpServer } from './mcp.js';
 import { REMOTE_METHODS } from './remote/client.js';
 
 const METHOD_SET = new Set(REMOTE_METHODS);
@@ -106,6 +108,37 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
 
     if (request.method === 'GET' && requestUrl.pathname === '/healthz') {
       sendJson(response, 200, { ok: true });
+      return;
+    }
+
+    if (requestUrl.pathname === '/mcp') {
+      if (!isAuthorized(request, authToken)) {
+        sendJson(response, 401, { error: { message: 'Unauthorized.' } });
+        return;
+      }
+      const mcpServer = createContextForgeMcpServer({ app: serverApp });
+      try {
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined,
+        });
+        await mcpServer.connect(transport);
+        await transport.handleRequest(request, response);
+        response.on('close', () => {
+          transport.close();
+          mcpServer.close();
+        });
+      } catch (error) {
+        if (!response.headersSent) {
+          sendJson(response, 500, {
+            jsonrpc: '2.0',
+            error: {
+              code: -32603,
+              message: error.message,
+            },
+            id: null,
+          });
+        }
+      }
       return;
     }
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -7,6 +7,7 @@ import { promisify } from 'node:util';
 import test from 'node:test';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { createContextForge } from '../src/core.js';
 import { validateDistillOutput } from '../src/distill/validate.js';
 import { searchMemories } from '../src/retrieval/search.js';
@@ -1264,6 +1265,75 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     assert.equal(promotedResult.structuredContent.result.key, 'promoted-mcp-rule');
   } finally {
     await client.close();
+  }
+});
+
+test('MCP streamable HTTP endpoint exposes core tools with bearer auth', async () => {
+  const dataDir = await makeTempDir();
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+    },
+  });
+  const client = new Client({ name: 'contextforge-http-test-client', version: '0.0.0' }, { capabilities: {} });
+  const transport = new StreamableHTTPClientTransport(new URL(`${remote.url}/mcp`), {
+    requestInit: {
+      headers: {
+        authorization: 'Bearer test-token',
+      },
+    },
+  });
+
+  try {
+    await client.connect(transport);
+    const toolList = await client.listTools();
+    assert.ok(toolList.tools.some((tool) => tool.name === 'remember'));
+
+    const remembered = await client.callTool({
+      name: 'remember',
+      arguments: {
+        scope: 'repo',
+        scopeKey: 'http-mcp-repo',
+        key: 'http-mcp-rule',
+        content: 'HTTP MCP should share canonical remote memory.',
+      },
+    });
+    assert.equal(remembered.structuredContent.result.scopeKey, 'http-mcp-repo');
+
+    const searched = await client.callTool({
+      name: 'search',
+      arguments: {
+        scope: 'repo',
+        scopeKey: 'http-mcp-repo',
+        query: 'canonical remote',
+      },
+    });
+    assert.equal(searched.structuredContent.result[0].memory.key, 'http-mcp-rule');
+  } finally {
+    await client.close();
+    await remote.close();
+  }
+});
+
+test('MCP streamable HTTP endpoint rejects missing bearer auth', async () => {
+  const dataDir = await makeTempDir();
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+    },
+  });
+  const client = new Client({ name: 'contextforge-http-unauthorized-client', version: '0.0.0' }, { capabilities: {} });
+  const transport = new StreamableHTTPClientTransport(new URL(`${remote.url}/mcp`));
+
+  try {
+    await assert.rejects(() => client.connect(transport), /Unauthorized|Streamable HTTP error|401/);
+  } finally {
+    await client.close().catch(() => {});
+    await remote.close();
   }
 });
 


### PR DESCRIPTION
## Summary
- add a Streamable HTTP MCP endpoint at /mcp on the remote server
- reuse the existing remote bearer token and server-side store for HTTP MCP calls
- document HTTP MCP as the canonical multi-environment setup while keeping stdio for local/development use

## Tests
- npm test
- git diff --check
- npm pack --dry-run
- npm audit --audit-level=moderate