### PR TITLE
Add Codex rollout ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added `ingestCodexRollout`, which ingests Codex TUI rollout JSONL artifacts
+  into raw evidence without spending model tokens on capture, deduplicates
+  records, and can optionally trigger checkpoint distillation.
 - The remote server now exposes a Streamable HTTP MCP endpoint at `/mcp`, so
   agents on multiple machines can connect directly to the same canonical memory
   store without launching a local stdio MCP bridge.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,27 @@ events are captured when callers use `appendRaw`, and checkpoints are produced
 only when a caller invokes `distillCheckpoint` or the MCP `distill_checkpoint`
 tool. This keeps cost and model usage explicit.
 
+Codex TUI sessions can also be ingested from their rollout JSONL artifacts
+without routing raw transcript text through the model. This keeps raw capture
+out of the token path:
+
+```bash
+CONTEXTFORGE_STORAGE_MODE=remote \
+CONTEXTFORGE_REMOTE_URL=https://memory.example.com \
+CONTEXTFORGE_REMOTE_TOKEN=change-me \
+node src/cli.js ingestCodexRollout \
+  --file ~/.codex/sessions/2026/04/25/rollout-example.jsonl \
+  --scope repo \
+  --repoPath /path/to/repo \
+  --distill auto
+```
+
+`ingestCodexRollout` captures user, assistant, tool-call, and tool-result
+records, skips developer/system instructions, deduplicates previously ingested
+records by stable ingest ids, then checks `sessionStatus`. Use `--distill never`
+to capture only, `--distill auto` to distill when thresholds recommend it, or
+`--distill always` to force a checkpoint after ingest.
+
 Agents can call `sessionStatus` or the MCP `session_status` tool to inspect
 whether a session has enough new raw evidence to justify a checkpoint. The
 status response includes raw event counts, raw character counts, the latest

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { createContextForge } from './core.js';
+import { ingestCodexRolloutFile } from './ingest/codex.js';
 import { startContextForgeServer } from './server.js';
 
 function parseArgs(argv) {
@@ -77,6 +78,9 @@ function toCoreOptions(options) {
     minEvents: options.minEvents == null ? undefined : Number(options.minEvents),
     minIntervalMs: options.minIntervalMs == null ? undefined : Number(options.minIntervalMs),
     charThreshold: options.charThreshold == null ? undefined : Number(options.charThreshold),
+    file: options.file,
+    distill: options.distill,
+    maxContentChars: options.maxContentChars == null ? undefined : Number(options.maxContentChars),
   };
 }
 
@@ -100,8 +104,10 @@ async function main() {
     search: (app, coreOptions) => app.search(coreOptions),
     getMemory: (app, coreOptions) => app.getMemory(coreOptions),
     appendRaw: (app, coreOptions) => app.appendRaw(coreOptions),
+    listRawEvents: (app, coreOptions) => app.listRawEvents(coreOptions),
     distillCheckpoint: (app, coreOptions) => app.distillCheckpoint(coreOptions),
     listDistillRuns: (app, coreOptions) => app.listDistillRuns(coreOptions),
+    ingestCodexRollout: (app, coreOptions) => ingestCodexRolloutFile(app, coreOptions),
   };
 
   if (!command || command === 'help' || command === '--help') {

--- a/src/core.js
+++ b/src/core.js
@@ -336,6 +336,12 @@ export function createContextForge(options = {}) {
       );
     },
 
+    listRawEvents(options) {
+      const scope = normalizeScopeOptions(options, config);
+      requireOption(options.sessionId, 'sessionId');
+      return useStore((store) => store.listRawEvents({ ...scope, sessionId: options.sessionId }));
+    },
+
     async distillCheckpoint(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.sessionId, 'sessionId');

