### PR TITLE
Add Codex sessions ingest watch loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   records, and can optionally trigger checkpoint distillation.
 - Added `ingestCodexSessions` for repeated multi-session scans of Codex rollout
   directories, including safe handling for actively-written trailing lines.
+- Added `ingestCodexSessions --watch` for long-running local TUI capture loops
+  with per-iteration JSON logs and bounded `--iterations` smoke checks.
 - The remote server now exposes a Streamable HTTP MCP endpoint at `/mcp`, so
   agents on multiple machines can connect directly to the same canonical memory
   store without launching a local stdio MCP bridge.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,29 @@ their Codex session id, skips already-ingested records, and ignores a trailing
 partial JSON line from an actively-written rollout file so the next scan can
 pick it up when complete.
 
+For local TUI use, the same command can stay resident and poll for new rollout
+events:
+
+```bash
+CONTEXTFORGE_STORAGE_MODE=remote \
+CONTEXTFORGE_REMOTE_URL=https://memory.example.com \
+CONTEXTFORGE_REMOTE_TOKEN=change-me \
+node src/cli.js ingestCodexSessions \
+  --sessionsDir ~/.codex/sessions \
+  --scope repo \
+  --repoPath /path/to/repo \
+  --sinceMinutes 1440 \
+  --distill auto \
+  --watch \
+  --intervalMs 30000
+```
+
+Watch mode emits one compact JSON object per scan iteration plus a final
+summary when it stops. Use `--iterations N` for bounded smoke checks or tests.
+Repeated watch scans do not spend model tokens while capturing raw evidence;
+model usage happens only when `--distill auto` decides to checkpoint or
+`--distill always` is set.
+
 Agents can call `sessionStatus` or the MCP `session_status` tool to inspect
 whether a session has enough new raw evidence to justify a checkpoint. The
 status response includes raw event counts, raw character counts, the latest

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { createContextForge } from './core.js';
-import { ingestCodexRolloutFile, ingestCodexSessions } from './ingest/codex.js';
+import { ingestCodexRolloutFile, ingestCodexSessions, watchCodexSessions } from './ingest/codex.js';
 import { startContextForgeServer } from './server.js';
 
 function parseArgs(argv) {
@@ -84,6 +84,9 @@ function toCoreOptions(options) {
     maxContentChars: options.maxContentChars == null ? undefined : Number(options.maxContentChars),
     sinceMinutes: options.sinceMinutes == null ? undefined : Number(options.sinceMinutes),
     scanLimit: options.scanLimit == null ? undefined : Number(options.scanLimit),
+    watch: options.watch === true || options.watch === 'true',
+    intervalMs: options.intervalMs == null ? undefined : Number(options.intervalMs),
+    iterations: options.iterations == null ? undefined : Number(options.iterations),
   };
 }
 
