### PR TITLE
Standardize Codex ingest provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   directories, including safe handling for actively-written trailing lines.
 - Added `ingestCodexSessions --watch` for long-running local TUI capture loops
   with per-iteration JSON logs and bounded `--iterations` smoke checks.
+- Codex ingest now namespaces session ids as `codex:<native-session-id>` and
+  records standard agent/runtime provenance metadata for future multi-TUI use.
 - The remote server now exposes a Streamable HTTP MCP endpoint at `/mcp`, so
   agents on multiple machines can connect directly to the same canonical memory
   store without launching a local stdio MCP bridge.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,15 @@ records by stable ingest ids, then checks `sessionStatus`. Use `--distill never`
 to capture only, `--distill auto` to distill when thresholds recommend it, or
 `--distill always` to force a checkpoint after ingest.
 
+Codex-ingested raw events use a namespaced session id:
+`codex:<native-codex-session-id>`. Their metadata also includes
+`sourceAgent: "codex"`, `sourceRuntime: "codex_tui"`,
+`sourceAdapter: "codex_rollout_jsonl"`, and `nativeSessionId`. Future TUI
+adapters should use the same provenance pattern, for example
+`claude_code:<native-session-id>` plus a distinct `sourceAgent` and
+`sourceAdapter`. Durable repo memory stays shared across agents; raw evidence
+and checkpoints stay attributable to the originating TUI session.
+
 For local machines with several active or recent Codex TUI sessions, scan the
 sessions tree instead of naming one file:
 

--- a/src/core.js
+++ b/src/core.js
@@ -92,6 +92,22 @@ function buildSessionStatus({ scope, sessionId, rawEvents, latestCheckpoint, pol
   };
 }
 