--- a/src/ingest/codex.js
+++ b/src/ingest/codex.js
@@ -1,0 +1,194 @@
+import fs from 'node:fs/promises';
+
+const DEFAULT_MAX_CONTENT_CHARS = 8000;
+
+function truncate(value, maxChars = DEFAULT_MAX_CONTENT_CHARS) {
+  const text = String(value || '');
+  if (text.length <= maxChars) {
+    return { text, truncated: false };
+  }
+  return { text: `${text.slice(0, maxChars)}\n[truncated]`, truncated: true };
+}
+
+function textFromContent(content) {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return '';
+  }
+  return content
+    .map((item) => {
+      if (!item || typeof item !== 'object') return '';
+      return item.text || item.input_text || item.output_text || '';
+    })
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function normalizeFunctionCall(payload) {
+  const name = payload.name || payload.call?.name || 'tool_call';
+  const args = payload.arguments || payload.call?.arguments || {};
+  return {
+    role: 'tool_call',
+    content: JSON.stringify({ name, arguments: args }, null, 2),
+  };
+}
+
+function normalizeFunctionOutput(payload) {
+  return {
+    role: 'tool_result',
+    content: payload.output || payload.result || '',
+  };
+}
+
+export function normalizeCodexRolloutRecord(record, context, options = {}) {
+  if (record.type === 'session_meta') {
+    context.sessionId = context.sessionId || record.payload?.id;
+    context.conversationId = context.conversationId || record.payload?.id;
+    context.cwd = context.cwd || record.payload?.cwd || null;
+    return null;
+  }
+
+  if (record.type !== 'response_item') {
+    return null;
+  }
+
+  const payload = record.payload || {};
+  let normalized = null;
+  if (payload.type === 'message' && (payload.role === 'user' || payload.role === 'assistant')) {
+    normalized = {
+      role: payload.role,
+      content: textFromContent(payload.content),
+    };
+  } else if (payload.type === 'function_call') {
+    normalized = normalizeFunctionCall(payload);
+  } else if (payload.type === 'function_call_output') {
+    normalized = normalizeFunctionOutput(payload);
+  }
+
+  if (!normalized?.content) {
+    return null;
+  }
+
+  const content = truncate(normalized.content, options.maxContentChars);
+  return {
+    role: normalized.role,
+    content: content.text,
+    metadata: {
+      source: 'codex_rollout_jsonl',
+      ingestId: `codex-rollout:${context.sessionId || 'unknown'}:${context.lineNumber}`,
+      recordType: record.type,
+      payloadType: payload.type || null,
+      codexRole: payload.role || null,
+      rolloutTimestamp: record.timestamp || null,
+      truncated: content.truncated,
+      sourceFile: context.filePath || null,
+    },
+  };
+}
+
+export async function parseCodexRolloutFile(filePath, options = {}) {
+  const text = await fs.readFile(filePath, 'utf8');
+  const context = {
+    filePath,
+    sessionId: options.sessionId || null,
+    conversationId: options.conversationId || null,
+    cwd: null,
+    lineNumber: 0,
+  };
+  const events = [];
+
+  for (const line of text.split(/\r?\n/)) {
+    context.lineNumber += 1;
+    if (!line.trim()) continue;
+    const record = JSON.parse(line);
+    const event = normalizeCodexRolloutRecord(record, context, options);
+    if (event) {
+      events.push(event);
+    }
+  }
+
+  return {
+    sessionId: options.sessionId || context.sessionId,
+    conversationId: options.conversationId || context.conversationId || context.sessionId,
+    cwd: context.cwd,
+    events,
+  };
+}
+
+async function appendNewEvents(app, scopeOptions, parsed) {
+  const existing = await app.listRawEvents({
+    ...scopeOptions,
+    sessionId: parsed.sessionId,
+  });
+  const existingIds = new Set(existing.map((event) => event.metadata?.ingestId).filter(Boolean));
+  const appended = [];
+  let skipped = 0;
+
+  for (const event of parsed.events) {
+    if (existingIds.has(event.metadata.ingestId)) {
+      skipped += 1;
+      continue;
+    }
+    appended.push(
+      await app.appendRaw({
+        ...scopeOptions,
+        sessionId: parsed.sessionId,
+        conversationId: parsed.conversationId,
+        role: event.role,
+        content: event.content,
+        metadata: event.metadata,
+      }),
+    );
+  }
+
+  return { appended, skipped };
+}
+
+export async function ingestCodexRolloutFile(app, options = {}) {
+  if (!options.file) {
+    throw new Error('file is required.');
+  }
+  const parsed = await parseCodexRolloutFile(options.file, options);
+  if (!parsed.sessionId) {
+    throw new Error('Codex rollout session id could not be determined.');
+  }
+  const scopeOptions = {
+    scope: options.scope,
+    scopeKey: options.scopeKey,
+    cwd: options.cwd || parsed.cwd,
+    repoPath: options.repoPath,
+  };
+  const { appended, skipped } = await appendNewEvents(app, scopeOptions, parsed);
+  const statusOptions = {
+    ...scopeOptions,
+    sessionId: parsed.sessionId,
+    minEvents: options.minEvents,
+    minIntervalMs: options.minIntervalMs,
+    charThreshold: options.charThreshold,
+  };
+  const status = await app.sessionStatus(statusOptions);
+  let checkpoint = null;
+  const distill = options.distill || 'never';
+  if (distill === 'always' || (distill === 'auto' && status.shouldDistill)) {
+    checkpoint = await app.distillCheckpoint({
+      ...scopeOptions,
+      sessionId: parsed.sessionId,
+      conversationId: parsed.conversationId,
+      provider: options.provider,
+    });
+  }
+
+  return {
+    source: 'codex_rollout_jsonl',
+    file: options.file,
+    sessionId: parsed.sessionId,
+    conversationId: parsed.conversationId,
+    parsedEvents: parsed.events.length,
+    appendedEvents: appended.length,
+    skippedEvents: skipped,
+    status,
+    checkpoint,
+  };
+}

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -14,6 +14,7 @@ const REMOTE_METHODS = [
   'getMemory',
   'search',
   'appendRaw',
+  'listRawEvents',
   'distillCheckpoint',
   'listDistillRuns',
 ];

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -27,6 +27,64 @@ async function makeGitRepo(remoteUrl = 'git@github.com:example/contextforge.git'
   return cwd;
 }
 