@@ -111,7 +114,15 @@ async function main() {
     distillCheckpoint: (app, coreOptions) => app.distillCheckpoint(coreOptions),
     listDistillRuns: (app, coreOptions) => app.listDistillRuns(coreOptions),
     ingestCodexRollout: (app, coreOptions) => ingestCodexRolloutFile(app, coreOptions),
-    ingestCodexSessions: (app, coreOptions) => ingestCodexSessions(app, coreOptions),
+    ingestCodexSessions: (app, coreOptions) =>
+      coreOptions.watch
+        ? watchCodexSessions(app, {
+            ...coreOptions,
+            onResult: (result) => {
+              console.log(JSON.stringify(result));
+            },
+          })
+        : ingestCodexSessions(app, coreOptions),
   };
 
   if (!command || command === 'help' || command === '--help') {

--- a/src/ingest/codex.js
+++ b/src/ingest/codex.js
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 const DEFAULT_MAX_CONTENT_CHARS = 8000;
+const DEFAULT_WATCH_INTERVAL_MS = 30000;
 
 function truncate(value, maxChars = DEFAULT_MAX_CONTENT_CHARS) {
   const text = String(value || '');
@@ -274,5 +275,74 @@ export async function ingestCodexSessions(app, options = {}) {
     skippedEvents: results.reduce((total, result) => total + result.skippedEvents, 0),
     checkpointsCreated: results.filter((result) => result.checkpoint).length,
     fileResults: results,
+  };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function summarizeWatchResults(results) {
+  return {
+    filesScanned: results.reduce((total, result) => total + result.filesScanned, 0),
+    parsedEvents: results.reduce((total, result) => total + result.parsedEvents, 0),
+    appendedEvents: results.reduce((total, result) => total + result.appendedEvents, 0),
+    skippedEvents: results.reduce((total, result) => total + result.skippedEvents, 0),
+    checkpointsCreated: results.reduce((total, result) => total + result.checkpointsCreated, 0),
+  };
+}
+
+export async function watchCodexSessions(app, options = {}) {
+  const intervalMs =
+    options.intervalMs == null ? DEFAULT_WATCH_INTERVAL_MS : Math.max(0, Number(options.intervalMs));
+  const maxIterations = options.iterations == null ? null : Math.max(0, Number(options.iterations));
+  const startedAt = new Date().toISOString();
+  const results = [];
+  let iterations = 0;
+  let stopped = false;
+
+  const stop = () => {
+    stopped = true;
+  };
+
+  process.once('SIGINT', stop);
+  process.once('SIGTERM', stop);
+
+  try {
+    while (!stopped && (maxIterations == null || iterations < maxIterations)) {
+      iterations += 1;
+      const result = await ingestCodexSessions(app, options);
+      const iterationResult = {
+        ...result,
+        source: 'codex_sessions_watch_iteration',
+        iteration: iterations,
+        intervalMs,
+        watchedAt: new Date().toISOString(),
+      };
+      results.push(iterationResult);
+      if (options.onResult) {
+        await options.onResult(iterationResult);
+      }
+      if (!stopped && (maxIterations == null || iterations < maxIterations)) {
+        await sleep(intervalMs);
+      }
+    }
+  } finally {
+    process.removeListener('SIGINT', stop);
+    process.removeListener('SIGTERM', stop);
+  }
+
+  return {
+    source: 'codex_sessions_watch',
+    sessionsDir: path.resolve(options.sessionsDir || defaultSessionsDir()),
+    intervalMs,
+    iterations,
+    stopped,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    totals: summarizeWatchResults(results),
+    results,
   };
 }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -10,6 +10,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { createContextForge } from '../src/core.js';
 import { validateDistillOutput } from '../src/distill/validate.js';
+import { watchCodexSessions } from '../src/ingest/codex.js';
 import { searchMemories } from '../src/retrieval/search.js';
 import { startContextForgeServer } from '../src/server.js';
 import { SCHEMA_VERSION } from '../src/storage/sqlite.js';
@@ -83,6 +84,19 @@ async function writeSyntheticCodexRollout(filePath, sessionId = 'codex-rollout-s
     },
   ];
   await fs.writeFile(filePath, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`);
+}
+
+async function appendSyntheticCodexAssistantMessage(filePath, text) {
+  const record = {
+    timestamp: '2026-04-25T00:00:06.000Z',
+    type: 'response_item',
+    payload: {
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'output_text', text }],
+    },
+  };
+  await fs.appendFile(filePath, `${JSON.stringify(record)}\n`);
 }
 
 async function writeSyntheticSessionsTree(rootDir) {
@@ -721,6 +735,49 @@ test('CLI ingests multiple Codex session rollout files safely', async () => {
   });
   assert.equal(firstEvents.length, 4);
   assert.equal(secondEvents.length, 4);
+});
+
+test('Codex sessions watch loop picks up new events without duplicates', async () => {
+  const dataDir = await makeTempDir();
+  const sessionsDir = await makeTempDir();
+  const rolloutDir = path.join(sessionsDir, '2026', '04', '25');
+  const file = path.join(rolloutDir, 'rollout-watch.jsonl');
+  await fs.mkdir(rolloutDir, { recursive: true });
+  await writeSyntheticCodexRollout(file, 'codex-watch-session');
+  const app = createContextForge({
+    env: { CONTEXTFORGE_DATA_DIR: dataDir },
+    cwd: process.cwd(),
+  });
+  const iterationResults = [];
+
+  const result = await watchCodexSessions(app, {
+    sessionsDir,
+    scope: 'repo',
+    scopeKey: 'codex-watch-repo',
+    distill: 'never',
+    iterations: 2,
+    intervalMs: 1,
+    onResult: async (iterationResult) => {
+      iterationResults.push(iterationResult);
+      if (iterationResult.iteration === 1) {
+        await appendSyntheticCodexAssistantMessage(file, 'A new active TUI event arrived.');
+      }
+    },
+  });
+
+  assert.equal(result.iterations, 2);
+  assert.equal(result.totals.appendedEvents, 5);
+  assert.equal(iterationResults[0].appendedEvents, 4);
+  assert.equal(iterationResults[1].appendedEvents, 1);
+  assert.equal(iterationResults[1].skippedEvents, 4);
+
+  const events = app.listRawEvents({
+    scope: 'repo',
+    scopeKey: 'codex-watch-repo',
+    sessionId: 'codex-watch-session',
+  });
+  assert.equal(events.length, 5);
+  assert.equal(events.at(-1).content, 'A new active TUI event arrived.');
 });
 
 test('CLI Codex sessions scan is not capped by search limit defaults', async () => {


### PR DESCRIPTION
Closes #40.

## Summary

- Add watchCodexSessions for long-running repeated Codex TUI session ingestion.
- Wire ingestCodexSessions --watch with interval and bounded iteration options.
- Document watch mode and token behavior for local TUI capture loops.

## Verification

- npm test
- git diff --check
- npm pack --dry-run
- npm audit --audit-level=moderate
- Bounded local CLI smoke with --watch --iterations 1
