### PR TITLE
Expose memory candidate promotion over MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   scopes.
 - Checkpoint distillation now uses bounded recent raw-event windows with
   configurable max event/character limits and records source window metadata.
+- MCP now exposes `promote_memory_candidate` so reviewed checkpoint candidates
+  can be promoted without manually copying candidate fields.
 - The remote server now exposes a Streamable HTTP MCP endpoint at `/mcp`, so
   agents on multiple machines can connect directly to the same canonical memory
   store without launching a local stdio MCP bridge.

--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ The MCP server exposes a narrow tool surface over the same core API:
 - `append_raw`
 - `distill_checkpoint`
 - `promote_memory`
+- `promote_memory_candidate`
 - `correct_memory`
 - `deactivate_memory`
 
@@ -554,9 +555,11 @@ only when they know the durable key they need, append raw evidence for later
 distillation, and call `remember` when the user or agent intentionally decides
 that an important fact, preference, decision, or runbook note should become
 durable memory. Use `promote_memory` only after a checkpoint candidate or
-decision has been reviewed. Use `correct_memory` to preserve the previous value
-while changing a durable key, and `deactivate_memory` to remove stale memories
-from retrieval without deleting their history.
+decision has been reviewed, or `promote_memory_candidate` when promoting a
+reviewed candidate directly by checkpoint id and candidate index. Use
+`correct_memory` to preserve the previous value while changing a durable key,
+and `deactivate_memory` to remove stale memories from retrieval without
+deleting their history.
 
 ## codex_exec Provider
 

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -246,6 +246,34 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
   );
 
   server.registerTool(
+    'promote_memory_candidate',
+    {
+      title: 'Promote Memory Candidate',
+      description:
+        'Promote a reviewed checkpoint memory candidate into intentional durable memory without copying candidate fields manually.',
+      inputSchema: {
+        ...scopedSchema,
+        checkpointId: z.string(),
+        sourceCandidateIndex: z.number().int().optional(),
+        sessionId: z.string().optional(),
+        key: z.string().optional(),
+        content: z.string().optional(),
+        category: z.string().optional(),
+        tags: optionalTags,
+        importance: z.number().int().optional(),
+        sourceRawEventIds: z.array(z.string()).optional(),
+        reason: z.string().optional(),
+      },
+      annotations: {
+        title: 'Promote Memory Candidate',
+        readOnlyHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.promoteMemoryCandidate(args)),
+  );
+
+  server.registerTool(
     'correct_memory',
     {
       title: 'Correct Memory',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1965,6 +1965,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'list_memory_candidates',
       'list_memory_events',
       'promote_memory',
+      'promote_memory_candidate',
       'remember',
       'search',
       'session_status',
@@ -2051,6 +2052,10 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       },
     });
     assert.equal(promotedResult.structuredContent.result.key, 'promoted-mcp-rule');
+
+    const candidateTool = toolList.tools.find((tool) => tool.name === 'promote_memory_candidate');
+    assert.ok(candidateTool.inputSchema.properties.checkpointId);
+    assert.ok(candidateTool.inputSchema.properties.sourceCandidateIndex);
   } finally {
     await client.close();
   }
@@ -2058,10 +2063,35 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
 
 test('MCP streamable HTTP endpoint exposes core tools with bearer auth', async () => {
   const dataDir = await makeTempDir();
-  const remote = await startContextForgeServer({
-    port: 0,
+  const app = createContextForge({
     env: {
       CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'candidate_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      candidate_provider: async () => ({
+        summaryShort: 'HTTP MCP candidate checkpoint.',
+        summaryText: 'The checkpoint contains one reviewed memory candidate.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'http-mcp-candidate',
+            content: 'HTTP MCP can promote memory candidates by checkpoint id.',
+            reason: 'Synthetic HTTP MCP candidate.',
+          },
+        ],
+        sourceEventCount: 1,
+        metadata: { synthetic: true },
+      }),
+    },
+  });
+  const remote = await startContextForgeServer({
+    app,
+    port: 0,
+    env: {
       CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
     },
   });
@@ -2099,9 +2129,40 @@ test('MCP streamable HTTP endpoint exposes core tools with bearer auth', async (
       },
     });
     assert.equal(searched.structuredContent.result[0].memory.key, 'http-mcp-rule');
+
+    await client.callTool({
+      name: 'append_raw',
+      arguments: {
+        scope: 'repo',
+        scopeKey: 'http-mcp-repo',
+        sessionId: 'http-mcp-session',
+        role: 'assistant',
+        content: 'Candidate: HTTP MCP can promote memory candidates by checkpoint id.',
+      },
+    });
+    const checkpoint = await client.callTool({
+      name: 'distill_checkpoint',
+      arguments: {
+        scope: 'repo',
+        scopeKey: 'http-mcp-repo',
+        sessionId: 'http-mcp-session',
+      },
+    });
+    const promoted = await client.callTool({
+      name: 'promote_memory_candidate',
+      arguments: {
+        scope: 'repo',
+        scopeKey: 'http-mcp-repo',
+        checkpointId: checkpoint.structuredContent.result.id,
+        sourceCandidateIndex: 0,
+        reason: 'Reviewed over HTTP MCP.',
+      },
+    });
+    assert.equal(promoted.structuredContent.result.key, 'http-mcp-candidate');
   } finally {
     await client.close();
     await remote.close();
+    app.close();
   }
 });
 


### PR DESCRIPTION
Closes #54.

## Summary

- Add promote_memory_candidate to the MCP tool surface.
- Include checkpoint/candidate index inputs plus optional durable memory overrides.
- Update README MCP tool list and agent guidance.
- Cover stdio schema exposure and HTTP MCP candidate promotion flow.

## Verification

- npm test
- git diff --check
- npm pack --dry-run
- npm audit --audit-level=moderate
