### PR TITLE
Complete local TUI operationalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
   with per-iteration JSON logs and bounded `--iterations` smoke checks.
 - Codex ingest now namespaces session ids as `codex:<native-session-id>` and
   records standard agent/runtime provenance metadata for future multi-TUI use.
+- Added Claude Code JSONL ingestion with `claude_code:<native-session-id>`
+  session namespacing and the same raw evidence/checkpoint provenance model.
+- Added `promoteMemoryCandidate` so reviewed checkpoint candidates can be
+  promoted from CLI without copying candidate fields manually.
+- Added a systemd user service installer for long-running Codex watch ingest
+  against a remote ContextForge server.
 - The remote server now exposes a Streamable HTTP MCP endpoint at `/mcp`, so
   agents on multiple machines can connect directly to the same canonical memory
   store without launching a local stdio MCP bridge.

--- a/README.md
+++ b/README.md
@@ -225,6 +225,42 @@ Repeated watch scans do not spend model tokens while capturing raw evidence;
 model usage happens only when `--distill auto` decides to checkpoint or
 `--distill always` is set.
 
+To install that Codex watch loop as a systemd user service:
+
+```bash
+CONTEXTFORGE_REMOTE_URL=https://memory.example.com \
+scripts/install-codex-watch-service.sh \
+  --name contextforge \
+  --repo-path /path/to/repo \
+  --token-env-file ~/.config/contextforge/server.env \
+  --distill auto
+```
+
+The token env file should define `CONTEXTFORGE_REMOTE_TOKEN`. The installer
+creates and starts a `contextforge-codex-watch-<name>.service` user unit. Use
+`systemctl --user status contextforge-codex-watch-<name>.service` to inspect
+logs and health.
+
+Claude Code transcripts can be ingested with the same model:
+
+```bash
+CONTEXTFORGE_STORAGE_MODE=remote \
+CONTEXTFORGE_REMOTE_URL=https://memory.example.com \
+CONTEXTFORGE_REMOTE_TOKEN=change-me \
+node src/cli.js ingestClaudeCodeSessions \
+  --projectsDir ~/.claude/projects \
+  --scope repo \
+  --repoPath /path/to/repo \
+  --sinceMinutes 1440 \
+  --distill auto
+```
+
+Claude Code sessions are stored as `claude_code:<native-session-id>` with
+`sourceAgent: "claude_code"`, `sourceRuntime: "claude_code_tui"`, and
+`sourceAdapter: "claude_code_jsonl"` metadata. This lets Codex and Claude Code
+share durable repo memory while keeping raw evidence and checkpoints
+attributable to the originating TUI.
+
 Agents can call `sessionStatus` or the MCP `session_status` tool to inspect
 whether a session has enough new raw evidence to justify a checkpoint. The
 status response includes raw event counts, raw character counts, the latest
@@ -373,6 +409,18 @@ node src/cli.js promoteMemory \
   --key retrieval-policy \
   --content "Search repo and shared memory before loading raw evidence." \
   --sourceCheckpointId checkpoint-id \
