### PR TITLE
Filter TUI watch ingestion by repo cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   promoted from CLI without copying candidate fields manually.
 - Added a systemd user service installer for long-running Codex watch ingest
   against a remote ContextForge server.
+- Repo-specific TUI ingest now skips transcript files whose recorded cwd is
+  outside `--repoPath`, preventing global session scans from crossing repo
+  scopes.
 - The remote server now exposes a Streamable HTTP MCP endpoint at `/mcp`, so
   agents on multiple machines can connect directly to the same canonical memory
   store without launching a local stdio MCP bridge.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,9 @@ node src/cli.js ingestCodexSessions \
 The sessions scan is safe to run repeatedly. It keeps rollout files isolated by
 their Codex session id, skips already-ingested records, and ignores a trailing
 partial JSON line from an actively-written rollout file so the next scan can
-pick it up when complete.
+pick it up when complete. When `--repoPath` is set, files whose recorded TUI
+cwd is outside that repo path are skipped so a global sessions directory can be
+watched safely by a repo-specific service.
 
 For local TUI use, the same command can stay resident and poll for new rollout
 events:

--- a/src/ingest/claude_code.js
+++ b/src/ingest/claude_code.js
@@ -20,6 +20,17 @@ function claudeCodeSessionId(nativeSessionId) {
   return native ? `claude_code:${native}` : null;
 }
 