+async function writeSyntheticCodexRollout(filePath, sessionId = 'codex-rollout-session') {
+  const records = [
+    {
+      timestamp: '2026-04-25T00:00:00.000Z',
+      type: 'session_meta',
+      payload: {
+        id: sessionId,
+        cwd: path.dirname(filePath),
+      },
+    },
+    {
+      timestamp: '2026-04-25T00:00:01.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'developer',
+        content: [{ type: 'input_text', text: 'Developer instructions should not be captured.' }],
+      },
+    },
+    {
+      timestamp: '2026-04-25T00:00:02.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Please continue the ContextForge ingest work.' }],
+      },
+    },
+    {
+      timestamp: '2026-04-25T00:00:03.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        name: 'exec_command',
+        arguments: '{"cmd":"npm test"}',
+      },
+    },
+    {
+      timestamp: '2026-04-25T00:00:04.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call_output',
+        output: 'tests passed',
+      },
+    },
+    {
+      timestamp: '2026-04-25T00:00:05.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'I added Codex rollout ingestion.' }],
+      },
+    },
+  ];
+  await fs.writeFile(filePath, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`);
+}
+
 test('dbInfo initializes a fresh SQLite store', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
@@ -415,6 +473,172 @@ test('CLI reports invalid metadata JSON clearly', async () => {
       ),
     /Invalid --metadata JSON/,
   );
+});
+
+test('CLI ingests Codex rollout JSONL idempotently without capturing developer messages', async () => {
+  const dataDir = await makeTempDir();
+  const rolloutDir = await makeTempDir();
+  const file = path.join(rolloutDir, 'rollout.jsonl');
+  await writeSyntheticCodexRollout(file, 'codex-ingest-session');
+  const env = {
+    ...process.env,
+    CONTEXTFORGE_DATA_DIR: dataDir,
+    CONTEXTFORGE_DEFAULT_SCOPE_KEY: 'codex-ingest-repo',
+  };
+
+  const first = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'ingestCodexRollout',
+      '--file',
+      file,
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'codex-ingest-repo',
+      '--distill',
+      'never',
+    ],
+    { env },
+  );
+  const firstResult = JSON.parse(first.stdout);
+  assert.equal(firstResult.parsedEvents, 4);
+  assert.equal(firstResult.appendedEvents, 4);
+  assert.equal(firstResult.skippedEvents, 0);
+  assert.equal(firstResult.status.rawEventCount, 4);
+
+  const second = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'ingestCodexRollout',
+      '--file',
+      file,
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'codex-ingest-repo',
+      '--distill',
+      'never',
+    ],
+    { env },
+  );
+  const secondResult = JSON.parse(second.stdout);
+  assert.equal(secondResult.appendedEvents, 0);
+  assert.equal(secondResult.skippedEvents, 4);
+  assert.equal(secondResult.status.rawEventCount, 4);
+
+  const rawEvents = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'listRawEvents',
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'codex-ingest-repo',
+      '--sessionId',
+      'codex-ingest-session',
+    ],
+    { env },
+  );
+  const events = JSON.parse(rawEvents.stdout);
+  assert.deepEqual(
+    events.map((event) => event.role),
+    ['user', 'tool_call', 'tool_result', 'assistant'],
+  );
+  assert.equal(events.some((event) => event.content.includes('Developer instructions')), false);
+  assert.ok(events.every((event) => event.metadata.ingestId));
+});
+
+test('CLI ingest can auto-distill Codex rollout evidence', async () => {
+  const dataDir = await makeTempDir();
+  const rolloutDir = await makeTempDir();
+  const file = path.join(rolloutDir, 'rollout.jsonl');
+  await writeSyntheticCodexRollout(file, 'codex-auto-distill-session');
+  const env = {
+    ...process.env,
+    CONTEXTFORGE_DATA_DIR: dataDir,
+    CONTEXTFORGE_DEFAULT_SCOPE_KEY: 'codex-auto-distill-repo',
+    CONTEXTFORGE_DISTILL_PROVIDER: 'mock',
+  };
+
+  const ingested = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'ingestCodexRollout',
+      '--file',
+      file,
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'codex-auto-distill-repo',
+      '--distill',
+      'auto',
+      '--charThreshold',
+      '1',
+    ],
+    { env },
+  );
+  const result = JSON.parse(ingested.stdout);
+  assert.equal(result.appendedEvents, 4);
+  assert.equal(result.status.shouldDistill, true);
+  assert.equal(result.checkpoint.sessionId, 'codex-auto-distill-session');
+  assert.equal(result.checkpoint.provider, 'mock');
+});
+
+test('CLI ingest works through remote storage mode', async () => {
+  const dataDir = await makeTempDir();
+  const rolloutDir = await makeTempDir();
+  const file = path.join(rolloutDir, 'rollout.jsonl');
+  await writeSyntheticCodexRollout(file, 'codex-remote-ingest-session');
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+    },
+  });
+
+  try {
+    const env = {
+      ...process.env,
+      CONTEXTFORGE_STORAGE_MODE: 'remote',
+      CONTEXTFORGE_REMOTE_URL: remote.url,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+    };
+    const ingested = await execFileAsync(
+      'node',
+      [
+        'src/cli.js',
+        'ingestCodexRollout',
+        '--file',
+        file,
+        '--scope',
+        'repo',
+        '--scopeKey',
+        'codex-remote-ingest-repo',
+        '--distill',
+        'never',
+      ],
+      { env },
+    );
+    const result = JSON.parse(ingested.stdout);
+    assert.equal(result.appendedEvents, 4);
+    assert.equal(result.status.rawEventCount, 4);
+
+    const app = createContextForge({ env, cwd: process.cwd() });
+    const rawEvents = await app.listRawEvents({
+      scope: 'repo',
+      scopeKey: 'codex-remote-ingest-repo',
+      sessionId: 'codex-remote-ingest-session',
+    });
+    assert.equal(rawEvents.length, 4);
+  } finally {
+    await remote.close();
+  }
 });
 
 test('search can combine repo and shared scopes while excluding local by default', async () => {


### PR DESCRIPTION
## Summary
- closes #36 by adding ingestCodexRollout for Codex TUI rollout JSONL artifacts
- captures user/assistant/tool-call/tool-result records outside the model token path while skipping developer/system instructions
- deduplicates by stable ingest ids, supports local and remote targets, and can trigger distillation with never/auto/always
- exposes listRawEvents for ingestion idempotency and diagnostics

## Tests
- npm test
- git diff --check
- npm pack --dry-run
- npm audit --audit-level=moderate
- live parser smoke against a real Codex rollout file using a temporary local data dir