### PR TITLE
Add bounded incremental distillation windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Repo-specific TUI ingest now skips transcript files whose recorded cwd is
   outside `--repoPath`, preventing global session scans from crossing repo
   scopes.
+- Checkpoint distillation now uses bounded recent raw-event windows with
+  configurable max event/character limits and records source window metadata.
 - The remote server now exposes a Streamable HTTP MCP endpoint at `/mcp`, so
   agents on multiple machines can connect directly to the same canonical memory
   store without launching a local stdio MCP bridge.

--- a/README.md
+++ b/README.md
@@ -282,6 +282,9 @@ Default distill recommendation thresholds are:
 - `CONTEXTFORGE_DISTILL_MIN_INTERVAL_MS`: `600000`
 - `CONTEXTFORGE_DISTILL_CHAR_THRESHOLD`: 80% of
   `CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS`, which defaults to `9600`
+- `CONTEXTFORGE_DISTILL_MAX_EVENTS`: `80`
+- `CONTEXTFORGE_DISTILL_MAX_CHARS`: `CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS`,
+  which defaults to `12000`
 
 Before the first checkpoint, `sessionStatus` recommends distillation only when
 the raw character threshold is reached. The event threshold is combined with the
@@ -289,6 +292,12 @@ character threshold for diagnostics, but it does not trigger an initial
 checkpoint by itself. After a checkpoint exists, the event threshold is paired
 with the interval threshold, and the character threshold can trigger on its own
 to avoid overrunning the provider input budget.
+
+Checkpoint distillation uses a bounded recent raw-event window. Very large
+sessions are not sent to the provider as one prompt; ContextForge selects at
+most `CONTEXTFORGE_DISTILL_MAX_EVENTS` and
+`CONTEXTFORGE_DISTILL_MAX_CHARS`, then records `sourceEventWindow` and
+`sourceRawEventIds` metadata on the run/checkpoint for auditability.
 
 Use an external scheduler if you want unattended checkpoints. For example, a
 systemd timer or cron job can call:

--- a/src/cli.js
+++ b/src/cli.js
@@ -79,6 +79,8 @@ function toCoreOptions(options) {
     minEvents: options.minEvents == null ? undefined : Number(options.minEvents),
     minIntervalMs: options.minIntervalMs == null ? undefined : Number(options.minIntervalMs),
     charThreshold: options.charThreshold == null ? undefined : Number(options.charThreshold),
+    maxEvents: options.maxEvents == null ? undefined : Number(options.maxEvents),
+    maxChars: options.maxChars == null ? undefined : Number(options.maxChars),
     file: options.file,
     sessionsDir: options.sessionsDir,
     projectsDir: options.projectsDir,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -205,6 +205,12 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
         'CONTEXTFORGE_DISTILL_CHAR_THRESHOLD',
         Math.floor(codexExecMaxInputChars * 0.8),
       ),
+      maxEvents: parsePositiveInteger(env.CONTEXTFORGE_DISTILL_MAX_EVENTS, 'CONTEXTFORGE_DISTILL_MAX_EVENTS', 80),
+      maxChars: parsePositiveInteger(
+        env.CONTEXTFORGE_DISTILL_MAX_CHARS,
+        'CONTEXTFORGE_DISTILL_MAX_CHARS',
+        codexExecMaxInputChars,
+      ),
     },
   };
 }

--- a/src/core.js
+++ b/src/core.js
@@ -50,8 +50,48 @@ function eventsAfterCheckpoint(events, checkpoint) {
   return events.filter((event) => Date.parse(event.createdAt) > checkpointTime);
 }
 