+  --reason "Reviewed and accepted by the maintainer."
+```
+
+If the checkpoint already contains a reviewed memory candidate, promote it by
+checkpoint id and candidate index without copying the candidate fields by hand:
+
+```bash
+node src/cli.js promoteMemoryCandidate \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --checkpointId checkpoint-id \
+  --sourceCandidateIndex 0 \
   --reason "Reviewed and accepted by the maintainer."
 ```
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "files": [
     "src",
+    "scripts",
     "examples",
     "README.md",
     "LICENSE"

--- a/scripts/install-codex-watch-service.sh
+++ b/scripts/install-codex-watch-service.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+name="contextforge"
+repo_path=""
+remote_url="${CONTEXTFORGE_REMOTE_URL:-}"
+token_env_file="${CONTEXTFORGE_TOKEN_ENV_FILE:-$HOME/.config/contextforge/server.env}"
+sessions_dir="${CONTEXTFORGE_CODEX_SESSIONS_DIR:-$HOME/.codex/sessions}"
+interval_ms="${CONTEXTFORGE_CODEX_WATCH_INTERVAL_MS:-30000}"
+since_minutes="${CONTEXTFORGE_CODEX_WATCH_SINCE_MINUTES:-1440}"
+distill="${CONTEXTFORGE_CODEX_WATCH_DISTILL:-auto}"
+node_bin="${NODE:-node}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --name)
+      name="$2"
+      shift 2
+      ;;
+    --repo-path)
+      repo_path="$2"
+      shift 2
+      ;;
+    --remote-url)
+      remote_url="$2"
+      shift 2
+      ;;
+    --token-env-file)
+      token_env_file="$2"
+      shift 2
+      ;;
+    --sessions-dir)
+      sessions_dir="$2"
+      shift 2
+      ;;
+    --interval-ms)
+      interval_ms="$2"
+      shift 2
+      ;;
+    --since-minutes)
+      since_minutes="$2"
+      shift 2
+      ;;
+    --distill)
+      distill="$2"
+      shift 2
+      ;;
+    --node)
+      node_bin="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$repo_path" ]; then
+  echo "--repo-path is required." >&2
+  exit 2
+fi
+
+if [ -z "$remote_url" ]; then
+  echo "--remote-url or CONTEXTFORGE_REMOTE_URL is required." >&2
+  exit 2
+fi
+
+safe_name="$(printf '%s' "$name" | tr -c 'A-Za-z0-9_.@-' '-')"
+unit_dir="$HOME/.config/systemd/user"
+unit_name="contextforge-codex-watch-${safe_name}.service"
+unit_path="$unit_dir/$unit_name"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+mkdir -p "$unit_dir"
+
+cat >"$unit_path" <<EOF
+[Unit]
+Description=ContextForge Codex watch ingest (${name})
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=${repo_root}
+Environment=CONTEXTFORGE_STORAGE_MODE=remote
+Environment=CONTEXTFORGE_REMOTE_URL=${remote_url}
+EnvironmentFile=-${token_env_file}
+ExecStart=${node_bin} ${repo_root}/src/cli.js ingestCodexSessions --sessionsDir ${sessions_dir} --scope repo --repoPath ${repo_path} --sinceMinutes ${since_minutes} --distill ${distill} --watch --intervalMs ${interval_ms}
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user enable --now "$unit_name"
+systemctl --user --no-pager status "$unit_name"

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { createContextForge } from './core.js';
+import { ingestClaudeCodeFile, ingestClaudeCodeSessions, watchClaudeCodeSessions } from './ingest/claude_code.js';
 import { ingestCodexRolloutFile, ingestCodexSessions, watchCodexSessions } from './ingest/codex.js';
 import { startContextForgeServer } from './server.js';
 
@@ -80,6 +81,7 @@ function toCoreOptions(options) {
     charThreshold: options.charThreshold == null ? undefined : Number(options.charThreshold),
     file: options.file,
     sessionsDir: options.sessionsDir,
+    projectsDir: options.projectsDir,
     distill: options.distill,
     maxContentChars: options.maxContentChars == null ? undefined : Number(options.maxContentChars),
     sinceMinutes: options.sinceMinutes == null ? undefined : Number(options.sinceMinutes),
@@ -103,6 +105,7 @@ async function main() {
     sessionStatus: (app, coreOptions) => app.sessionStatus(coreOptions),
     remember: (app, coreOptions) => app.remember(coreOptions),
     promoteMemory: (app, coreOptions) => app.promoteMemory(coreOptions),
+    promoteMemoryCandidate: (app, coreOptions) => app.promoteMemoryCandidate(coreOptions),
     correctMemory: (app, coreOptions) => app.correctMemory(coreOptions),
     deactivateMemory: (app, coreOptions) => app.deactivateMemory(coreOptions),
     listMemoryEvents: (app, coreOptions) => app.listMemoryEvents(coreOptions),
@@ -123,6 +126,16 @@ async function main() {
             },
           })
         : ingestCodexSessions(app, coreOptions),
+    ingestClaudeCodeFile: (app, coreOptions) => ingestClaudeCodeFile(app, coreOptions),
+    ingestClaudeCodeSessions: (app, coreOptions) =>
+      coreOptions.watch
+        ? watchClaudeCodeSessions(app, {
+            ...coreOptions,
+            onResult: (result) => {
+              console.log(JSON.stringify(result));
+            },
+          })
+        : ingestClaudeCodeSessions(app, coreOptions),
   };
 
   if (!command || command === 'help' || command === '--help') {

--- a/src/core.js
+++ b/src/core.js
@@ -310,6 +310,48 @@ export function createContextForge(options = {}) {
       );
     },
 
+    promoteMemoryCandidate(options) {
+      const scope = normalizeScopeOptions(options, config);
+      requireOption(options.checkpointId, 'checkpointId');
+      const candidateIndex = options.sourceCandidateIndex == null ? 0 : options.sourceCandidateIndex;
+      return useStore((store) => {
+        const checkpoint = store
+          .listCheckpoints({
+            ...scope,
+            sessionId: options.sessionId || null,
+          })
+          .find((item) => item.id === options.checkpointId);
+        if (!checkpoint) {
+          throw new Error(`Checkpoint not found: ${options.checkpointId}`);
+        }
+        const candidates = checkpoint.metadata?.memoryCandidates || [];
+        const candidate = candidates[candidateIndex];
+        if (!candidate) {
+          throw new Error(`Memory candidate not found at index ${candidateIndex}.`);
+        }
+        const key = options.key || candidate.key;
+        requireOption(key, 'key');
+        const content = options.content || candidate.content;
+        requireOption(content, 'content');
+        return store.rememberMemory({
+          ...scope,
+          key,
+          content,
+          category: options.category || candidate.category || 'note',
+          tags: options.tags?.length ? options.tags : candidate.tags || [],
+          importance: options.importance == null ? candidate.importance || 0 : options.importance,
+          eventType: 'promote',
+          eventMetadata: {
+            sourceCheckpointId: checkpoint.id,
+            sourceSessionId: checkpoint.sessionId,
+            sourceCandidateIndex: candidateIndex,
+            sourceRawEventIds: options.sourceRawEventIds || [],
+            reason: options.reason || null,
+          },
+        });
+      });
+    },
+
     getMemory(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.key, 'key');

--- a/src/ingest/claude_code.js
+++ b/src/ingest/claude_code.js
@@ -1,0 +1,368 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const DEFAULT_MAX_CONTENT_CHARS = 8000;
+const DEFAULT_WATCH_INTERVAL_MS = 30000;
+const CLAUDE_CODE_PROVENANCE = {
+  sourceAgent: 'claude_code',
+  sourceRuntime: 'claude_code_tui',
+  sourceAdapter: 'claude_code_jsonl',
+};
+
+function stripClaudeCodeSessionPrefix(sessionId) {
+  const text = String(sessionId || '');
+  return text.startsWith('claude_code:') ? text.slice('claude_code:'.length) : text;
+}
+
+function claudeCodeSessionId(nativeSessionId) {
+  const native = stripClaudeCodeSessionPrefix(nativeSessionId);
+  return native ? `claude_code:${native}` : null;
+}
+
+function truncate(value, maxChars = DEFAULT_MAX_CONTENT_CHARS) {
+  const text = String(value || '');
+  if (text.length <= maxChars) {
+    return { text, truncated: false };
+  }
+  return { text: `${text.slice(0, maxChars)}\n[truncated]`, truncated: true };
+}
+
+function textFromContent(content) {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return '';
+  }
+  return content
+    .map((item) => {
+      if (!item || typeof item !== 'object') return '';
+      if (item.type === 'text') return item.text || '';
+      if (item.type === 'tool_use') {
+        return JSON.stringify({ name: item.name || 'tool_use', input: item.input || {}, id: item.id || null }, null, 2);
+      }
+      if (item.type === 'tool_result') {
+        return typeof item.content === 'string' ? item.content : JSON.stringify(item.content ?? '', null, 2);
+      }
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function roleFromRecord(record) {
+  const role = record.message?.role || record.role || record.type;
+  if (role === 'user' || role === 'assistant') {
+    return role;
+  }
+  return null;
+}
+
+function outputRoleFromContent(content, fallbackRole) {
+  if (Array.isArray(content) && content.some((item) => item?.type === 'tool_use')) {
+    return 'tool_call';
+  }
+  if (Array.isArray(content) && content.some((item) => item?.type === 'tool_result')) {
+    return 'tool_result';
+  }
+  return fallbackRole;
+}
+
+export function normalizeClaudeCodeRecord(record, context, options = {}) {
+  const nativeSessionId = record.sessionId || context.nativeSessionId;
+  if (nativeSessionId) {
+    context.nativeSessionId = context.nativeSessionId || nativeSessionId;
+    context.sessionId = context.sessionId || claudeCodeSessionId(nativeSessionId);
+    context.conversationId = context.conversationId || claudeCodeSessionId(nativeSessionId);
+  }
+  context.cwd = context.cwd || record.cwd || null;
+
+  const role = roleFromRecord(record);
+  if (!role) {
+    return null;
+  }
+
+  const contentValue = record.message?.content ?? record.content;
+  const content = truncate(textFromContent(contentValue), options.maxContentChars);
+  if (!content.text) {
+    return null;
+  }
+
+  const native = context.nativeSessionId || stripClaudeCodeSessionPrefix(context.sessionId) || null;
+  return {
+    role: outputRoleFromContent(contentValue, role),
+    content: content.text,
+    metadata: {
+      source: 'claude_code_jsonl',
+      ...CLAUDE_CODE_PROVENANCE,
+      nativeSessionId: native,
+      ingestId: `claude-code:${native || 'unknown'}:${record.uuid || context.lineNumber}`,
+      recordType: record.type || null,
+      claudeRole: role,
+      claudeUuid: record.uuid || null,
+      parentUuid: record.parentUuid || null,
+      timestamp: record.timestamp || null,
+      truncated: content.truncated,
+      sourceFile: context.filePath || null,
+    },
+  };
+}
+
+export async function parseClaudeCodeFile(filePath, options = {}) {
+  const text = await fs.readFile(filePath, 'utf8');
+  const nativeSessionId = options.sessionId ? stripClaudeCodeSessionPrefix(options.sessionId) : null;
+  const sessionId = nativeSessionId ? claudeCodeSessionId(nativeSessionId) : null;
+  const context = {
+    filePath,
+    nativeSessionId,
+    sessionId,
+    conversationId: options.conversationId ? claudeCodeSessionId(options.conversationId) : sessionId,
+    cwd: null,
+    lineNumber: 0,
+  };
+  const events = [];
+  const warnings = [];
+  const lines = text.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    context.lineNumber += 1;
+    if (!line.trim()) continue;
+    let record;
+    try {
+      record = JSON.parse(line);
+    } catch (error) {
+      if (index === lines.length - 1 || index === lines.length - 2) {
+        warnings.push({
+          type: 'partial_json_line',
+          lineNumber: context.lineNumber,
+          message: error.message,
+        });
+        continue;
+      }
+      throw error;
+    }
+    const event = normalizeClaudeCodeRecord(record, context, options);
+    if (event) {
+      events.push(event);
+    }
+  }
+
+  return {
+    nativeSessionId: context.nativeSessionId,
+    sessionId: context.sessionId,
+    conversationId: context.conversationId || context.sessionId,
+    cwd: context.cwd,
+    events,
+    warnings,
+  };
+}
+
+async function appendNewEvents(app, scopeOptions, parsed) {
+  const existing = await app.listRawEvents({
+    ...scopeOptions,
+    sessionId: parsed.sessionId,
+  });
+  const existingIds = new Set(existing.map((event) => event.metadata?.ingestId).filter(Boolean));
+  const appended = [];
+  let skipped = 0;
+
+  for (const event of parsed.events) {
+    if (existingIds.has(event.metadata.ingestId)) {
+      skipped += 1;
+      continue;
+    }
+    appended.push(
+      await app.appendRaw({
+        ...scopeOptions,
+        sessionId: parsed.sessionId,
+        conversationId: parsed.conversationId,
+        role: event.role,
+        content: event.content,
+        metadata: event.metadata,
+      }),
+    );
+  }
+
+  return { appended, skipped };
+}
+
+export async function ingestClaudeCodeFile(app, options = {}) {
+  if (!options.file) {
+    throw new Error('file is required.');
+  }
+  const parsed = await parseClaudeCodeFile(options.file, options);
+  if (!parsed.sessionId) {
+    throw new Error('Claude Code session id could not be determined.');
+  }
+  const scopeOptions = {
+    scope: options.scope,
+    scopeKey: options.scopeKey,
+    cwd: options.cwd || parsed.cwd,
+    repoPath: options.repoPath,
+  };
+  const { appended, skipped } = await appendNewEvents(app, scopeOptions, parsed);
+  const statusOptions = {
+    ...scopeOptions,
+    sessionId: parsed.sessionId,
+    minEvents: options.minEvents,
+    minIntervalMs: options.minIntervalMs,
+    charThreshold: options.charThreshold,
+  };
+  const status = await app.sessionStatus(statusOptions);
+  let checkpoint = null;
+  const distill = options.distill || 'never';
+  if (distill === 'always' || (distill === 'auto' && status.shouldDistill)) {
+    checkpoint = await app.distillCheckpoint({
+      ...scopeOptions,
+      sessionId: parsed.sessionId,
+      conversationId: parsed.conversationId,
+      provider: options.provider,
+    });
+  }
+
+  return {
+    source: 'claude_code_jsonl',
+    file: options.file,
+    sessionId: parsed.sessionId,
+    conversationId: parsed.conversationId,
+    parsedEvents: parsed.events.length,
+    appendedEvents: appended.length,
+    skippedEvents: skipped,
+    warnings: parsed.warnings,
+    status,
+    checkpoint,
+  };
+}
+
+async function walkFiles(rootDir) {
+  let entries;
+  try {
+    entries = await fs.readdir(rootDir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+  const files = [];
+  for (const entry of entries) {
+    const entryPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walkFiles(entryPath)));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+function defaultProjectsDir() {
+  return path.join(os.homedir(), '.claude', 'projects');
+}
+
+export async function discoverClaudeCodeFiles(options = {}) {
+  const projectsDir = path.resolve(options.projectsDir || options.sessionsDir || defaultProjectsDir());
+  const files = (await walkFiles(projectsDir)).filter((file) => file.endsWith('.jsonl'));
+  const stats = await Promise.all(
+    files.map(async (file) => ({
+      file,
+      stat: await fs.stat(file),
+    })),
+  );
+  const sinceMs = options.sinceMinutes == null ? null : Date.now() - Number(options.sinceMinutes) * 60 * 1000;
+  return stats
+    .filter((item) => sinceMs == null || item.stat.mtimeMs >= sinceMs)
+    .sort((a, b) => a.stat.mtimeMs - b.stat.mtimeMs || a.file.localeCompare(b.file))
+    .slice(0, options.scanLimit == null ? undefined : Number(options.scanLimit))
+    .map((item) => item.file);
+}
+
+export async function ingestClaudeCodeSessions(app, options = {}) {
+  const files = options.file ? [options.file] : await discoverClaudeCodeFiles(options);
+  const results = [];
+  for (const file of files) {
+    results.push(await ingestClaudeCodeFile(app, { ...options, file }));
+  }
+
+  return {
+    source: 'claude_code_sessions',
+    projectsDir: path.resolve(options.projectsDir || options.sessionsDir || defaultProjectsDir()),
+    filesScanned: files.length,
+    parsedEvents: results.reduce((total, result) => total + result.parsedEvents, 0),
+    appendedEvents: results.reduce((total, result) => total + result.appendedEvents, 0),
+    skippedEvents: results.reduce((total, result) => total + result.skippedEvents, 0),
+    checkpointsCreated: results.filter((result) => result.checkpoint).length,
+    fileResults: results,
+  };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function summarizeWatchResults(results) {
+  return {
+    filesScanned: results.reduce((total, result) => total + result.filesScanned, 0),
+    parsedEvents: results.reduce((total, result) => total + result.parsedEvents, 0),
+    appendedEvents: results.reduce((total, result) => total + result.appendedEvents, 0),
+    skippedEvents: results.reduce((total, result) => total + result.skippedEvents, 0),
+    checkpointsCreated: results.reduce((total, result) => total + result.checkpointsCreated, 0),
+  };
+}
+
+export async function watchClaudeCodeSessions(app, options = {}) {
+  const intervalMs =
+    options.intervalMs == null ? DEFAULT_WATCH_INTERVAL_MS : Math.max(0, Number(options.intervalMs));
+  const maxIterations = options.iterations == null ? null : Math.max(0, Number(options.iterations));
+  const startedAt = new Date().toISOString();
+  const results = [];
+  let iterations = 0;
+  let stopped = false;
+
+  const stop = () => {
+    stopped = true;
+  };
+
+  process.once('SIGINT', stop);
+  process.once('SIGTERM', stop);
+
+  try {
+    while (!stopped && (maxIterations == null || iterations < maxIterations)) {
+      iterations += 1;
+      const result = await ingestClaudeCodeSessions(app, options);
+      const iterationResult = {
+        ...result,
+        source: 'claude_code_sessions_watch_iteration',
+        iteration: iterations,
+        intervalMs,
+        watchedAt: new Date().toISOString(),
+      };
+      results.push(iterationResult);
+      if (options.onResult) {
+        await options.onResult(iterationResult);
+      }
+      if (!stopped && (maxIterations == null || iterations < maxIterations)) {
+        await sleep(intervalMs);
+      }
+    }
+  } finally {
+    process.removeListener('SIGINT', stop);
+    process.removeListener('SIGTERM', stop);
+  }
+
+  return {
+    source: 'claude_code_sessions_watch',
+    projectsDir: path.resolve(options.projectsDir || options.sessionsDir || defaultProjectsDir()),
+    intervalMs,
+    iterations,
+    stopped,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    totals: summarizeWatchResults(results),
+    results,
+  };
+}

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -7,6 +7,7 @@ const REMOTE_METHODS = [
   'sessionStatus',
   'remember',
   'promoteMemory',
+  'promoteMemoryCandidate',
   'correctMemory',
   'deactivateMemory',
   'listMemoryEvents',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -86,6 +86,62 @@ async function writeSyntheticCodexRollout(filePath, sessionId = 'codex-rollout-s
   await fs.writeFile(filePath, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`);
 }
 
