### PR TITLE
Support multi-session Codex ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added `ingestCodexRollout`, which ingests Codex TUI rollout JSONL artifacts
   into raw evidence without spending model tokens on capture, deduplicates
   records, and can optionally trigger checkpoint distillation.
+- Added `ingestCodexSessions` for repeated multi-session scans of Codex rollout
+  directories, including safe handling for actively-written trailing lines.
 - The remote server now exposes a Streamable HTTP MCP endpoint at `/mcp`, so
   agents on multiple machines can connect directly to the same canonical memory
   store without launching a local stdio MCP bridge.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,26 @@ records by stable ingest ids, then checks `sessionStatus`. Use `--distill never`
 to capture only, `--distill auto` to distill when thresholds recommend it, or
 `--distill always` to force a checkpoint after ingest.
 
+For local machines with several active or recent Codex TUI sessions, scan the
+sessions tree instead of naming one file:
+
+```bash
+CONTEXTFORGE_STORAGE_MODE=remote \
+CONTEXTFORGE_REMOTE_URL=https://memory.example.com \
+CONTEXTFORGE_REMOTE_TOKEN=change-me \
+node src/cli.js ingestCodexSessions \
+  --sessionsDir ~/.codex/sessions \
+  --scope repo \
+  --repoPath /path/to/repo \
+  --sinceMinutes 1440 \
+  --distill auto
+```
+
+The sessions scan is safe to run repeatedly. It keeps rollout files isolated by
+their Codex session id, skips already-ingested records, and ignores a trailing
+partial JSON line from an actively-written rollout file so the next scan can
+pick it up when complete.
+
 Agents can call `sessionStatus` or the MCP `session_status` tool to inspect
 whether a session has enough new raw evidence to justify a checkpoint. The
 status response includes raw event counts, raw character counts, the latest

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { createContextForge } from './core.js';
-import { ingestCodexRolloutFile } from './ingest/codex.js';
+import { ingestCodexRolloutFile, ingestCodexSessions } from './ingest/codex.js';
 import { startContextForgeServer } from './server.js';
 
 function parseArgs(argv) {
@@ -79,8 +79,11 @@ function toCoreOptions(options) {
     minIntervalMs: options.minIntervalMs == null ? undefined : Number(options.minIntervalMs),
     charThreshold: options.charThreshold == null ? undefined : Number(options.charThreshold),
     file: options.file,
+    sessionsDir: options.sessionsDir,
     distill: options.distill,
     maxContentChars: options.maxContentChars == null ? undefined : Number(options.maxContentChars),
+    sinceMinutes: options.sinceMinutes == null ? undefined : Number(options.sinceMinutes),
+    scanLimit: options.scanLimit == null ? undefined : Number(options.scanLimit),
   };
 }
 