+function selectDistillWindow(rawEvents, latestCheckpoint, policy) {
+  const candidateEvents = eventsAfterCheckpoint(rawEvents, latestCheckpoint);
+  const selected = [];
+  let selectedChars = 0;
+  const maxEvents = policy.maxEvents;
+  const maxChars = policy.maxChars;
+
+  for (let index = candidateEvents.length - 1; index >= 0; index -= 1) {
+    if (selected.length >= maxEvents) break;
+    const event = candidateEvents[index];
+    const eventChars = String(event.content || '').length;
+    if (selected.length > 0 && selectedChars + eventChars > maxChars) {
+      break;
+    }
+    selected.unshift(event);
+    selectedChars += eventChars;
+    if (selectedChars >= maxChars) {
+      break;
+    }
+  }
+
+  return {
+    events: selected,
+    metadata: {
+      mode: latestCheckpoint ? 'since_latest_checkpoint_recent_window' : 'initial_recent_window',
+      totalRawEventCount: rawEvents.length,
+      candidateEventCount: candidateEvents.length,
+      candidateCharCount: rawCharCount(candidateEvents),
+      selectedEventCount: selected.length,
+      selectedCharCount: selectedChars,
+      maxEvents,
+      maxChars,
+      truncated: selected.length < candidateEvents.length,
+      firstRawEventId: selected[0]?.id || null,
+      lastRawEventId: selected.at(-1)?.id || null,
+    },
+  };
+}
+
 function buildSessionStatus({ scope, sessionId, rawEvents, latestCheckpoint, policy, now = new Date() }) {
   const eventsSinceLastCheckpoint = eventsAfterCheckpoint(rawEvents, latestCheckpoint);
+  const distillWindow = selectDistillWindow(rawEvents, latestCheckpoint, policy);
   const rawEventCount = rawEvents.length;
   const rawCharTotal = rawCharCount(rawEvents);
   const charsSinceLastCheckpoint = rawCharCount(eventsSinceLastCheckpoint);
@@ -87,6 +127,7 @@ function buildSessionStatus({ scope, sessionId, rawEvents, latestCheckpoint, pol
     charsSinceLastCheckpoint,
     elapsedSinceLastCheckpointMs: elapsedMs,
     thresholds: policy,
+    distillWindow: distillWindow.metadata,
     shouldDistill: reasons.some((reason) => reason !== 'no_raw_events'),
     reasons,
   };
@@ -173,6 +214,14 @@ export function createContextForge(options = {}) {
         charThreshold: positiveNumber(
           options.charThreshold == null ? config.distillPolicy.charThreshold : Number(options.charThreshold),
           'charThreshold',
+        ),
+        maxEvents: positiveNumber(
+          options.maxEvents == null ? config.distillPolicy.maxEvents : Number(options.maxEvents),
+          'maxEvents',
+        ),
+        maxChars: positiveNumber(
+          options.maxChars == null ? config.distillPolicy.maxChars : Number(options.maxChars),
+          'maxChars',
         ),
       };
       return useStore((store) =>
@@ -411,7 +460,19 @@ export function createContextForge(options = {}) {
       return useStore(async (store) => {
         const rawEvents = store.listRawEvents({ ...scope, sessionId: options.sessionId });
         const previousCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId });
-        const sourceProvenance = sourceProvenanceFromEvents(rawEvents);
+        const policy = {
+          maxEvents: positiveNumber(
+            options.maxEvents == null ? config.distillPolicy.maxEvents : Number(options.maxEvents),
+            'maxEvents',
+          ),
+          maxChars: positiveNumber(
+            options.maxChars == null ? config.distillPolicy.maxChars : Number(options.maxChars),
+            'maxChars',
+          ),
+        };
+        const distillWindow = selectDistillWindow(rawEvents, previousCheckpoint, policy);
+        const selectedRawEvents = distillWindow.events;
+        const sourceProvenance = sourceProvenanceFromEvents(selectedRawEvents);
         const conversationId =
           options.conversationId || rawEvents.find((event) => event.conversationId)?.conversationId || null;
         const requestedOutputSchema = {
@@ -430,13 +491,14 @@ export function createContextForge(options = {}) {
           sessionId: options.sessionId,
           conversationId,
           provider: provider.name,
-          sourceEventCount: rawEvents.length,
+          sourceEventCount: selectedRawEvents.length,
           inputMetadata: {
-            rawEventIds: rawEvents.map((event) => event.id),
+            rawEventIds: selectedRawEvents.map((event) => event.id),
             previousCheckpointId: previousCheckpoint?.id || null,
             requestedOutputSchema,
             providerMetadata,
             sourceProvenance,
+            sourceEventWindow: distillWindow.metadata,
           },
         });
 
@@ -448,7 +510,7 @@ export function createContextForge(options = {}) {
               sessionId: options.sessionId,
               conversationId,
             },
-            rawEvents,
+            rawEvents: selectedRawEvents,
             previousCheckpoint,
             requestedOutputSchema,
           });
@@ -489,13 +551,15 @@ export function createContextForge(options = {}) {
           decisions: output.decisions,
           todos: output.todos,
           openQuestions: output.openQuestions,
-          sourceEventCount: output.sourceEventCount ?? rawEvents.length,
+          sourceEventCount: output.sourceEventCount ?? selectedRawEvents.length,
           provider: output.provider || provider.name,
           distillRunId: distillRun.id,
           metadata: {
             providerMetadata: output.metadata,
             memoryCandidates: output.memoryCandidates,
             sourceProvenance,
+            sourceRawEventIds: selectedRawEvents.map((event) => event.id),
+            sourceEventWindow: distillWindow.metadata,
           },
         });
 

--- a/src/ingest/claude_code.js
+++ b/src/ingest/claude_code.js
@@ -254,6 +254,8 @@ export async function ingestClaudeCodeFile(app, options = {}) {
     minEvents: options.minEvents,
     minIntervalMs: options.minIntervalMs,
     charThreshold: options.charThreshold,
+    maxEvents: options.maxEvents,
+    maxChars: options.maxChars,
   };
   const status = await app.sessionStatus(statusOptions);
   let checkpoint = null;
@@ -268,9 +270,11 @@ export async function ingestClaudeCodeFile(app, options = {}) {
         checkpoint = await app.distillCheckpoint({
           ...scopeOptions,
           sessionId: parsed.sessionId,
-          conversationId: parsed.conversationId,
-          provider: options.provider,
-        });
+        conversationId: parsed.conversationId,
+        provider: options.provider,
+        maxEvents: options.maxEvents,
+        maxChars: options.maxChars,
+      });
       } catch (error) {
         checkpointError = {
           message: error.message,

--- a/src/ingest/codex.js
+++ b/src/ingest/codex.js
@@ -257,6 +257,8 @@ export async function ingestCodexRolloutFile(app, options = {}) {
     minEvents: options.minEvents,
     minIntervalMs: options.minIntervalMs,
     charThreshold: options.charThreshold,
+    maxEvents: options.maxEvents,
+    maxChars: options.maxChars,
   };
   const status = await app.sessionStatus(statusOptions);
   let checkpoint = null;
@@ -271,9 +273,11 @@ export async function ingestCodexRolloutFile(app, options = {}) {
         checkpoint = await app.distillCheckpoint({
           ...scopeOptions,
           sessionId: parsed.sessionId,
-          conversationId: parsed.conversationId,
-          provider: options.provider,
-        });
+        conversationId: parsed.conversationId,
+        provider: options.provider,
+        maxEvents: options.maxEvents,
+        maxChars: options.maxChars,
+      });
       } catch (error) {
         checkpointError = {
           message: error.message,

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1324,6 +1324,7 @@ test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
   });
   assert.equal(statusBefore.rawEventCount, 2);
   assert.equal(statusBefore.eventsSinceLastCheckpoint, 2);