+async function writeSyntheticClaudeCodeTranscript(filePath, sessionId = 'claude-code-session') {
+  const records = [
+    {
+      type: 'summary',
+      sessionId,
+      timestamp: '2026-04-25T00:00:00.000Z',
+      content: 'Summaries should not be captured as raw dialogue.',
+    },
+    {
+      type: 'user',
+      sessionId,
+      uuid: 'claude-user-1',
+      cwd: path.dirname(filePath),
+      timestamp: '2026-04-25T00:00:01.000Z',
+      message: {
+        role: 'user',
+        content: 'Continue the ContextForge Claude Code ingest work.',
+      },
+    },
+    {
+      type: 'assistant',
+      sessionId,
+      uuid: 'claude-assistant-tool',
+      cwd: path.dirname(filePath),
+      timestamp: '2026-04-25T00:00:02.000Z',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'toolu_1', name: 'Read', input: { file_path: 'README.md' } }],
+      },
+    },
+    {
+      type: 'user',
+      sessionId,
+      uuid: 'claude-tool-result',
+      cwd: path.dirname(filePath),
+      timestamp: '2026-04-25T00:00:03.000Z',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'README contents.' }],
+      },
+    },
+    {
+      type: 'assistant',
+      sessionId,
+      uuid: 'claude-assistant-1',
+      cwd: path.dirname(filePath),
+      timestamp: '2026-04-25T00:00:04.000Z',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'I added Claude Code transcript ingestion.' }],
+      },
+    },
+  ];
+  await fs.writeFile(filePath, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`);
+}
+
 async function appendSyntheticCodexAssistantMessage(filePath, text) {
   const record = {
     timestamp: '2026-04-25T00:00:06.000Z',
@@ -333,6 +389,31 @@ test('memory candidates require explicit promotion and can be corrected or deact
   assert.equal(candidates[0].index, 0);
   assert.equal(candidates[0].candidate.key, 'candidate-rule');
 
+  const promotedFromCandidate = app.promoteMemoryCandidate({
+    scope: 'repo',
+    scopeKey: 'repo-promote',
+    checkpointId: checkpoint.id,
+    sourceCandidateIndex: 0,
+    key: 'candidate-rule-via-helper',
+    reason: 'Reviewed via helper.',
+  });
+  assert.equal(promotedFromCandidate.key, 'candidate-rule-via-helper');
+  assert.equal(promotedFromCandidate.content, candidates[0].candidate.content);
+
+  const helperEvents = app.listMemoryEvents({
+    scope: 'repo',
+    scopeKey: 'repo-promote',
+    key: 'candidate-rule-via-helper',
+  });
+  assert.equal(helperEvents[0].metadata.sourceCheckpointId, checkpoint.id);
+  assert.equal(helperEvents[0].metadata.sourceSessionId, 'candidate-session');
+  app.deactivateMemory({
+    scope: 'repo',
+    scopeKey: 'repo-promote',
+    key: 'candidate-rule-via-helper',
+    reason: 'Keep the helper assertion isolated from search assertions.',
+  });
+
   const promoted = app.promoteMemory({
     scope: 'repo',
     scopeKey: 'repo-promote',
@@ -380,7 +461,7 @@ test('memory candidates require explicit promotion and can be corrected or deact
   const searchBeforeDeactivate = app.search({
     scope: 'repo',
     scopeKey: 'repo-promote',
-    query: 'agent review',
+    query: 'human agent review',
   });
   assert.equal(searchBeforeDeactivate.length, 1);
   assert.equal(searchBeforeDeactivate[0].memory.key, 'candidate-rule');
@@ -834,6 +915,85 @@ test('CLI Codex sessions scan is not capped by search limit defaults', async () 
   const parsed = JSON.parse(result.stdout);
   assert.equal(parsed.filesScanned, 11);
   assert.equal(parsed.appendedEvents, 44);
+});
+
+test('CLI ingests Claude Code JSONL transcripts with agent provenance', async () => {
+  const dataDir = await makeTempDir();
+  const projectsDir = await makeTempDir();
+  const file = path.join(projectsDir, 'project-a', 'claude-session.jsonl');
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await writeSyntheticClaudeCodeTranscript(file, 'claude-native-session');
+  await fs.appendFile(file, '{"type":"assistant","sessionId":"claude-native-session"');
+  const env = {
+    ...process.env,
+    CONTEXTFORGE_DATA_DIR: dataDir,
+  };
+
+  const first = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'ingestClaudeCodeSessions',
+      '--projectsDir',
+      projectsDir,
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'claude-code-repo',
+      '--distill',
+      'never',
+    ],
+    { env },
+  );
+  const firstResult = JSON.parse(first.stdout);
+  assert.equal(firstResult.filesScanned, 1);
+  assert.equal(firstResult.parsedEvents, 4);
+  assert.equal(firstResult.appendedEvents, 4);
+  assert.equal(firstResult.fileResults[0].sessionId, 'claude_code:claude-native-session');
+  assert.equal(firstResult.fileResults[0].warnings.length, 1);
+
+  const second = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'ingestClaudeCodeSessions',
+      '--projectsDir',
+      projectsDir,
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'claude-code-repo',
+      '--distill',
+      'never',
+    ],
+    { env },
+  );
+  const secondResult = JSON.parse(second.stdout);
+  assert.equal(secondResult.appendedEvents, 0);
+  assert.equal(secondResult.skippedEvents, 4);
+
+  const rawEvents = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'listRawEvents',
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'claude-code-repo',
+      '--sessionId',
+      'claude_code:claude-native-session',
+    ],
+    { env },
+  );
+  const events = JSON.parse(rawEvents.stdout);
+  assert.deepEqual(
+    events.map((event) => event.role),
+    ['user', 'tool_call', 'tool_result', 'assistant'],
+  );
+  assert.ok(events.every((event) => event.metadata.sourceAgent === 'claude_code'));
+  assert.ok(events.every((event) => event.metadata.sourceAdapter === 'claude_code_jsonl'));
+  assert.ok(events.every((event) => event.metadata.nativeSessionId === 'claude-native-session'));
 });
 
 test('search can combine repo and shared scopes while excluding local by default', async () => {


### PR DESCRIPTION
Closes #44.

## Summary

- Add Claude Code JSONL transcript ingestion with claude_code:<native-session-id> provenance.
- Add promoteMemoryCandidate for reviewed checkpoint candidate promotion without manual field copying.
- Add a systemd user service installer for Codex watch ingestion against remote ContextForge.
- Document Codex watch service setup, Claude Code ingestion, and the recommended watch + distill auto policy.

## Verification

- npm test
- bash -n scripts/install-codex-watch-service.sh
- git diff --check
- npm pack --dry-run
- npm audit --audit-level=moderate
- Temp DB Claude Code ingest smoke against ~/.claude/projects with --scanLimit 1