+function isPathWithin(parentPath, childPath) {
+  const parent = path.resolve(parentPath);
+  const child = path.resolve(childPath);
+  const relative = path.relative(parent, child);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function shouldSkipOutsideRepo(parsed, options = {}) {
+  return Boolean(options.repoPath && parsed.cwd && !isPathWithin(options.repoPath, parsed.cwd));
+}
+
 function truncate(value, maxChars = DEFAULT_MAX_CONTENT_CHARS) {
   const text = String(value || '');
   if (text.length <= maxChars) {
@@ -202,6 +213,24 @@ export async function ingestClaudeCodeFile(app, options = {}) {
     cwd: options.cwd || parsed.cwd,
     repoPath: options.repoPath,
   };
+  if (shouldSkipOutsideRepo(parsed, options)) {
+    return {
+      source: 'claude_code_jsonl',
+      file: options.file,
+      sessionId: parsed.sessionId,
+      conversationId: parsed.conversationId,
+      parsedEvents: parsed.events.length,
+      appendedEvents: 0,
+      skippedEvents: parsed.events.length,
+      warnings: parsed.warnings,
+      skipped: true,
+      skippedReason: 'cwd_outside_repo_path',
+      cwd: parsed.cwd,
+      repoPath: path.resolve(options.repoPath),
+      status: null,
+      checkpoint: null,
+    };
+  }
   const { appended, skipped } = await appendNewEvents(app, scopeOptions, parsed);
   const statusOptions = {
     ...scopeOptions,

--- a/src/ingest/codex.js
+++ b/src/ingest/codex.js
@@ -20,6 +20,17 @@ function codexSessionId(nativeSessionId) {
   return native ? `codex:${native}` : null;
 }
 
+function isPathWithin(parentPath, childPath) {
+  const parent = path.resolve(parentPath);
+  const child = path.resolve(childPath);
+  const relative = path.relative(parent, child);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function shouldSkipOutsideRepo(parsed, options = {}) {
+  return Boolean(options.repoPath && parsed.cwd && !isPathWithin(options.repoPath, parsed.cwd));
+}
+
 function truncate(value, maxChars = DEFAULT_MAX_CONTENT_CHARS) {
   const text = String(value || '');
   if (text.length <= maxChars) {
@@ -205,6 +216,24 @@ export async function ingestCodexRolloutFile(app, options = {}) {
     cwd: options.cwd || parsed.cwd,
     repoPath: options.repoPath,
   };
+  if (shouldSkipOutsideRepo(parsed, options)) {
+    return {
+      source: 'codex_rollout_jsonl',
+      file: options.file,
+      sessionId: parsed.sessionId,
+      conversationId: parsed.conversationId,
+      parsedEvents: parsed.events.length,
+      appendedEvents: 0,
+      skippedEvents: parsed.events.length,
+      warnings: parsed.warnings,
+      skipped: true,
+      skippedReason: 'cwd_outside_repo_path',
+      cwd: parsed.cwd,
+      repoPath: path.resolve(options.repoPath),
+      status: null,
+      checkpoint: null,
+    };
+  }
   const { appended, skipped } = await appendNewEvents(app, scopeOptions, parsed);
   const statusOptions = {
     ...scopeOptions,

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -496,9 +496,9 @@ test('CLI supports promoteMemory', async () => {
   const env = { ...process.env, CONTEXTFORGE_DATA_DIR: dataDir };
 
   const promoted = await execFileAsync(
-    'node',
-    [
-      'src/cli.js',
+      'node',
+      [
+      path.resolve('src/cli.js'),
       'promoteMemory',
       '--scope',
       'repo',
@@ -557,9 +557,9 @@ test('CLI reports invalid metadata JSON clearly', async () => {
   await assert.rejects(
     () =>
       execFileAsync(
-        'node',
-        [
-          'src/cli.js',
+      'node',
+      [
+      path.resolve('src/cli.js'),
           'appendRaw',
           '--scope',
           'repo',
@@ -594,7 +594,7 @@ test('CLI ingests Codex rollout JSONL idempotently without capturing developer m
   const first = await execFileAsync(
     'node',
     [
-      'src/cli.js',
+      path.resolve('src/cli.js'),
       'ingestCodexRollout',
       '--file',
       file,
@@ -616,7 +616,7 @@ test('CLI ingests Codex rollout JSONL idempotently without capturing developer m
   const second = await execFileAsync(
     'node',
     [
-      'src/cli.js',
+      path.resolve('src/cli.js'),
       'ingestCodexRollout',
       '--file',
       file,
@@ -837,6 +837,48 @@ test('CLI ingests multiple Codex session rollout files safely', async () => {
   assert.equal(secondEvents.length, 4);
 });
 
+test('repoPath ingest skips Codex session files from other working directories', async () => {
+  const dataDir = await makeTempDir();
+  const sessionsDir = await makeTempDir();
+  const otherRepo = await makeTempDir();
+  const targetRepo = await makeGitRepo('https://github.com/example/filter-target.git');
+  const file = path.join(otherRepo, 'rollout-outside.jsonl');
+  await writeSyntheticCodexRollout(file, 'codex-outside-session');
+  const env = {
+    ...process.env,
+    CONTEXTFORGE_DATA_DIR: dataDir,
+  };
+
+  const result = await execFileAsync(
+    'node',
+    [
+      path.resolve('src/cli.js'),
+      'ingestCodexRollout',
+      '--file',
+      file,
+      '--scope',
+      'repo',
+      '--repoPath',
+      targetRepo,
+      '--distill',
+      'never',
+    ],
+    { cwd: sessionsDir, env },
+  );
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.skipped, true);
+  assert.equal(parsed.skippedReason, 'cwd_outside_repo_path');
+  assert.equal(parsed.appendedEvents, 0);
+
+  const app = createContextForge({ env, cwd: process.cwd() });
+  const events = app.listRawEvents({
+    scope: 'repo',
+    scopeKey: 'github.com/example/filter-target',
+    sessionId: 'codex:codex-outside-session',
+  });
+  assert.equal(events.length, 0);
+});
+
 test('Codex sessions watch loop picks up new events without duplicates', async () => {
   const dataDir = await makeTempDir();
   const sessionsDir = await makeTempDir();
@@ -994,6 +1036,40 @@ test('CLI ingests Claude Code JSONL transcripts with agent provenance', async ()
   assert.ok(events.every((event) => event.metadata.sourceAgent === 'claude_code'));
   assert.ok(events.every((event) => event.metadata.sourceAdapter === 'claude_code_jsonl'));
   assert.ok(events.every((event) => event.metadata.nativeSessionId === 'claude-native-session'));
+});
+
+test('repoPath ingest skips Claude Code transcripts from other working directories', async () => {
+  const dataDir = await makeTempDir();
+  const projectsDir = await makeTempDir();
+  const targetRepo = await makeGitRepo('https://github.com/example/claude-filter-target.git');
+  const otherDir = await makeTempDir();
+  const file = path.join(otherDir, 'claude-outside.jsonl');
+  await writeSyntheticClaudeCodeTranscript(file, 'claude-outside-session');
+  const env = {
+    ...process.env,
+    CONTEXTFORGE_DATA_DIR: dataDir,
+  };
+
+  const result = await execFileAsync(
+    'node',
+    [
+      path.resolve('src/cli.js'),
+      'ingestClaudeCodeFile',
+      '--file',
+      file,
+      '--scope',
+      'repo',
+      '--repoPath',
+      targetRepo,
+      '--distill',
+      'never',
+    ],
+    { cwd: projectsDir, env },
+  );
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.skipped, true);
+  assert.equal(parsed.skippedReason, 'cwd_outside_repo_path');
+  assert.equal(parsed.appendedEvents, 0);
 });
 
 test('search can combine repo and shared scopes while excluding local by default', async () => {


### PR DESCRIPTION
Closes #46.

## Summary

- Skip Codex rollout files whose recorded cwd is outside --repoPath.
- Skip Claude Code transcript files whose recorded cwd is outside --repoPath.
- Surface skipped files with skippedReason: cwd_outside_repo_path.
- Document why repo-specific watch services can safely scan global TUI session directories.

## Verification

- npm test
- bash -n scripts/install-codex-watch-service.sh
- git diff --check
- npm pack --dry-run
- npm audit --audit-level=moderate
