### PR TITLE
Throttle auto distill retries after provider failures

### DIFF
--- a/src/ingest/claude_code.js
+++ b/src/ingest/claude_code.js
@@ -31,6 +31,22 @@ function shouldSkipOutsideRepo(parsed, options = {}) {
   return Boolean(options.repoPath && parsed.cwd && !isPathWithin(options.repoPath, parsed.cwd));
 }
 
+async function shouldSkipRecentFailedAutoDistill(app, scopeOptions, sessionId, status) {
+  const runs = await app.listDistillRuns({
+    ...scopeOptions,
+    sessionId,
+  });
+  const latest = runs[0];
+  if (!latest || latest.status !== 'failed') {
+    return false;
+  }
+  const failedAt = Date.parse(latest.completedAt || latest.createdAt);
+  if (!Number.isFinite(failedAt)) {
+    return false;
+  }
+  return Date.now() - failedAt < status.thresholds.minIntervalMs;
+}
+
 function truncate(value, maxChars = DEFAULT_MAX_CONTENT_CHARS) {
   const text = String(value || '');
   if (text.length <= maxChars) {
@@ -242,20 +258,25 @@ export async function ingestClaudeCodeFile(app, options = {}) {
   const status = await app.sessionStatus(statusOptions);
   let checkpoint = null;
   let checkpointError = null;
+  let checkpointSkippedReason = null;
   const distill = options.distill || 'never';
   if (distill === 'always' || (distill === 'auto' && status.shouldDistill)) {
-    try {
-      checkpoint = await app.distillCheckpoint({
-        ...scopeOptions,
-        sessionId: parsed.sessionId,
-        conversationId: parsed.conversationId,
-        provider: options.provider,
-      });
-    } catch (error) {
-      checkpointError = {
-        message: error.message,
-        name: error.name,
-      };
+    if (distill === 'auto' && (await shouldSkipRecentFailedAutoDistill(app, scopeOptions, parsed.sessionId, status))) {
+      checkpointSkippedReason = 'recent_failed_distill';
+    } else {
+      try {
+        checkpoint = await app.distillCheckpoint({
+          ...scopeOptions,
+          sessionId: parsed.sessionId,
+          conversationId: parsed.conversationId,
+          provider: options.provider,
+        });
+      } catch (error) {
+        checkpointError = {
+          message: error.message,
+          name: error.name,
+        };
+      }
     }
   }
 
@@ -271,6 +292,7 @@ export async function ingestClaudeCodeFile(app, options = {}) {
     status,
     checkpoint,
     checkpointError,
+    checkpointSkippedReason,
   };
 }
 

--- a/src/ingest/codex.js
+++ b/src/ingest/codex.js
@@ -31,6 +31,22 @@ function shouldSkipOutsideRepo(parsed, options = {}) {
   return Boolean(options.repoPath && parsed.cwd && !isPathWithin(options.repoPath, parsed.cwd));
 }
 
+async function shouldSkipRecentFailedAutoDistill(app, scopeOptions, sessionId, status) {
+  const runs = await app.listDistillRuns({
+    ...scopeOptions,
+    sessionId,
+  });
+  const latest = runs[0];
+  if (!latest || latest.status !== 'failed') {
+    return false;
+  }
+  const failedAt = Date.parse(latest.completedAt || latest.createdAt);
+  if (!Number.isFinite(failedAt)) {
+    return false;
+  }
+  return Date.now() - failedAt < status.thresholds.minIntervalMs;
+}
+
 function truncate(value, maxChars = DEFAULT_MAX_CONTENT_CHARS) {
   const text = String(value || '');
   if (text.length <= maxChars) {
@@ -245,20 +261,25 @@ export async function ingestCodexRolloutFile(app, options = {}) {
   const status = await app.sessionStatus(statusOptions);
   let checkpoint = null;
   let checkpointError = null;
+  let checkpointSkippedReason = null;
   const distill = options.distill || 'never';
   if (distill === 'always' || (distill === 'auto' && status.shouldDistill)) {
-    try {
-      checkpoint = await app.distillCheckpoint({
-        ...scopeOptions,
-        sessionId: parsed.sessionId,
-        conversationId: parsed.conversationId,
-        provider: options.provider,
-      });
-    } catch (error) {
-      checkpointError = {
-        message: error.message,
-        name: error.name,
-      };
+    if (distill === 'auto' && (await shouldSkipRecentFailedAutoDistill(app, scopeOptions, parsed.sessionId, status))) {
+      checkpointSkippedReason = 'recent_failed_distill';
+    } else {
+      try {
+        checkpoint = await app.distillCheckpoint({
+          ...scopeOptions,
+          sessionId: parsed.sessionId,
+          conversationId: parsed.conversationId,
+          provider: options.provider,
+        });
+      } catch (error) {
+        checkpointError = {
+          message: error.message,
+          name: error.name,
+        };
+      }
     }
   }
 
@@ -274,6 +295,7 @@ export async function ingestCodexRolloutFile(app, options = {}) {
     status,
     checkpoint,
     checkpointError,
+    checkpointSkippedReason,
   };
 }
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -755,6 +755,24 @@ test('Codex ingest preserves raw evidence when auto distill fails', async () => 
     sessionId: 'codex:codex-auto-fail-session',
   });
   assert.equal(runs[0].status, 'failed');
+
+  const retry = await ingestCodexRolloutFile(app, {
+    file,
+    scope: 'repo',
+    scopeKey: 'codex-auto-fail-repo',
+    distill: 'auto',
+    charThreshold: 1,
+  });
+  assert.equal(retry.appendedEvents, 0);
+  assert.equal(retry.checkpointSkippedReason, 'recent_failed_distill');
+  assert.equal(
+    app.listDistillRuns({
+      scope: 'repo',
+      scopeKey: 'codex-auto-fail-repo',
+      sessionId: 'codex:codex-auto-fail-session',
+    }).length,
+    1,
+  );
 });
 
 test('CLI ingest works through remote storage mode', async () => {


### PR DESCRIPTION
Closes #50.

## Summary

- Skip auto checkpoint retries when the latest distill run failed within minIntervalMs.
- Return checkpointSkippedReason: recent_failed_distill in ingest results.
- Keep distill always as the immediate force mode.
- Cover raw preservation and retry throttling in tests.

## Verification

- npm test
- git diff --check
- npm pack --dry-run
- npm audit --audit-level=moderate