+  assert.equal(statusBefore.distillWindow.selectedEventCount, 2);
   assert.equal(statusBefore.latestCheckpointId, null);
   assert.equal(statusBefore.shouldDistill, false);
 
@@ -1363,6 +1364,7 @@ test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
   assert.equal(runs.length, 1);
   assert.equal(runs[0].status, 'succeeded');
   assert.equal(runs[0].outputMetadata.checkpointId, checkpoint.id);
+  assert.equal(runs[0].inputMetadata.sourceEventWindow.selectedEventCount, 2);
 
   const statusAfter = app.sessionStatus({
     scope: 'repo',
@@ -1372,7 +1374,76 @@ test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
   });
   assert.equal(statusAfter.latestCheckpointId, checkpoint.id);
   assert.equal(statusAfter.eventsSinceLastCheckpoint, 0);
+  assert.equal(statusAfter.distillWindow.selectedEventCount, 0);
   assert.equal(statusAfter.shouldDistill, false);
+});
+
+test('distillCheckpoint uses a bounded recent raw-event window', async () => {
+  const dataDir = await makeTempDir();
+  const seen = [];
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'window_provider',
+      CONTEXTFORGE_DISTILL_MAX_EVENTS: '3',
+      CONTEXTFORGE_DISTILL_MAX_CHARS: '60',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      window_provider: async (input) => {
+        seen.push(input.rawEvents.map((event) => event.content));
+        return {
+          summaryShort: 'Window checkpoint.',
+          summaryText: 'The provider saw a bounded recent raw-event window.',
+          decisions: [],
+          todos: [],
+          openQuestions: [],
+          memoryCandidates: [],
+          sourceEventCount: input.rawEvents.length,
+          metadata: { synthetic: true },
+        };
+      },
+    },
+  });
+
+  for (let index = 0; index < 6; index += 1) {
+    app.appendRaw({
+      scope: 'repo',
+      scopeKey: 'repo-window',
+      sessionId: 'window-session',
+      role: index % 2 === 0 ? 'user' : 'assistant',
+      content: `event-${index}`,
+    });
+  }
+
+  const status = app.sessionStatus({
+    scope: 'repo',
+    scopeKey: 'repo-window',
+    sessionId: 'window-session',
+  });
+  assert.equal(status.rawEventCount, 6);
+  assert.equal(status.distillWindow.candidateEventCount, 6);
+  assert.equal(status.distillWindow.selectedEventCount, 3);
+  assert.equal(status.distillWindow.truncated, true);
+
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-window',
+    sessionId: 'window-session',
+  });
+  assert.deepEqual(seen[0], ['event-3', 'event-4', 'event-5']);
+  assert.equal(checkpoint.sourceEventCount, 3);
+  assert.equal(checkpoint.metadata.sourceRawEventIds.length, 3);
+  assert.equal(checkpoint.metadata.sourceEventWindow.selectedEventCount, 3);
+  assert.equal(checkpoint.metadata.sourceEventWindow.truncated, true);
+
+  const runs = app.listDistillRuns({
+    scope: 'repo',
+    scopeKey: 'repo-window',
+    sessionId: 'window-session',
+  });
+  assert.equal(runs[0].inputMetadata.rawEventIds.length, 3);
+  assert.equal(runs[0].inputMetadata.sourceEventWindow.totalRawEventCount, 6);
 });
 
 test('distillCheckpoint rejects malformed provider output and preserves raw evidence', async () => {


### PR DESCRIPTION
Closes #52.

## Summary

- Add configurable distill window limits with CONTEXTFORGE_DISTILL_MAX_EVENTS and CONTEXTFORGE_DISTILL_MAX_CHARS.
- Select a bounded recent raw-event window for first and subsequent checkpoints instead of passing full large sessions.
- Surface distillWindow metadata in sessionStatus.
- Record sourceEventWindow and sourceRawEventIds on distill run input metadata and checkpoints.
- Pass maxEvents/maxChars through CLI and TUI ingest auto-distill paths.

## Verification

- npm test
- git diff --check
- npm pack --dry-run
- npm audit --audit-level=moderate