+function commonMetadataValue(rawEvents, key) {
+  const values = new Set(rawEvents.map((event) => event.metadata?.[key]).filter(Boolean));
+  return values.size === 1 ? [...values][0] : null;
+}
+
+function sourceProvenanceFromEvents(rawEvents) {
+  const provenance = {};
+  for (const key of ['sourceAgent', 'sourceRuntime', 'sourceAdapter', 'nativeSessionId']) {
+    const value = commonMetadataValue(rawEvents, key);
+    if (value) {
+      provenance[key] = value;
+    }
+  }
+  return provenance;
+}
+
 export function createContextForge(options = {}) {
   const config = loadConfig(options);
   if (config.storageMode === 'remote') {
@@ -353,6 +369,7 @@ export function createContextForge(options = {}) {
       return useStore(async (store) => {
         const rawEvents = store.listRawEvents({ ...scope, sessionId: options.sessionId });
         const previousCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId });
+        const sourceProvenance = sourceProvenanceFromEvents(rawEvents);
         const conversationId =
           options.conversationId || rawEvents.find((event) => event.conversationId)?.conversationId || null;
         const requestedOutputSchema = {
@@ -377,6 +394,7 @@ export function createContextForge(options = {}) {
             previousCheckpointId: previousCheckpoint?.id || null,
             requestedOutputSchema,
             providerMetadata,
+            sourceProvenance,
           },
         });
 
@@ -435,6 +453,7 @@ export function createContextForge(options = {}) {
           metadata: {
             providerMetadata: output.metadata,
             memoryCandidates: output.memoryCandidates,
+            sourceProvenance,
           },
         });
 

--- a/src/ingest/codex.js
+++ b/src/ingest/codex.js
@@ -4,6 +4,21 @@ import path from 'node:path';
 
 const DEFAULT_MAX_CONTENT_CHARS = 8000;
 const DEFAULT_WATCH_INTERVAL_MS = 30000;
+const CODEX_AGENT_PROVENANCE = {
+  sourceAgent: 'codex',
+  sourceRuntime: 'codex_tui',
+  sourceAdapter: 'codex_rollout_jsonl',
+};
+
+function stripCodexSessionPrefix(sessionId) {
+  const text = String(sessionId || '');
+  return text.startsWith('codex:') ? text.slice('codex:'.length) : text;
+}
+
+function codexSessionId(nativeSessionId) {
+  const native = stripCodexSessionPrefix(nativeSessionId);
+  return native ? `codex:${native}` : null;
+}
 
 function truncate(value, maxChars = DEFAULT_MAX_CONTENT_CHARS) {
   const text = String(value || '');
@@ -47,8 +62,10 @@ function normalizeFunctionOutput(payload) {
 
 export function normalizeCodexRolloutRecord(record, context, options = {}) {
   if (record.type === 'session_meta') {
-    context.sessionId = context.sessionId || record.payload?.id;
-    context.conversationId = context.conversationId || record.payload?.id;
+    const nativeSessionId = record.payload?.id;
+    context.nativeSessionId = context.nativeSessionId || nativeSessionId;
+    context.sessionId = context.sessionId || codexSessionId(nativeSessionId);
+    context.conversationId = context.conversationId || codexSessionId(nativeSessionId);
     context.cwd = context.cwd || record.payload?.cwd || null;
     return null;
   }
@@ -80,7 +97,11 @@ export function normalizeCodexRolloutRecord(record, context, options = {}) {
     content: content.text,
     metadata: {
       source: 'codex_rollout_jsonl',
-      ingestId: `codex-rollout:${context.sessionId || 'unknown'}:${context.lineNumber}`,
+      ...CODEX_AGENT_PROVENANCE,
+      nativeSessionId: context.nativeSessionId || stripCodexSessionPrefix(context.sessionId) || null,
+      ingestId: `codex-rollout:${context.nativeSessionId || stripCodexSessionPrefix(context.sessionId) || 'unknown'}:${
+        context.lineNumber
+      }`,
       recordType: record.type,
       payloadType: payload.type || null,
       codexRole: payload.role || null,
@@ -93,10 +114,13 @@ export function normalizeCodexRolloutRecord(record, context, options = {}) {
 
 export async function parseCodexRolloutFile(filePath, options = {}) {
   const text = await fs.readFile(filePath, 'utf8');
+  const nativeSessionId = options.sessionId ? stripCodexSessionPrefix(options.sessionId) : null;
+  const sessionId = nativeSessionId ? codexSessionId(nativeSessionId) : null;
   const context = {
     filePath,
-    sessionId: options.sessionId || null,
-    conversationId: options.conversationId || null,
+    nativeSessionId,
+    sessionId,
+    conversationId: options.conversationId ? codexSessionId(options.conversationId) : sessionId,
     cwd: null,
     lineNumber: 0,
   };
@@ -129,8 +153,9 @@ export async function parseCodexRolloutFile(filePath, options = {}) {
   }
 
   return {
-    sessionId: options.sessionId || context.sessionId,
-    conversationId: options.conversationId || context.conversationId || context.sessionId,
+    nativeSessionId: context.nativeSessionId,
+    sessionId: context.sessionId,
+    conversationId: context.conversationId || context.sessionId,
     cwd: context.cwd,
     events,
     warnings,

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -563,7 +563,7 @@ test('CLI ingests Codex rollout JSONL idempotently without capturing developer m
       '--scopeKey',
       'codex-ingest-repo',
       '--sessionId',
-      'codex-ingest-session',
+      'codex:codex-ingest-session',
     ],
     { env },
   );
@@ -574,6 +574,11 @@ test('CLI ingests Codex rollout JSONL idempotently without capturing developer m
   );
   assert.equal(events.some((event) => event.content.includes('Developer instructions')), false);
   assert.ok(events.every((event) => event.metadata.ingestId));
+  assert.ok(events.every((event) => event.metadata.sourceAgent === 'codex'));
+  assert.ok(events.every((event) => event.metadata.sourceRuntime === 'codex_tui'));
+  assert.ok(events.every((event) => event.metadata.sourceAdapter === 'codex_rollout_jsonl'));
+  assert.ok(events.every((event) => event.metadata.nativeSessionId === 'codex-ingest-session'));
+  assert.equal(firstResult.sessionId, 'codex:codex-ingest-session');
 });
 
 test('CLI ingest can auto-distill Codex rollout evidence', async () => {
@@ -609,8 +614,22 @@ test('CLI ingest can auto-distill Codex rollout evidence', async () => {
   const result = JSON.parse(ingested.stdout);
   assert.equal(result.appendedEvents, 4);
   assert.equal(result.status.shouldDistill, true);
-  assert.equal(result.checkpoint.sessionId, 'codex-auto-distill-session');
+  assert.equal(result.checkpoint.sessionId, 'codex:codex-auto-distill-session');
   assert.equal(result.checkpoint.provider, 'mock');
+  assert.deepEqual(result.checkpoint.metadata.sourceProvenance, {
+    sourceAgent: 'codex',
+    sourceRuntime: 'codex_tui',
+    sourceAdapter: 'codex_rollout_jsonl',
+    nativeSessionId: 'codex-auto-distill-session',
+  });
+
+  const app = createContextForge({ env, cwd: process.cwd() });
+  const runs = app.listDistillRuns({
+    scope: 'repo',
+    scopeKey: 'codex-auto-distill-repo',
+    sessionId: 'codex:codex-auto-distill-session',
+  });
+  assert.deepEqual(runs[0].inputMetadata.sourceProvenance, result.checkpoint.metadata.sourceProvenance);
 });
 
 test('CLI ingest works through remote storage mode', async () => {
@@ -657,7 +676,7 @@ test('CLI ingest works through remote storage mode', async () => {
     const rawEvents = await app.listRawEvents({
       scope: 'repo',
       scopeKey: 'codex-remote-ingest-repo',
-      sessionId: 'codex-remote-ingest-session',
+      sessionId: 'codex:codex-remote-ingest-session',
     });
     assert.equal(rawEvents.length, 4);
   } finally {
@@ -697,7 +716,7 @@ test('CLI ingests multiple Codex session rollout files safely', async () => {
   assert.equal(firstResult.skippedEvents, 0);
   assert.deepEqual(
     firstResult.fileResults.map((result) => result.sessionId).sort(),
-    ['codex-session-first', 'codex-session-second'],
+    ['codex:codex-session-first', 'codex:codex-session-second'],
   );
   assert.equal(firstResult.fileResults.some((result) => result.warnings.length > 0), true);
 
@@ -726,12 +745,12 @@ test('CLI ingests multiple Codex session rollout files safely', async () => {
   const firstEvents = app.listRawEvents({
     scope: 'repo',
     scopeKey: 'codex-multi-session-repo',
-    sessionId: 'codex-session-first',
+    sessionId: 'codex:codex-session-first',
   });
   const secondEvents = app.listRawEvents({
     scope: 'repo',
     scopeKey: 'codex-multi-session-repo',
-    sessionId: 'codex-session-second',
+    sessionId: 'codex:codex-session-second',
   });
   assert.equal(firstEvents.length, 4);
   assert.equal(secondEvents.length, 4);
@@ -774,7 +793,7 @@ test('Codex sessions watch loop picks up new events without duplicates', async (
   const events = app.listRawEvents({
     scope: 'repo',
     scopeKey: 'codex-watch-repo',
-    sessionId: 'codex-watch-session',
+    sessionId: 'codex:codex-watch-session',
   });
   assert.equal(events.length, 5);
   assert.equal(events.at(-1).content, 'A new active TUI event arrived.');


### PR DESCRIPTION
Closes #42.

## Summary

- Namespace Codex-ingested sessions as codex:<native-session-id>.
- Add standard sourceAgent/sourceRuntime/sourceAdapter/nativeSessionId metadata to Codex raw events.
- Carry common source provenance into distill run input metadata and checkpoint metadata.
- Document the multi-TUI provenance pattern for future adapters such as Claude Code.

## Verification

- npm test
- git diff --check
- npm pack --dry-run
- npm audit --audit-level=moderate
- Temp DB CLI ingest smoke using ~/.codex/sessions with --scanLimit 1