@@ -108,6 +111,7 @@ async function main() {
     distillCheckpoint: (app, coreOptions) => app.distillCheckpoint(coreOptions),
     listDistillRuns: (app, coreOptions) => app.listDistillRuns(coreOptions),
     ingestCodexRollout: (app, coreOptions) => ingestCodexRolloutFile(app, coreOptions),
+    ingestCodexSessions: (app, coreOptions) => ingestCodexSessions(app, coreOptions),
   };
 
   if (!command || command === 'help' || command === '--help') {

--- a/src/ingest/codex.js
+++ b/src/ingest/codex.js
@@ -1,4 +1,6 @@
 import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 const DEFAULT_MAX_CONTENT_CHARS = 8000;
 
@@ -98,11 +100,27 @@ export async function parseCodexRolloutFile(filePath, options = {}) {
     lineNumber: 0,
   };
   const events = [];
+  const warnings = [];
+  const lines = text.split(/\r?\n/);
 
-  for (const line of text.split(/\r?\n/)) {
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
     context.lineNumber += 1;
     if (!line.trim()) continue;
-    const record = JSON.parse(line);
+    let record;
+    try {
+      record = JSON.parse(line);
+    } catch (error) {
+      if (index === lines.length - 1 || index === lines.length - 2) {
+        warnings.push({
+          type: 'partial_json_line',
+          lineNumber: context.lineNumber,
+          message: error.message,
+        });
+        continue;
+      }
+      throw error;
+    }
     const event = normalizeCodexRolloutRecord(record, context, options);
     if (event) {
       events.push(event);
@@ -114,6 +132,7 @@ export async function parseCodexRolloutFile(filePath, options = {}) {
     conversationId: options.conversationId || context.conversationId || context.sessionId,
     cwd: context.cwd,
     events,
+    warnings,
   };
 }
 
@@ -188,7 +207,72 @@ export async function ingestCodexRolloutFile(app, options = {}) {
     parsedEvents: parsed.events.length,
     appendedEvents: appended.length,
     skippedEvents: skipped,
+    warnings: parsed.warnings,
     status,
     checkpoint,
+  };
+}
+
+async function walkFiles(rootDir) {
+  let entries;
+  try {
+    entries = await fs.readdir(rootDir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+  const files = [];
+  for (const entry of entries) {
+    const entryPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walkFiles(entryPath)));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+function defaultSessionsDir() {
+  return path.join(os.homedir(), '.codex', 'sessions');
+}
+
+export async function discoverCodexRolloutFiles(options = {}) {
+  const sessionsDir = path.resolve(options.sessionsDir || defaultSessionsDir());
+  const files = (await walkFiles(sessionsDir)).filter(
+    (file) => path.basename(file).startsWith('rollout-') && file.endsWith('.jsonl'),
+  );
+  const stats = await Promise.all(
+    files.map(async (file) => ({
+      file,
+      stat: await fs.stat(file),
+    })),
+  );
+  const sinceMs = options.sinceMinutes == null ? null : Date.now() - Number(options.sinceMinutes) * 60 * 1000;
+  return stats
+    .filter((item) => sinceMs == null || item.stat.mtimeMs >= sinceMs)
+    .sort((a, b) => a.stat.mtimeMs - b.stat.mtimeMs || a.file.localeCompare(b.file))
+    .slice(0, options.scanLimit == null ? undefined : Number(options.scanLimit))
+    .map((item) => item.file);
+}
+
+export async function ingestCodexSessions(app, options = {}) {
+  const files = options.file ? [options.file] : await discoverCodexRolloutFiles(options);
+  const results = [];
+  for (const file of files) {
+    results.push(await ingestCodexRolloutFile(app, { ...options, file }));
+  }
+
+  return {
+    source: 'codex_sessions',
+    sessionsDir: path.resolve(options.sessionsDir || defaultSessionsDir()),
+    filesScanned: files.length,
+    parsedEvents: results.reduce((total, result) => total + result.parsedEvents, 0),
+    appendedEvents: results.reduce((total, result) => total + result.appendedEvents, 0),
+    skippedEvents: results.reduce((total, result) => total + result.skippedEvents, 0),
+    checkpointsCreated: results.filter((result) => result.checkpoint).length,
+    fileResults: results,
   };
 }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -85,6 +85,16 @@ async function writeSyntheticCodexRollout(filePath, sessionId = 'codex-rollout-s
   await fs.writeFile(filePath, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`);
 }
 
+async function writeSyntheticSessionsTree(rootDir) {
+  const first = path.join(rootDir, '2026', '04', '25', 'rollout-first.jsonl');
+  const second = path.join(rootDir, '2026', '04', '25', 'rollout-second.jsonl');
+  await fs.mkdir(path.dirname(first), { recursive: true });
+  await writeSyntheticCodexRollout(first, 'codex-session-first');
+  await writeSyntheticCodexRollout(second, 'codex-session-second');
+  await fs.appendFile(second, '{"timestamp":"2026-04-25T00:00:06.000Z","type":"response_item"');
+  return { first, second };
+}
+
 test('dbInfo initializes a fresh SQLite store', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
@@ -639,6 +649,115 @@ test('CLI ingest works through remote storage mode', async () => {
   } finally {
     await remote.close();
   }
+});
+
+test('CLI ingests multiple Codex session rollout files safely', async () => {
+  const dataDir = await makeTempDir();
+  const sessionsDir = await makeTempDir();
+  await writeSyntheticSessionsTree(sessionsDir);
+  const env = {
+    ...process.env,
+    CONTEXTFORGE_DATA_DIR: dataDir,
+  };
+
+  const first = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'ingestCodexSessions',
+      '--sessionsDir',
+      sessionsDir,
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'codex-multi-session-repo',
+      '--distill',
+      'never',
+    ],
+    { env },
+  );
+  const firstResult = JSON.parse(first.stdout);
+  assert.equal(firstResult.filesScanned, 2);
+  assert.equal(firstResult.parsedEvents, 8);
+  assert.equal(firstResult.appendedEvents, 8);
+  assert.equal(firstResult.skippedEvents, 0);
+  assert.deepEqual(
+    firstResult.fileResults.map((result) => result.sessionId).sort(),
+    ['codex-session-first', 'codex-session-second'],
+  );
+  assert.equal(firstResult.fileResults.some((result) => result.warnings.length > 0), true);
+
+  const second = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'ingestCodexSessions',
+      '--sessionsDir',
+      sessionsDir,
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'codex-multi-session-repo',
+      '--distill',
+      'never',
+    ],
+    { env },
+  );
+  const secondResult = JSON.parse(second.stdout);
+  assert.equal(secondResult.filesScanned, 2);
+  assert.equal(secondResult.appendedEvents, 0);
+  assert.equal(secondResult.skippedEvents, 8);
+
+  const app = createContextForge({ env, cwd: process.cwd() });
+  const firstEvents = app.listRawEvents({
+    scope: 'repo',
+    scopeKey: 'codex-multi-session-repo',
+    sessionId: 'codex-session-first',
+  });
+  const secondEvents = app.listRawEvents({
+    scope: 'repo',
+    scopeKey: 'codex-multi-session-repo',
+    sessionId: 'codex-session-second',
+  });
+  assert.equal(firstEvents.length, 4);
+  assert.equal(secondEvents.length, 4);
+});
+
+test('CLI Codex sessions scan is not capped by search limit defaults', async () => {
+  const dataDir = await makeTempDir();
+  const sessionsDir = await makeTempDir();
+  const rolloutDir = path.join(sessionsDir, '2026', '04', '25');
+  await fs.mkdir(rolloutDir, { recursive: true });
+  for (let index = 0; index < 11; index += 1) {
+    await writeSyntheticCodexRollout(
+      path.join(rolloutDir, `rollout-${String(index).padStart(2, '0')}.jsonl`),
+      `codex-session-${index}`,
+    );
+  }
+  const env = {
+    ...process.env,
+    CONTEXTFORGE_DATA_DIR: dataDir,
+  };
+
+  const result = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'ingestCodexSessions',
+      '--sessionsDir',
+      sessionsDir,
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'codex-uncapped-session-repo',
+      '--distill',
+      'never',
+    ],
+    { env },
+  );
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.filesScanned, 11);
+  assert.equal(parsed.appendedEvents, 44);
 });
 
 test('search can combine repo and shared scopes while excluding local by default', async () => {


### PR DESCRIPTION
## Summary
- closes #38 by adding ingestCodexSessions to scan Codex sessions directories for multiple rollout JSONL files
- keeps each rollout isolated by Codex session id while reusing the existing idempotent ingest ids
- tolerates an actively-written trailing partial JSON line so repeated scans can pick it up later
- adds scan controls for sessionsDir, sinceMinutes, and scanLimit without leaking search limit defaults into ingestion

## Tests
- npm test
- git diff --check
- npm pack --dry-run
- npm audit --audit-level=moderate
- local smoke against ~/.codex/sessions with a temporary data dir