### PR TITLE
[codex] Add sqlite-vec embedding retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ data/
 # Local environment
 .env
 .env.*
-!.env.example
 
 # Logs
 *.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,9 @@ Private agent-memory systems may be useful reference material, but do not mutate
 - Store runtime data locally by default and keep it out of git.
 - Support `shared`, `repo`, and `local` scopes explicitly.
 - Treat checkpoints as recent continuity, not canonical truth.
+- Treat distilled checkpoints as compressed retrieval indexes: preserve
+  concrete names, numbers, intervals, APIs, paths, commands, error strings,
+  decisions, rationale, risks, conditions, next actions, and retrieval hooks.
 - Promote durable facts and decisions intentionally.
 
 ## Storage Modes
@@ -91,6 +94,16 @@ At task start, run a small bootstrap: search repo memory for this task, and
 search shared memory only when cross-repo or user-wide policy may matter. Use
 the inferred repo scope key, or an explicit `github.com/owner/repo` key when
 cross-machine continuity matters.
+
+Before relying on retrieval, distinguish storage authority. Remote ContextForge
+storage is canonical shared memory for the configured scope; local or
+project-local storage is machine/check-out local context unless the user says
+otherwise.
+
+Interpret search result types by trust level:
+- `memory`: reviewed durable fact or decision.
+- `checkpoint`: recent session continuity, not canonical truth.
+- `memory_candidate`: unreviewed promotion candidate and review material.
 
 Keep durable memory intentional. After distilling a checkpoint, review
 `list_memory_candidates` and promote only stable, reviewed facts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.2.0 - 2026-05-01
+
+- Added sqlite-vec backed derived embedding storage with startup `vec_version`
+  reporting in `dbInfo`.
+- Added OpenAI embeddings configuration with `text-embedding-3-small` defaults,
+  configurable dimensions, and server-side credential handling for remote mode.
+- Added `rebuildEmbeddings` across the core API, CLI, remote API, and MCP
+  `rebuild_embeddings` tool to backfill durable memories, checkpoints, and
+  memory candidates.
+- Added automatic checkpoint and memory-candidate embedding after successful
+  `distillCheckpoint` runs, while keeping embedding failures from erasing or
+  failing the checkpoint itself.
+- Expanded `search` so vector retrieval can return `memory`, `checkpoint`, and
+  `memory_candidate` result types with transparent vector distance/model
+  metadata.
+- Added the MCP `db_info` tool and updated MCP instructions so agents can
+  distinguish remote canonical storage from local/project-local context.
+- Upgraded the `codex_exec` distillation prompt/schema to v3 with required
+  `metadata.retrievalHooks`, making checkpoints act as compressed retrieval
+  indexes rather than generic summaries.
+- Documented remote-vs-local `AGENTS.md` snippets, search result trust levels,
+  server-side embeddings env placement, and checkpoint/candidate retrieval
+  behavior.
+
 ## 0.1.4 - 2026-04-26
 
 - Added candidate-id review workflows: `promoteMemoryCandidate --candidateId`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,28 @@
 - Added sqlite-vec backed derived embedding storage with startup `vec_version`
   reporting in `dbInfo`.
 - Added OpenAI embeddings configuration with `text-embedding-3-small` defaults,
-  configurable dimensions, and server-side credential handling for remote mode.
+  configurable dimensions, dimensions request gating for legacy models, and
+  server-side credential handling for remote mode.
 - Added `rebuildEmbeddings` across the core API, CLI, remote API, and MCP
   `rebuild_embeddings` tool to backfill durable memories, checkpoints, and
   memory candidates.
 - Added automatic checkpoint and memory-candidate embedding after successful
   `distillCheckpoint` runs, while keeping embedding failures from erasing or
-  failing the checkpoint itself.
+  failing the checkpoint itself and reporting partial write progress.
 - Expanded `search` so vector retrieval can return `memory`, `checkpoint`, and
   `memory_candidate` result types with transparent vector distance/model
-  metadata.
+  metadata, Korean/no-lexical-token vector fallback, lexical candidate unioning,
+  and normalized hybrid ranking.
+- Added a guard against silent vector-index drops when embedding dimensions
+  change; operators must run a forced rebuild to reset the derived index.
 - Added the MCP `db_info` tool and updated MCP instructions so agents can
   distinguish remote canonical storage from local/project-local context.
 - Upgraded the `codex_exec` distillation prompt/schema to v3 with required
   `metadata.retrievalHooks`, making checkpoints act as compressed retrieval
   indexes rather than generic summaries.
 - Documented remote-vs-local `AGENTS.md` snippets, search result trust levels,
-  server-side embeddings env placement, and checkpoint/candidate retrieval
-  behavior.
+  server-side embeddings env placement, sqlite-vec compatibility notes, and
+  checkpoint/candidate retrieval behavior.
 
 ## 0.1.4 - 2026-04-26
 

--- a/README.md
+++ b/README.md
@@ -265,12 +265,35 @@ CONTEXTFORGE_RAW_TTL_DAYS=30
 CONTEXTFORGE_DISTILL_PROVIDER=codex_exec
 CONTEXTFORGE_CODEX_EXEC_MODEL=gpt-5.4-mini
 CONTEXTFORGE_CODEX_EXEC_REASONING_EFFORT=low
+CONTEXTFORGE_EMBEDDINGS_PROVIDER=openai
+CONTEXTFORGE_OPENAI_API_KEY=sk-...
+CONTEXTFORGE_EMBEDDINGS_MODEL=text-embedding-3-small
+CONTEXTFORGE_EMBEDDINGS_DIMENSIONS=1536
+CONTEXTFORGE_EMBEDDINGS_TIMEOUT_MS=30000
 ```
 
 Use a long random token and store the same value on client machines as
 `CONTEXTFORGE_REMOTE_TOKEN`. Treat this token as an administrator credential:
 it can call every remote API method, including pruning raw evidence and running
 provider health checks. Do not put this file in git.
+
+`CONTEXTFORGE_OPENAI_API_KEY` is only needed on the process that performs
+embedding calls. In remote/server-backed deployments, keep that key only in the
+server environment file. Clients that call the remote server need
+`CONTEXTFORGE_REMOTE_TOKEN`, not the OpenAI key.
+
+If you run the remote server as a systemd user service instead of a system
+service, use the same variable names in a private user env file such as:
+
+```text
+~/.config/contextforge/server.env
+```
+
+and point the user unit at it:
+
+```ini
+EnvironmentFile=%h/.config/contextforge/server.env
+```
 
 5. Install a systemd service:
 
@@ -359,6 +382,18 @@ layer already provides encryption and access control. The bearer token protects
 the ContextForge API, but it is not a replacement for TLS on untrusted networks
 or for operator-only handling of admin-capable credentials.
 
+When embeddings are enabled on the server, successful `distillCheckpoint` calls
+immediately embed the new checkpoint and any memory candidates from that
+checkpoint into the derived sqlite-vec index. The canonical tables remain
+SQLite memory/checkpoint tables; the vector index is rebuildable with:
+
+```bash
+node src/cli.js rebuildEmbeddings --scope repo --scopeKey github.com/example/repo
+```
+
+If embedding fails after a successful distillation, the checkpoint remains
+stored and the result reports `embedding.reason = "embedding_failed"`.
+
 After the VPS is healthy, configure each laptop, desktop, or agent host with
 the same URL and bearer token using the next section.
 
@@ -385,6 +420,8 @@ chmod 600 ~/.config/contextforge/server.env
 ```
 
 Do not commit this file. Use the token configured on the remote server.
+Do not put `CONTEXTFORGE_OPENAI_API_KEY` on client machines unless they also run
+ContextForge in local/project-local mode and perform embeddings directly.
 
 3. Register the remote HTTP MCP endpoint with Codex:
 
@@ -1042,9 +1079,11 @@ For agent prompt or `AGENTS.md` guidance, see
 [ContextForge Agent Instructions](docs/agent-instructions.md). That guide
 covers startup bootstrap, retrieval order, repo scope keys, checkpoint
 candidate review, durable memory promotion, raw evidence retention, and
-distillation cost discipline. Keep repository `AGENTS.md` files short: include
-only a small ContextForge bootstrap snippet and link to the longer guide instead
-of copying every MCP rule into each project.
+distillation cost discipline. It also includes separate `AGENTS.md` snippets
+for remote-canonical deployments and local/project-local stores. Keep
+repository `AGENTS.md` files short: include only a small ContextForge bootstrap
+snippet and link to the longer guide instead of copying every MCP rule into
+each project.
 
 ## codex_exec Provider
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,11 @@ CONTEXTFORGE_EMBEDDINGS_DIMENSIONS=1536
 CONTEXTFORGE_EMBEDDINGS_TIMEOUT_MS=30000
 ```
 
+The default and recommended embedding model is `text-embedding-3-small`.
+`CONTEXTFORGE_EMBEDDINGS_DIMENSIONS` is sent to OpenAI only for
+`text-embedding-3-*` models; legacy models such as `text-embedding-ada-002` do
+not support that request field and must return the configured dimension count.
+
 Use a long random token and store the same value on client machines as
 `CONTEXTFORGE_REMOTE_TOKEN`. Treat this token as an administrator credential:
 it can call every remote API method, including pruning raw evidence and running
@@ -392,7 +397,24 @@ node src/cli.js rebuildEmbeddings --scope repo --scopeKey github.com/example/rep
 ```
 
 If embedding fails after a successful distillation, the checkpoint remains
-stored and the result reports `embedding.reason = "embedding_failed"`.
+stored and the result reports `embedding.reason = "embedding_failed"`. If some
+rows were already written before the failure, the response also includes
+`embedding.embedded`, `embedding.bySourceType`, and
+`embedding.partialFailure = true` so operators can see the partial DB state.
+
+If the configured embedding dimensions change, ContextForge refuses to silently
+drop the existing vector index. Run a forced rebuild only when you intentionally
+want to reset and repopulate the derived sqlite-vec tables:
+
+```bash
+node src/cli.js rebuildEmbeddings --scope repo --scopeKey github.com/example/repo --force
+```
+
+ContextForge uses the npm `sqlite-vec` package and expects sqlite-vec 0.1.x with
+`vec0` support for auxiliary primary-key columns. Check `node src/cli.js dbInfo`
+for `vector.sqliteVecAvailable`, `vector.sqliteVecVersion`, and any load error.
+The package is routinely used on Linux and macOS; platform SQLite build options
+can affect extension loading.
 
 After the VPS is healthy, configure each laptop, desktop, or agent host with
 the same URL and bearer token using the next section.

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -342,4 +342,6 @@ Prefer distilling at meaningful boundaries:
 - `list_memory_events`: inspect memory provenance.
 - `prune_raw_events`: manually prune raw evidence older than the configured TTL.
 - `rebuild_embeddings`: backfill or rebuild the derived vector index for
-  durable memories, checkpoints, and memory candidates.
+  durable memories, checkpoints, and memory candidates. If embedding dimensions
+  changed, pass `force=true` only when the operator intentionally wants to reset
+  the derived sqlite-vec index.

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -14,8 +14,15 @@ repo scope with repoPath, cwd, or an explicit scopeKey, then search durable
 memory for the current repo and, when useful, shared scope. Prefer canonical
 GitHub scope keys such as github.com/owner/repo.
 
-Treat durable memories as reviewed facts, decisions, preferences, and runbook
-notes. Do not treat checkpoints or raw evidence as canonical truth.
+Before relying on results, identify whether ContextForge is using remote
+canonical storage or local/project-local storage. Remote results are shared
+ContextForge state for the configured scope. Local/project-local results are
+machine-local context unless the user says that store is authoritative.
+
+Interpret search result types carefully:
+- `memory`: reviewed durable fact, decision, preference, or runbook note.
+- `checkpoint`: recent session continuity, not canonical truth.
+- `memory_candidate`: unreviewed promotion candidate, useful for review.
 
 Use search first. Use get_memory only when you know the exact key. Use local
 scope only when the memory is machine-specific or explicitly requested.
@@ -56,6 +63,12 @@ At task start, run a small bootstrap: search repo memory for this task, and
 search shared memory only when cross-repo/user-wide policy may matter. Use
 scopeKey github.com/example/repo unless the user says otherwise.
 
+Check whether ContextForge is remote canonical storage or local/project-local
+storage before treating retrieval results as shared state.
+
+Interpret search result types by trust level: memory is reviewed durable state,
+checkpoint is recent continuity, and memory_candidate is review material.
+
 Keep durable memory intentional. After distilling a checkpoint, review
 list_memory_candidates and promote only stable, reviewed facts.
 
@@ -67,6 +80,57 @@ If an agent environment supports external instruction references, prefer a link
 to this file over copying it. If it does not, copy only the short snippet above
 and rely on MCP `search` for detailed, scoped guidance.
 
+## AGENTS.md Examples
+
+Use a remote-canonical snippet when the repo should share memory across
+machines, agents, or deployment hosts:
+
+```text
+Use ContextForge MCP for scoped project memory.
+
+This repo uses remote ContextForge as the canonical shared memory store. At
+task start, call db_info if storage authority is unclear, then search repo
+scope for this task. Use scopeKey github.com/example/repo unless the user says
+otherwise. Search shared scope only for user-wide policy, deployment,
+credential-location, or cross-repo conventions.
+
+Interpret search result types by trust level:
+- memory: reviewed durable fact or decision.
+- checkpoint: recent session continuity; verify important claims before acting.
+- memory_candidate: unreviewed promotion candidate and review material.
+
+When distilling, treat checkpoints as compressed retrieval indexes. Preserve
+concrete names, numbers, intervals, APIs, paths, commands, errors, decisions,
+rationale, risks, conditions, next actions, and retrieval hooks. After
+distill_checkpoint, review list_memory_candidates and promote only stable,
+reviewed facts.
+
+Do not store secrets in memory. In remote mode, provider credentials such as
+OpenAI embedding keys belong on the ContextForge server, not in this repo.
+```
+
+Use a local or project-local snippet when the repo intentionally keeps memory
+inside the current machine or checkout:
+
+```text
+Use ContextForge MCP for scoped local project memory.
+
+This repo uses local/project-local ContextForge storage. Treat retrieval as
+machine-local context, not shared canonical memory, unless the user explicitly
+says this store is authoritative. At task start, call db_info when storage mode
+matters, then search repo scope for this task. Use local scope only for
+machine-specific notes.
+
+Interpret search result types by trust level:
+- memory: reviewed durable fact for this local store.
+- checkpoint: recent continuity from this machine/check-out.
+- memory_candidate: unreviewed promotion candidate and review material.
+
+Before making deployment or cross-machine claims, verify against current code,
+runtime, remote memory, or user confirmation. Keep durable memory intentional:
+promote only stable, scoped, non-secret facts.
+```
+
 ## Startup Bootstrap
 
 At the beginning of a non-trivial project task, do a small bootstrap instead of
@@ -74,12 +138,14 @@ loading a large memory dump.
 
 1. Resolve the intended scope. Use `scope: "repo"` with `repoPath`, `cwd`, or an
    explicit `scopeKey`.
-2. Search repo durable memory with a query derived from the user's task.
-3. Search shared durable memory only if user-wide conventions, deployment
+2. Call `db_info` when storage mode, remote/local authority, schema version, raw
+   retention, or vector readiness may affect the task.
+3. Search repo scope with a query derived from the user's task.
+4. Search shared scope only if user-wide conventions, deployment
    policy, credentials locations, or cross-repo decisions may matter.
-4. If resuming a known session, call `session_status` for that `sessionId` to
+5. If resuming a known session, call `session_status` for that `sessionId` to
    inspect recent checkpoint state.
-5. If the task depends on recent handoff state, call `list_memory_candidates`
+6. If the task depends on recent handoff state, call `list_memory_candidates`
    for the relevant session or checkpoint and review candidates before
    promoting anything.
 
@@ -98,18 +164,56 @@ Example bootstrap sequence:
 
 For most coding tasks, use this order:
 
-1. `search` repo scope for the active project.
-2. `search` shared scope if the task may depend on user-wide or organization
+1. `db_info` when you need to know whether the server is remote canonical
+   storage or local/project-local storage.
+2. `search` repo scope for the active project.
+3. `search` shared scope if the task may depend on user-wide or organization
    conventions.
-3. `get_memory` only for exact durable keys returned by search or supplied by
+4. `get_memory` only for exact durable keys returned by search or supplied by
    the user.
-4. Use checkpoint candidates only as review material, not as canonical memory.
-5. Avoid raw evidence unless debugging distillation, reconstructing provenance,
+5. Use checkpoints for recent continuity, not canonical truth.
+6. Use memory candidates only as review material, not as canonical memory.
+7. Avoid raw evidence unless debugging distillation, reconstructing provenance,
    or explicitly asked.
 
 When the agent process starts outside the target checkout, pass `repoPath` or
 `cwd` on scoped calls. For cross-machine continuity, prefer an explicit
 `scopeKey`, for example `github.com/example/service`.
+
+## Storage Authority
+
+ContextForge can run in `local`, `project-local`, or `remote` storage mode.
+Agents should not treat these modes as equivalent.
+
+- `remote`: server-backed canonical memory for multiple machines or agents.
+  Treat retrieved `memory` results as shared reviewed state for the configured
+  scope. OpenAI embedding keys and canonical SQLite storage should live on the
+  server side.
+- `local`: single-machine storage. Treat results as useful local context, not
+  shared deployment memory, unless the user confirms this host is the intended
+  authority.
+- `project-local`: repo-bound storage in a gitignored directory. Treat results
+  as checkout-local context. Do not assume other machines or agents can see it.
+
+Use `db_info` to inspect the active backend and sqlite-vec readiness. If a
+client is configured for remote mode, clients normally need the remote bearer
+token only; embedding provider credentials belong to the remote server process.
+
+## Search Result Types
+
+`search` can return multiple result types. The type is part of the trust model.
+
+- `memory`: reviewed durable memory. These are the best retrieval results for
+  decisions, preferences, and reusable runbook facts.
+- `checkpoint`: LLM-distilled recent continuity from one session. Use it to
+  resume work and understand recent context, then verify important claims
+  against current code, status, or durable memory.
+- `memory_candidate`: a checkpoint-generated candidate that might deserve
+  promotion. Use it as review material. Do not treat it as final truth until it
+  is promoted or rewritten as durable memory.
+
+Vector-backed checkpoint and candidate hits are useful for "what happened last
+time?" queries. They are intentionally not a replacement for durable memory.
 
 ## Writing Memory
 
@@ -137,6 +241,16 @@ longer appear in retrieval, while preserving provenance.
 
 Checkpoints are recent continuity. They are useful for handoff, but they are
 not canonical truth.
+
+Good checkpoints are compressed retrieval indexes, not generic summaries. They
+should preserve the names, numbers, intervals, commands, paths, APIs, error
+strings, issue numbers, and domain terms that a future agent is likely to
+search for. A useful checkpoint keeps decision, rationale, risks, conditions,
+and next action together when the raw evidence supports them.
+
+Distillation providers should populate `metadata.retrievalHooks` with concise
+future-search keywords. Those hooks are embedded with the checkpoint so later
+queries can find the right session even when the exact summary wording differs.
 
 After `distill_checkpoint`, call `list_memory_candidates` for the same
 `sessionId` or `checkpointId` when:
@@ -204,7 +318,11 @@ Prefer distilling at meaningful boundaries:
 
 ## Tool Summary
 
-- `search`: retrieve reviewed durable memories.
+- `db_info`: inspect storage mode, table counts, raw retention, schema version,
+  and sqlite-vec/embedding readiness.
+- `search`: retrieve scoped results. Results can include reviewed durable
+  `memory`, recent-continuity `checkpoint`, and unreviewed
+  `memory_candidate` records.
 - `get_memory`: load one known durable memory by key.
 - `remember`: write a reviewed durable memory.
 - `correct_memory`: update a durable memory while preserving provenance.
@@ -223,3 +341,5 @@ Prefer distilling at meaningful boundaries:
 - `promote_memory`: promote a reviewed fact with explicit provenance.
 - `list_memory_events`: inspect memory provenance.
 - `prune_raw_events`: manually prune raw evidence older than the configured TTL.
+- `rebuild_embeddings`: backfill or rebuild the derived vector index for
+  durable memories, checkpoints, and memory candidates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,22 @@
 {
   "name": "contextforge",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contextforge",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.9.0",
+        "sqlite-vec": "^0.1.9",
         "zod": "^4.3.6"
       },
       "bin": {
         "contextforge": "src/cli.js",
+        "contextforge-mcp": "src/mcp.js",
         "contextforge-server": "src/server.js"
       },
       "engines": {
@@ -1421,6 +1423,84 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "node_modules/sqlite-vec": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.9.tgz",
+      "integrity": "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==",
+      "license": "MIT OR Apache",
+      "optionalDependencies": {
+        "sqlite-vec-darwin-arm64": "0.1.9",
+        "sqlite-vec-darwin-x64": "0.1.9",
+        "sqlite-vec-linux-arm64": "0.1.9",
+        "sqlite-vec-linux-x64": "0.1.9",
+        "sqlite-vec-windows-x64": "0.1.9"
+      }
+    },
+    "node_modules/sqlite-vec-darwin-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.9.tgz",
+      "integrity": "sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-darwin-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.9.tgz",
+      "integrity": "sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.9.tgz",
+      "integrity": "sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.9.tgz",
+      "integrity": "sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-windows-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.9.tgz",
+      "integrity": "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contextforge",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Self-hosted memory and distillation runtime for coding agents.",
   "type": "module",
   "bin": {
@@ -40,6 +40,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.9.0",
+    "sqlite-vec": "^0.1.9",
     "zod": "^4.3.6"
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -114,6 +114,8 @@ function toCoreOptions(options) {
     intervalMs: options.intervalMs == null ? undefined : Number(options.intervalMs),
     iterations: options.iterations == null ? undefined : Number(options.iterations),
     charsPerToken: options.charsPerToken == null ? undefined : Number(options.charsPerToken),
+    batchSize: options.batchSize == null ? undefined : Number(options.batchSize),
+    force: options.force === true || options.force === 'true',
   };
 }
 
@@ -137,6 +139,7 @@ async function main() {
     listMemoryEvents: (app, coreOptions) => app.listMemoryEvents(coreOptions),
     listMemoryCandidates: (app, coreOptions) => app.listMemoryCandidates(coreOptions),
     search: (app, coreOptions) => app.search(coreOptions),
+    rebuildEmbeddings: (app, coreOptions) => app.rebuildEmbeddings(coreOptions),
     getMemory: (app, coreOptions) => app.getMemory(coreOptions),
     appendRaw: (app, coreOptions) => app.appendRaw(coreOptions),
     listRawEvents: (app, coreOptions) => app.listRawEvents(coreOptions),

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -5,6 +5,7 @@ import { createHash } from 'node:crypto';
 
 const VALID_SCOPES = new Set(['shared', 'repo', 'local']);
 const VALID_STORAGE_MODES = new Set(['local', 'project-local', 'remote']);
+const VALID_EMBEDDINGS_PROVIDERS = new Set(['none', 'openai']);
 
 function parsePositiveInteger(value, name, fallback) {
   if (value == null || value === '') {
@@ -169,6 +170,15 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
     'CONTEXTFORGE_CODEX_EXEC_MAX_INPUT_CHARS',
     12000,
   );
+  const embeddingsProvider = env.CONTEXTFORGE_EMBEDDINGS_PROVIDER || (env.CONTEXTFORGE_OPENAI_API_KEY || env.OPENAI_API_KEY ? 'openai' : 'none');
+  if (!VALID_EMBEDDINGS_PROVIDERS.has(embeddingsProvider)) {
+    throw new Error(`Invalid CONTEXTFORGE_EMBEDDINGS_PROVIDER: ${embeddingsProvider}`);
+  }
+  const embeddingsDimensions = parsePositiveInteger(
+    env.CONTEXTFORGE_EMBEDDINGS_DIMENSIONS,
+    'CONTEXTFORGE_EMBEDDINGS_DIMENSIONS',
+    1536,
+  );
   const distillMinIntervalMs = parsePositiveInteger(
     env.CONTEXTFORGE_DISTILL_MIN_INTERVAL_MS,
     'CONTEXTFORGE_DISTILL_MIN_INTERVAL_MS',
@@ -186,6 +196,18 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
     defaultScopeKey,
     defaultSharedScopeKey,
     distillProvider: env.CONTEXTFORGE_DISTILL_PROVIDER || 'mock',
+    embeddings: {
+      provider: embeddingsProvider,
+      model: env.CONTEXTFORGE_EMBEDDINGS_MODEL || 'text-embedding-3-small',
+      dimensions: embeddingsDimensions,
+      apiKey: env.CONTEXTFORGE_OPENAI_API_KEY || env.OPENAI_API_KEY || null,
+      baseUrl: env.CONTEXTFORGE_OPENAI_BASE_URL || 'https://api.openai.com/v1',
+      timeoutMs: parsePositiveInteger(
+        env.CONTEXTFORGE_EMBEDDINGS_TIMEOUT_MS,
+        'CONTEXTFORGE_EMBEDDINGS_TIMEOUT_MS',
+        30000,
+      ),
+    },
     remote: {
       url: env.CONTEXTFORGE_REMOTE_URL || null,
       token: env.CONTEXTFORGE_REMOTE_TOKEN || null,

--- a/src/core.js
+++ b/src/core.js
@@ -431,23 +431,32 @@ export function createContextForge(options = {}) {
     store.ensureEmbeddingIndex(embeddingProvider.dimensions);
     let embedded = 0;
     const bySourceType = {};
-    for (let index = 0; index < sources.length; index += batchSize) {
-      const batch = sources.slice(index, index + batchSize);
-      const embeddings = await embeddingProvider.embed(batch.map((source) => source.text));
-      for (const [offset, source] of batch.entries()) {
-        store.upsertEmbedding({
-          sourceType: source.sourceType,
-          recordId: source.recordId,
-          scopeType: source.scopeType,
-          scopeKey: source.scopeKey,
-          model: embeddingProvider.model,
-          dimensions: embeddingProvider.dimensions,
-          contentHash: source.contentHash,
-          embedding: embeddings[offset],
-        });
-        embedded += 1;
-        bySourceType[source.sourceType] = (bySourceType[source.sourceType] || 0) + 1;
+    try {
+      for (let index = 0; index < sources.length; index += batchSize) {
+        const batch = sources.slice(index, index + batchSize);
+        const embeddings = await embeddingProvider.embed(batch.map((source) => source.text));
+        for (const [offset, source] of batch.entries()) {
+          store.upsertEmbedding({
+            sourceType: source.sourceType,
+            recordId: source.recordId,
+            scopeType: source.scopeType,
+            scopeKey: source.scopeKey,
+            model: embeddingProvider.model,
+            dimensions: embeddingProvider.dimensions,
+            contentHash: source.contentHash,
+            embedding: embeddings[offset],
+          });
+          embedded += 1;
+          bySourceType[source.sourceType] = (bySourceType[source.sourceType] || 0) + 1;
+        }
       }
+    } catch (error) {
+      error.embeddingProgress = {
+        scanned: sources.length,
+        embedded,
+        bySourceType,
+      };
+      throw error;
     }
     return {
       provider: embeddingProvider.name,
@@ -457,6 +466,25 @@ export function createContextForge(options = {}) {
       embedded,
       bySourceType,
       skipped: false,
+    };
+  }
+
+  function embeddingFailureResult(error) {
+    const progress = error.embeddingProgress || {};
+    return {
+      provider: embeddingProvider.name,
+      model: embeddingProvider.model,
+      dimensions: embeddingProvider.dimensions,
+      scanned: progress.scanned ?? null,
+      embedded: progress.embedded || 0,
+      bySourceType: progress.bySourceType || {},
+      skipped: false,
+      partialFailure: Boolean(progress.embedded),
+      reason: 'embedding_failed',
+      error: {
+        name: error.name,
+        message: error.message,
+      },
     };
   }
 
@@ -819,6 +847,9 @@ export function createContextForge(options = {}) {
 
     async rebuildEmbeddings(options = {}) {
       const scope = normalizeScopeOptions(options, config);
+      if ((options.scope == null || options.scope === '') !== (options.scopeKey == null || options.scopeKey === '')) {
+        throw new Error('rebuildEmbeddings requires both scope and scopeKey when either option is provided.');
+      }
       if (!embeddingProvider) {
         return {
           provider: config.embeddings.provider,
@@ -829,10 +860,11 @@ export function createContextForge(options = {}) {
       }
       const batchSize = positiveNumber(options.batchSize == null ? 32 : Number(options.batchSize), 'batchSize');
       return useStore(async (store) => {
-        store.ensureEmbeddingIndex(embeddingProvider.dimensions);
+        store.ensureEmbeddingIndex(embeddingProvider.dimensions, { resetOnDimensionChange: truthyOption(options.force) });
+        const shouldNarrowScope = Boolean(options.scope || options.scopeKey || options.cwd || options.repoPath);
         const sourceOptions = {
-          scopeType: options.scope ? scope.scopeType : null,
-          scopeKey: options.scope || options.scopeKey || options.cwd || options.repoPath ? scope.scopeKey : null,
+          scopeType: shouldNarrowScope ? scope.scopeType : null,
+          scopeKey: shouldNarrowScope ? scope.scopeKey : null,
           model: embeddingProvider.model,
           dimensions: embeddingProvider.dimensions,
           force: truthyOption(options.force),
@@ -1035,19 +1067,7 @@ export function createContextForge(options = {}) {
               { batchSize: 32 },
             );
           } catch (error) {
-            embedding = {
-              provider: embeddingProvider.name,
-              model: embeddingProvider.model,
-              dimensions: embeddingProvider.dimensions,
-              skipped: true,
-              reason: 'embedding_failed',
-              embedded: 0,
-              bySourceType: {},
-              error: {
-                name: error.name,
-                message: error.message,
-              },
-            };
+            embedding = embeddingFailureResult(error);
           }
         }
 

--- a/src/core.js
+++ b/src/core.js
@@ -3,6 +3,7 @@ import { loadConfig } from './config/index.js';
 import { createDistillProvider } from './distill/index.js';
 import { checkCodexExecProvider } from './distill/providers/codex_exec.js';
 import { validateDistillOutput } from './distill/validate.js';
+import { createEmbeddingProvider } from './embeddings/index.js';
 import { createRemoteContextForge } from './remote/client.js';
 import { searchMemories } from './retrieval/search.js';
 import { normalizeScopeOptions } from './scopes/index.js';
@@ -390,6 +391,9 @@ export function createContextForge(options = {}) {
 
   const sharedStore = options.store || (options.reuseStore ? new ContextForgeStore({ dataDir: config.dataDir }) : null);
   const distillProviders = options.distillProviders || {};
+  const embeddingProvider = createEmbeddingProvider(config, options.embeddingProviders || {}, {
+    fetchImpl: options.fetchImpl,
+  });
   const codexExec = {
     ...config.codexExec,
     runner: options.codexExecRunner,
@@ -414,6 +418,48 @@ export function createContextForge(options = {}) {
     return store.pruneRawEventsOlderThan(rawTtlCutoffIso(config.rawRetention.ttlDays, now));
   }
 
+  async function embedSources(store, sources, { batchSize = 32 } = {}) {
+    if (!embeddingProvider) {
+      return {
+        provider: config.embeddings.provider,
+        skipped: true,
+        reason: 'embeddings_disabled',
+        embedded: 0,
+        bySourceType: {},
+      };
+    }
+    store.ensureEmbeddingIndex(embeddingProvider.dimensions);
+    let embedded = 0;
+    const bySourceType = {};
+    for (let index = 0; index < sources.length; index += batchSize) {
+      const batch = sources.slice(index, index + batchSize);
+      const embeddings = await embeddingProvider.embed(batch.map((source) => source.text));
+      for (const [offset, source] of batch.entries()) {
+        store.upsertEmbedding({
+          sourceType: source.sourceType,
+          recordId: source.recordId,
+          scopeType: source.scopeType,
+          scopeKey: source.scopeKey,
+          model: embeddingProvider.model,
+          dimensions: embeddingProvider.dimensions,
+          contentHash: source.contentHash,
+          embedding: embeddings[offset],
+        });
+        embedded += 1;
+        bySourceType[source.sourceType] = (bySourceType[source.sourceType] || 0) + 1;
+      }
+    }
+    return {
+      provider: embeddingProvider.name,
+      model: embeddingProvider.model,
+      dimensions: embeddingProvider.dimensions,
+      scanned: sources.length,
+      embedded,
+      bySourceType,
+      skipped: false,
+    };
+  }
+
   return {
     config,
 
@@ -426,6 +472,12 @@ export function createContextForge(options = {}) {
     dbInfo() {
       return useStore((store) => ({
         ...store.dbInfo(),
+        embeddings: {
+          provider: config.embeddings.provider,
+          model: config.embeddings.model,
+          dimensions: config.embeddings.dimensions,
+          enabled: Boolean(embeddingProvider),
+        },
         rawRetention: {
           ttlDays: config.rawRetention.ttlDays,
           pruneIntervalMs: config.rawRetention.pruneIntervalMs,
@@ -747,15 +799,51 @@ export function createContextForge(options = {}) {
     search(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.query, 'query');
-      return useStore((store) =>
+      const runSearch = (store, queryEmbedding = null) =>
         searchMemories(store, {
           ...scope,
           query: options.query,
           limit: options.limit,
           searchScopes: options.searchScopes,
           sharedScopeKey: options.sharedScopeKey || config.defaultSharedScopeKey,
-        }),
-      );
+          queryEmbedding,
+        });
+      if (!embeddingProvider) {
+        return useStore((store) => runSearch(store));
+      }
+      return useStore(async (store) => {
+        const [queryEmbedding] = await embeddingProvider.embed([options.query]);
+        return runSearch(store, queryEmbedding);
+      });
+    },
+
+    async rebuildEmbeddings(options = {}) {
+      const scope = normalizeScopeOptions(options, config);
+      if (!embeddingProvider) {
+        return {
+          provider: config.embeddings.provider,
+          skipped: true,
+          reason: 'embeddings_disabled',
+          embedded: 0,
+        };
+      }
+      const batchSize = positiveNumber(options.batchSize == null ? 32 : Number(options.batchSize), 'batchSize');
+      return useStore(async (store) => {
+        store.ensureEmbeddingIndex(embeddingProvider.dimensions);
+        const sourceOptions = {
+          scopeType: options.scope ? scope.scopeType : null,
+          scopeKey: options.scope || options.scopeKey || options.cwd || options.repoPath ? scope.scopeKey : null,
+          model: embeddingProvider.model,
+          dimensions: embeddingProvider.dimensions,
+          force: truthyOption(options.force),
+        };
+        const sources = [
+          ...store.listMemoryEmbeddingSources(sourceOptions),
+          ...store.listCheckpointEmbeddingSources(sourceOptions),
+          ...store.listMemoryCandidateEmbeddingSources(sourceOptions),
+        ];
+        return embedSources(store, sources, { batchSize });
+      });
     },
 
     appendRaw(options) {
@@ -925,9 +1013,48 @@ export function createContextForge(options = {}) {
           },
         });
 
+        let embedding = {
+          provider: config.embeddings.provider,
+          skipped: true,
+          reason: 'embeddings_disabled',
+          embedded: 0,
+          bySourceType: {},
+        };
+        if (embeddingProvider) {
+          try {
+            const candidates = store.listMemoryCandidates({
+              ...scope,
+              checkpointId: checkpoint.id,
+            });
+            embedding = await embedSources(
+              store,
+              [
+                store.embeddingSourceForCheckpoint(checkpoint),
+                ...candidates.map((candidate) => store.embeddingSourceForMemoryCandidate(candidate)),
+              ],
+              { batchSize: 32 },
+            );
+          } catch (error) {
+            embedding = {
+              provider: embeddingProvider.name,
+              model: embeddingProvider.model,
+              dimensions: embeddingProvider.dimensions,
+              skipped: true,
+              reason: 'embedding_failed',
+              embedded: 0,
+              bySourceType: {},
+              error: {
+                name: error.name,
+                message: error.message,
+              },
+            };
+          }
+        }
+
         return {
           ...checkpoint,
           memoryCandidateCount: output.memoryCandidates.length,
+          embedding,
         };
       });
     },

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -3,8 +3,8 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v1';
-export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v2';
+export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v3';
+export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v3';
 
 const OUTPUT_SCHEMA = {
   $id: CODEX_EXEC_OUTPUT_SCHEMA_VERSION,
@@ -67,9 +67,15 @@ const OUTPUT_SCHEMA = {
     metadata: {
       type: 'object',
       additionalProperties: false,
-      required: ['providerNotes'],
+      required: ['providerNotes', 'retrievalHooks'],
       properties: {
         providerNotes: { type: 'string' },
+        retrievalHooks: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Concrete future-search hooks preserved from the evidence: product names, APIs, commands, paths, error names, issue numbers, model names, time intervals, thresholds, and domain keywords.',
+        },
       },
     },
   },
@@ -151,9 +157,23 @@ export function buildCodexExecPrompt(input, options = {}) {
       'Do not include Markdown, code fences, commentary, or private assumptions.',
       'Preserve uncertainty in openQuestions instead of inventing facts.',
       'Use only the raw events and previous checkpoint supplied in this request.',
+      'Write the checkpoint as recent continuity for handoff and search, not as canonical durable truth.',
+      'Optimize the checkpoint for future retrieval, not for a generic meeting-summary style. Preserve concrete hooks a future agent might search for.',
+      'Preserve proper nouns, API names, command names, file paths, issue or PR numbers, model names, error strings, numeric thresholds, time intervals, and cadence details when they matter.',
+      'Distinguish decision, rationale, risks, conditions, and next action. Do not say only that a topic was discussed.',
+      'Include why a direction was chosen, not only what was chosen.',
+      'If a failure, bug, or risk was identified, name it concretely and include the suspected cause and affected path when known.',
+      'For conditional guidance, include the condition under which the decision applies.',
+      'The checkpoint should let a future agent continue without rereading raw evidence for ordinary follow-up work.',
+      'Do not copy secrets, tokens, private customer data, or large raw logs into summaries or memoryCandidates.',
+      'Populate metadata.retrievalHooks with concise search keywords from the evidence, such as API names, commands, paths, issue numbers, model names, intervals, thresholds, and error names.',
       'For memoryCandidates, include v2 review fields when useful: candidateType, confidence, stability, sensitivity, promotionRecommendation, and sourceEventIds.',
       'For nullable memoryCandidate fields that are not applicable, return null; do not omit required schema fields.',
+      'Create memoryCandidates only for facts, decisions, preferences, runbook steps, or failure modes that may remain useful beyond this checkpoint.',
+      'For memoryCandidate content, include decision plus rationale when both exist; put future-search keywords in tags and reason instead of flattening them away.',
       'Set promotionRecommendation to promote only for stable, reviewed-looking durable facts; otherwise prefer review, ignore, or reject.',
+      'Use low confidence or low stability for guesses, temporary state, implementation-in-progress details, and facts that require current runtime verification.',
+      'Use sensitivity high or restricted for any candidate that might contain secrets, personal data, customer data, private runtime paths, or credentials, and do not recommend promotion for it.',
     ],
     session: input.session,
     requestedOutputSchema: input.requestedOutputSchema,

--- a/src/embeddings/index.js
+++ b/src/embeddings/index.js
@@ -1,0 +1,88 @@
+export function createEmbeddingProvider(config, providers = {}, { fetchImpl = globalThis.fetch } = {}) {
+  const embeddingConfig = config.embeddings || {};
+  if (providers[embeddingConfig.provider]) {
+    return providers[embeddingConfig.provider];
+  }
+  if (embeddingConfig.provider === 'none') {
+    return null;
+  }
+  if (embeddingConfig.provider === 'openai') {
+    return createOpenAiEmbeddingProvider(embeddingConfig, { fetchImpl });
+  }
+  throw new Error(`Unknown embeddings provider: ${embeddingConfig.provider}`);
+}
+
+function timeoutSignal(timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  return {
+    signal: controller.signal,
+    clear: () => clearTimeout(timer),
+  };
+}
+
+function normalizeEmbedding(value, expectedDimensions) {
+  if (!Array.isArray(value)) {
+    throw new Error('Embedding provider returned a non-array embedding.');
+  }
+  const embedding = value.map((item) => Number(item));
+  if (!embedding.every(Number.isFinite)) {
+    throw new Error('Embedding provider returned non-numeric embedding values.');
+  }
+  if (expectedDimensions && embedding.length !== expectedDimensions) {
+    throw new Error(`Embedding provider returned ${embedding.length} dimensions; expected ${expectedDimensions}.`);
+  }
+  return embedding;
+}
+
+export function createOpenAiEmbeddingProvider(config, { fetchImpl = globalThis.fetch } = {}) {
+  if (!config.apiKey) {
+    throw new Error('OpenAI embeddings require CONTEXTFORGE_OPENAI_API_KEY or OPENAI_API_KEY.');
+  }
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('OpenAI embeddings require a fetch implementation.');
+  }
+
+  return {
+    name: 'openai',
+    model: config.model,
+    dimensions: config.dimensions,
+    async embed(texts) {
+      const input = Array.isArray(texts) ? texts : [texts];
+      if (input.length === 0) {
+        return [];
+      }
+      const timeout = timeoutSignal(config.timeoutMs);
+      try {
+        const response = await fetchImpl(`${config.baseUrl.replace(/\/$/, '')}/embeddings`, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${config.apiKey}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            model: config.model,
+            input,
+            dimensions: config.dimensions,
+            encoding_format: 'float',
+          }),
+          signal: timeout.signal,
+        });
+        if (!response.ok) {
+          const body = await response.text().catch(() => '');
+          throw new Error(`OpenAI embeddings request failed with HTTP ${response.status}: ${body.slice(0, 240)}`);
+        }
+        const payload = await response.json();
+        const rows = Array.isArray(payload.data) ? payload.data : [];
+        if (rows.length !== input.length) {
+          throw new Error(`OpenAI embeddings returned ${rows.length} row(s); expected ${input.length}.`);
+        }
+        return rows
+          .sort((a, b) => a.index - b.index)
+          .map((row) => normalizeEmbedding(row.embedding, config.dimensions));
+      } finally {
+        timeout.clear();
+      }
+    },
+  };
+}

--- a/src/embeddings/index.js
+++ b/src/embeddings/index.js
@@ -35,6 +35,10 @@ function normalizeEmbedding(value, expectedDimensions) {
   return embedding;
 }
 
+function supportsDimensionsParameter(model) {
+  return String(model || '').startsWith('text-embedding-3-');
+}
+
 export function createOpenAiEmbeddingProvider(config, { fetchImpl = globalThis.fetch } = {}) {
   if (!config.apiKey) {
     throw new Error('OpenAI embeddings require CONTEXTFORGE_OPENAI_API_KEY or OPENAI_API_KEY.');
@@ -54,18 +58,21 @@ export function createOpenAiEmbeddingProvider(config, { fetchImpl = globalThis.f
       }
       const timeout = timeoutSignal(config.timeoutMs);
       try {
+        const body = {
+          model: config.model,
+          input,
+          encoding_format: 'float',
+        };
+        if (supportsDimensionsParameter(config.model)) {
+          body.dimensions = config.dimensions;
+        }
         const response = await fetchImpl(`${config.baseUrl.replace(/\/$/, '')}/embeddings`, {
           method: 'POST',
           headers: {
             authorization: `Bearer ${config.apiKey}`,
             'content-type': 'application/json',
           },
-          body: JSON.stringify({
-            model: config.model,
-            input,
-            dimensions: config.dimensions,
-            encoding_format: 'float',
-          }),
+          body: JSON.stringify(body),
           signal: timeout.signal,
         });
         if (!response.ok) {

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -133,7 +133,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Rebuild Embeddings',
       description:
-        'Backfill or rebuild the derived sqlite-vec embedding index for durable memories, checkpoints, and memory candidates. Requires an embeddings provider such as OpenAI to be configured.',
+        'Backfill or rebuild the derived sqlite-vec embedding index for durable memories, checkpoints, and memory candidates. Requires an embeddings provider such as OpenAI to be configured. Pass force=true only when intentionally resetting the index after an embedding dimension change.',
       inputSchema: {
         ...scopedSchema,
         batchSize: z.number().int().positive().optional(),

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -22,6 +22,19 @@ function jsonResult(result) {
   };
 }
 
+const MCP_INSTRUCTIONS = [
+  'Use ContextForge for scoped memory retrieval on demand.',
+  'At the start of non-trivial project work, run a small bootstrap: call db_info when storage mode or vector readiness matters, search repo scope for the task, and search shared scope only when cross-repo or user-wide policy may matter.',
+  'If db_info shows remote storage, treat results as shared canonical ContextForge state for the configured scope. If it shows local or project-local storage, treat results as machine-local context unless the user confirms that store is authoritative.',
+  'Search result types have different trust levels: memory is reviewed durable fact or decision; checkpoint is recent session continuity, not canonical truth; memory_candidate is an unreviewed promotion candidate for review.',
+  'If working on a repository while the MCP process cwd is elsewhere, pass repoPath or cwd so repo scope resolves to that checkout; repoPath takes precedence when both are provided.',
+  'Treat scopeKey as the canonical repo memory key; pass an explicit normalized GitHub key when local paths differ across machines or the checkout cannot infer the right remote.',
+  'Use remember for reviewed durable facts the user or assistant intentionally wants saved.',
+  'After distill_checkpoint, check memoryCandidateCount; if it is greater than zero, call list_memory_candidates and promote only reviewed durable facts with promote_memory_candidate or reject unsuitable candidates with reject_memory_candidate.',
+  'When session_status reports latestCheckpointMemoryCandidateCount, use list_memory_candidates before deciding what should become durable memory.',
+  'Keep local scope opt-in.',
+].join(' ');
+
 export function createContextForgeMcpServer({ app = createContextForge() } = {}) {
   const server = new McpServer(
     {
@@ -29,9 +42,24 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
       version: '0.0.0',
     },
     {
-      instructions:
-        'Use ContextForge for scoped memory retrieval on demand. At the start of non-trivial project work, run a small bootstrap: search repo memory for the task, and search shared memory only when cross-repo or user-wide policy may matter. If working on a repository while the MCP process cwd is elsewhere, pass repoPath or cwd so repo scope resolves to that checkout; repoPath takes precedence when both are provided. Treat scopeKey as the canonical repo memory key; pass an explicit normalized GitHub key when local paths differ across machines or the checkout cannot infer the right remote. Use remember for reviewed durable facts the user or assistant intentionally wants saved. After distill_checkpoint, check memoryCandidateCount; if it is greater than zero, call list_memory_candidates and promote only reviewed durable facts with promote_memory_candidate or reject unsuitable candidates with reject_memory_candidate. When session_status reports latestCheckpointMemoryCandidateCount, use list_memory_candidates before deciding what should become durable memory. Keep local scope opt-in.',
+      instructions: MCP_INSTRUCTIONS,
     },
+  );
+
+  server.registerTool(
+    'db_info',
+    {
+      title: 'Database Info',
+      description:
+        'Inspect the configured ContextForge storage backend, table counts, raw retention, and sqlite-vec/embeddings readiness. Use this to distinguish remote canonical storage from local or project-local storage before relying on retrieval results.',
+      inputSchema: {},
+      annotations: {
+        title: 'Database Info',
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+    },
+    async () => jsonResult(await app.dbInfo()),
   );
 
   server.registerTool(
@@ -83,7 +111,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Search Memory',
       description:
-        'Search durable ContextForge memories in the requested scope. Pass repoPath or cwd to retrieve repo memories for a checkout outside the MCP process cwd; repoPath takes precedence. Pass scopeKey to pin the canonical repo memory key.',
+        'Search scoped ContextForge retrieval results. Results may include type=memory reviewed durable facts, type=checkpoint recent continuity, and type=memory_candidate unreviewed promotion candidates. Pass repoPath or cwd to retrieve repo results for a checkout outside the MCP process cwd; repoPath takes precedence. Pass scopeKey to pin the canonical repo memory key.',
       inputSchema: {
         ...scopedSchema,
         query: z.string(),
@@ -98,6 +126,26 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
       },
     },
     async (args) => jsonResult(await app.search(args)),
+  );
+
+  server.registerTool(
+    'rebuild_embeddings',
+    {
+      title: 'Rebuild Embeddings',
+      description:
+        'Backfill or rebuild the derived sqlite-vec embedding index for durable memories, checkpoints, and memory candidates. Requires an embeddings provider such as OpenAI to be configured.',
+      inputSchema: {
+        ...scopedSchema,
+        batchSize: z.number().int().positive().optional(),
+        force: z.boolean().optional(),
+      },
+      annotations: {
+        title: 'Rebuild Embeddings',
+        readOnlyHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.rebuildEmbeddings(args)),
   );
 
   server.registerTool(

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -15,6 +15,7 @@ const REMOTE_METHODS = [
   'listMemoryCandidates',
   'getMemory',
   'search',
+  'rebuildEmbeddings',
   'appendRaw',
   'listRawEvents',
   'pruneRawEvents',

--- a/src/retrieval/search.js
+++ b/src/retrieval/search.js
@@ -19,13 +19,14 @@ function toFtsQuery(tokens) {
 
 function ftsScore(rank) {
   if (rank == null) return 0;
-  return Math.max(0, Math.round(Math.abs(Number(rank)) * 1000000));
+  const score = Math.max(0, Math.round(Math.abs(Number(rank)) * 1000000));
+  return Math.min(1000, score);
 }
 
 function vectorScore(distance) {
   const parsed = Number(distance);
   if (!Number.isFinite(parsed)) return 0;
-  return Math.round(1000000 / (1 + Math.max(0, parsed)));
+  return Math.round(1000 / (1 + Math.max(0, parsed)));
 }
 
 function scoreMemory(memory, queryTokens) {
@@ -128,7 +129,7 @@ function vectorRetrieval(match) {
 
 export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, searchScopes, sharedScopeKey, queryEmbedding }) {
   const queryTokens = unique(tokenize(query));
-  if (queryTokens.length === 0) {
+  if (queryTokens.length === 0 && !queryEmbedding) {
     return [];
   }
 
@@ -137,7 +138,7 @@ export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, 
 
   return scopes
     .flatMap((source) => {
-      const ftsMatches = store.searchMemoryIndex
+      const ftsMatches = store.searchMemoryIndex && ftsQuery
         ? store.searchMemoryIndex({
             scopeType: source.scopeType,
             scopeKey: source.scopeKey,
@@ -173,17 +174,22 @@ export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, 
       const vectorById = new Map(vectorMatches.map((match) => [match.memory.id, match]));
       const ftsIds = new Set(ftsById.keys());
       const vectorIds = new Set(vectorById.keys());
-      const candidateMemories =
-        ftsMatches.length > 0 || vectorMatches.length > 0
-          ? [...ftsMatches.map((match) => match.memory), ...vectorMatches.map((match) => match.memory)]
-          : store.listMemories(source);
+      const lexicalCandidates =
+        queryTokens.length > 0 && store.listMemories
+          ? store.listMemories(source)
+          : [];
+      const candidateMemories = [
+        ...ftsMatches.map((match) => match.memory),
+        ...vectorMatches.map((match) => match.memory),
+        ...lexicalCandidates,
+      ];
       const memoriesById = new Map(candidateMemories.map((memory) => [memory.id, memory]));
 
       const memoryResults = [...memoriesById.values()].map((memory) => {
         const match = scoreMemory(memory, queryTokens);
         const ftsMatch = ftsById.get(memory.id);
         const vectorMatch = vectorById.get(memory.id);
-        const score = match.score + ftsScore(ftsMatch?.ftsRank) + vectorScore(vectorMatch?.distance);
+        const score = match.score * 100 + ftsScore(ftsMatch?.ftsRank) + vectorScore(vectorMatch?.distance);
         return {
           type: 'memory',
           score,

--- a/src/retrieval/search.js
+++ b/src/retrieval/search.js
@@ -22,6 +22,12 @@ function ftsScore(rank) {
   return Math.max(0, Math.round(Math.abs(Number(rank)) * 1000000));
 }
 
+function vectorScore(distance) {
+  const parsed = Number(distance);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.round(1000000 / (1 + Math.max(0, parsed)));
+}
+
 function scoreMemory(memory, queryTokens) {
   const fields = {
     key: memory.key,
@@ -100,7 +106,27 @@ function scopeBoost(source) {
   return 0;
 }
 
-export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, searchScopes, sharedScopeKey }) {
+function resultImportance(result) {
+  if (result.memory) return result.memory.importance;
+  if (result.candidate) return result.candidate.candidate.importance || 0;
+  return 0;
+}
+
+function resultTimestamp(result) {
+  return result.memory?.updatedAt || result.checkpoint?.createdAt || result.candidate?.createdAt || '';
+}
+
+function vectorRetrieval(match) {
+  return {
+    method: 'vector',
+    ftsRank: null,
+    vectorDistance: match.distance,
+    vectorModel: match.model,
+    vectorDimensions: match.dimensions,
+  };
+}
+
+export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, searchScopes, sharedScopeKey, queryEmbedding }) {
   const queryTokens = unique(tokenize(query));
   if (queryTokens.length === 0) {
     return [];
@@ -119,23 +145,62 @@ export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, 
             limit: Math.max(limit * 4, 50),
           })
         : [];
+      const vectorMatches = store.searchMemoryVectorIndex && queryEmbedding
+        ? store.searchMemoryVectorIndex({
+            scopeType: source.scopeType,
+            scopeKey: source.scopeKey,
+            embedding: queryEmbedding,
+            limit: Math.max(limit * 4, 50),
+          })
+        : [];
+      const checkpointVectorMatches = store.searchCheckpointVectorIndex && queryEmbedding
+        ? store.searchCheckpointVectorIndex({
+            scopeType: source.scopeType,
+            scopeKey: source.scopeKey,
+            embedding: queryEmbedding,
+            limit: Math.max(limit * 4, 50),
+          })
+        : [];
+      const candidateVectorMatches = store.searchMemoryCandidateVectorIndex && queryEmbedding
+        ? store.searchMemoryCandidateVectorIndex({
+            scopeType: source.scopeType,
+            scopeKey: source.scopeKey,
+            embedding: queryEmbedding,
+            limit: Math.max(limit * 4, 50),
+          })
+        : [];
       const ftsById = new Map(ftsMatches.map((match) => [match.memory.id, match]));
+      const vectorById = new Map(vectorMatches.map((match) => [match.memory.id, match]));
       const ftsIds = new Set(ftsById.keys());
+      const vectorIds = new Set(vectorById.keys());
       const candidateMemories =
-        ftsMatches.length > 0 ? ftsMatches.map((match) => match.memory) : store.listMemories(source);
+        ftsMatches.length > 0 || vectorMatches.length > 0
+          ? [...ftsMatches.map((match) => match.memory), ...vectorMatches.map((match) => match.memory)]
+          : store.listMemories(source);
       const memoriesById = new Map(candidateMemories.map((memory) => [memory.id, memory]));
 
-      return [...memoriesById.values()].map((memory) => {
+      const memoryResults = [...memoriesById.values()].map((memory) => {
         const match = scoreMemory(memory, queryTokens);
         const ftsMatch = ftsById.get(memory.id);
-        const score = match.score + ftsScore(ftsMatch?.ftsRank);
+        const vectorMatch = vectorById.get(memory.id);
+        const score = match.score + ftsScore(ftsMatch?.ftsRank) + vectorScore(vectorMatch?.distance);
         return {
           type: 'memory',
           score,
           why: match.matched,
           retrieval: {
-            method: ftsIds.has(memory.id) ? 'fts5+lexical' : 'lexical',
+            method:
+              ftsIds.has(memory.id) && vectorIds.has(memory.id)
+                ? 'hybrid:fts5+vector+lexical'
+                : ftsIds.has(memory.id)
+                  ? 'fts5+lexical'
+                  : vectorIds.has(memory.id)
+                    ? 'vector'
+                    : 'lexical',
             ftsRank: ftsMatch?.ftsRank ?? null,
+            vectorDistance: vectorMatch?.distance ?? null,
+            vectorModel: vectorMatch?.model ?? null,
+            vectorDimensions: vectorMatch?.dimensions ?? null,
           },
           source: {
             scopeType: source.scopeType,
@@ -145,14 +210,40 @@ export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, 
           memory,
         };
       });
+      const checkpointResults = checkpointVectorMatches.map((match) => ({
+        type: 'checkpoint',
+        score: vectorScore(match.distance),
+        why: [],
+        retrieval: vectorRetrieval(match),
+        source: {
+          scopeType: source.scopeType,
+          scopeKey: source.scopeKey,
+          role: source.role,
+        },
+        checkpoint: match.checkpoint,
+      }));
+      const candidateResults = candidateVectorMatches.map((match) => ({
+        type: 'memory_candidate',
+        score: vectorScore(match.distance),
+        why: [],
+        retrieval: vectorRetrieval(match),
+        source: {
+          scopeType: source.scopeType,
+          scopeKey: source.scopeKey,
+          role: source.role,
+        },
+        candidate: match.candidate,
+      }));
+
+      return [...memoryResults, ...checkpointResults, ...candidateResults];
     })
     .filter((result) => result.score > 0)
     .sort(
       (a, b) =>
         b.score - a.score ||
         scopeBoost(b.source) - scopeBoost(a.source) ||
-        b.memory.importance - a.memory.importance ||
-        b.memory.updatedAt.localeCompare(a.memory.updatedAt),
+        resultImportance(b) - resultImportance(a) ||
+        resultTimestamp(b).localeCompare(resultTimestamp(a)),
     )
     .slice(0, limit);
 }

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -1,9 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import Database from 'better-sqlite3';
+import * as sqliteVec from 'sqlite-vec';
 
-export const SCHEMA_VERSION = 7;
+export const SCHEMA_VERSION = 8;
 
 function nowIso() {
   return new Date().toISOString();
@@ -160,6 +161,18 @@ function normalizeTags(tags) {
   return Array.isArray(tags) ? tags.map((tag) => String(tag)) : [];
 }
 
+function contentHash(value) {
+  return createHash('sha256').update(String(value || '')).digest('hex');
+}
+
+function validateDimensions(dimensions) {
+  const parsed = Number(dimensions);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error('embedding dimensions must be a positive integer.');
+  }
+  return parsed;
+}
+
 function normalizeCandidate(candidate) {
   const value = candidate && typeof candidate === 'object' && !Array.isArray(candidate) ? candidate : {};
   return {
@@ -185,7 +198,25 @@ export class ContextForgeStore {
     this.dbPath = path.join(dataDir, 'contextforge.db');
     this.db = new Database(this.dbPath);
     this.db.exec('PRAGMA foreign_keys = ON;');
+    this.vectorStatus = this.loadVectorExtension();
     this.migrate();
+  }
+
+  loadVectorExtension() {
+    try {
+      sqliteVec.load(this.db);
+      return {
+        available: true,
+        version: this.db.prepare('SELECT vec_version() AS version').get().version,
+        error: null,
+      };
+    } catch (error) {
+      return {
+        available: false,
+        version: null,
+        error: error.message,
+      };
+    }
   }
 
   close() {
@@ -361,6 +392,12 @@ export class ContextForgeStore {
 
   dbInfo() {
     const count = (table) => this.db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get().count;
+    const embeddingIndexExists = this.db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'embedding_index'")
+      .get();
+    const embeddingDimensions = this.db
+      .prepare("SELECT value FROM schema_meta WHERE key = 'embedding_dimensions'")
+      .get()?.value;
     return {
       dataDir: this.dataDir,
       dbPath: this.dbPath,
@@ -374,8 +411,376 @@ export class ContextForgeStore {
         distillRuns: count('distill_runs'),
         memoryEvents: count('memory_events'),
         memoryCandidates: count('memory_candidate_index'),
+        embeddings: embeddingIndexExists ? count('embedding_index') : 0,
+      },
+      vector: {
+        sqliteVecAvailable: this.vectorStatus.available,
+        sqliteVecVersion: this.vectorStatus.version,
+        error: this.vectorStatus.error,
+        dimensions: embeddingDimensions ? Number(embeddingDimensions) : null,
       },
     };
+  }
+
+  ensureEmbeddingIndex(dimensions) {
+    const parsedDimensions = validateDimensions(dimensions);
+    if (!this.vectorStatus.available) {
+      throw new Error(`sqlite-vec is not available: ${this.vectorStatus.error}`);
+    }
+
+    const existing = this.db.prepare("SELECT value FROM schema_meta WHERE key = 'embedding_dimensions'").get();
+    const existingDimensions = existing?.value ? Number(existing.value) : null;
+    if (existingDimensions && existingDimensions !== parsedDimensions) {
+      this.db.exec(`
+        DROP TABLE IF EXISTS embedding_vec;
+        DROP TABLE IF EXISTS embedding_index;
+      `);
+    }
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS embedding_index (
+        source_id TEXT PRIMARY KEY,
+        source_type TEXT NOT NULL CHECK (source_type IN ('memory', 'checkpoint', 'memory_candidate')),
+        scope_type TEXT NOT NULL CHECK (scope_type IN ('shared', 'repo', 'local')),
+        scope_key TEXT NOT NULL,
+        record_id TEXT NOT NULL,
+        model TEXT NOT NULL,
+        dimensions INTEGER NOT NULL,
+        content_hash TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_embedding_index_scope
+        ON embedding_index(source_type, scope_type, scope_key);
+      CREATE INDEX IF NOT EXISTS idx_embedding_index_record
+        ON embedding_index(source_type, record_id);
+    `);
+    this.db.exec(
+      `CREATE VIRTUAL TABLE IF NOT EXISTS embedding_vec USING vec0(source_id TEXT PRIMARY KEY, embedding FLOAT[${parsedDimensions}])`,
+    );
+    this.db
+      .prepare(`
+        INSERT INTO schema_meta (key, value)
+        VALUES ('embedding_dimensions', ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+      `)
+      .run(String(parsedDimensions));
+  }
+
+  embeddingTextForMemory(memory) {
+    return [
+      `key: ${memory.key}`,
+      `category: ${memory.category}`,
+      memory.tags.length ? `tags: ${memory.tags.join(', ')}` : '',
+      `content: ${memory.content}`,
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  embeddingSourceForMemory(memory) {
+    const text = this.embeddingTextForMemory(memory);
+    return {
+      sourceType: 'memory',
+      recordId: memory.id,
+      scopeType: memory.scopeType,
+      scopeKey: memory.scopeKey,
+      text,
+      contentHash: contentHash(text),
+      memory,
+    };
+  }
+
+  embeddingTextForCheckpoint(checkpoint) {
+    const retrievalHooks = Array.isArray(checkpoint.metadata?.providerMetadata?.retrievalHooks)
+      ? checkpoint.metadata.providerMetadata.retrievalHooks
+      : [];
+    return [
+      `summary: ${checkpoint.summaryShort}`,
+      `details: ${checkpoint.summaryText}`,
+      checkpoint.decisions.length ? `decisions: ${checkpoint.decisions.join('\n')}` : '',
+      checkpoint.todos.length ? `todos: ${checkpoint.todos.join('\n')}` : '',
+      checkpoint.openQuestions.length ? `open questions: ${checkpoint.openQuestions.join('\n')}` : '',
+      retrievalHooks.length ? `retrieval hooks: ${retrievalHooks.join(', ')}` : '',
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  embeddingSourceForCheckpoint(checkpoint) {
+    const text = this.embeddingTextForCheckpoint(checkpoint);
+    return {
+      sourceType: 'checkpoint',
+      recordId: checkpoint.id,
+      scopeType: checkpoint.scopeType,
+      scopeKey: checkpoint.scopeKey,
+      text,
+      contentHash: contentHash(text),
+      checkpoint,
+    };
+  }
+
+  embeddingTextForMemoryCandidate(candidate) {
+    return [
+      `key: ${candidate.candidate.key}`,
+      `category: ${candidate.candidate.category}`,
+      candidate.candidate.tags.length ? `tags: ${candidate.candidate.tags.join(', ')}` : '',
+      candidate.candidate.reason ? `reason: ${candidate.candidate.reason}` : '',
+      `content: ${candidate.candidate.content}`,
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  embeddingSourceForMemoryCandidate(candidate) {
+    const text = this.embeddingTextForMemoryCandidate(candidate);
+    return {
+      sourceType: 'memory_candidate',
+      recordId: candidate.id,
+      scopeType: candidate.scopeType,
+      scopeKey: candidate.scopeKey,
+      text,
+      contentHash: contentHash(text),
+      candidate,
+    };
+  }
+
+  listMemoryEmbeddingSources({ scopeType = null, scopeKey = null, model, dimensions, force = false }) {
+    const values = [model, dimensions];
+    const scopeClause = [];
+    if (scopeType) {
+      scopeClause.push('memories.scope_type = ?');
+      values.push(scopeType);
+    }
+    if (scopeKey) {
+      scopeClause.push('memories.scope_key = ?');
+      values.push(scopeKey);
+    }
+    const scopeSql = scopeClause.length ? `AND ${scopeClause.join(' AND ')}` : '';
+    const rows = this.db
+      .prepare(`
+        SELECT memories.*, embedding_index.content_hash AS embedding_content_hash
+        FROM memories
+        LEFT JOIN embedding_index
+          ON embedding_index.source_type = 'memory'
+          AND embedding_index.record_id = memories.id
+          AND embedding_index.model = ?
+          AND embedding_index.dimensions = ?
+        WHERE memories.status = 'active'
+          ${scopeSql}
+        ORDER BY memories.updated_at ASC, memories.id ASC
+      `)
+      .all(...values);
+    return rows
+      .map((row) => {
+        const memory = hydrateMemory(row);
+        return {
+          ...this.embeddingSourceForMemory(memory),
+          indexedContentHash: row.embedding_content_hash,
+        };
+      })
+      .filter((source) => force || source.indexedContentHash !== source.contentHash);
+  }
+
+  listCheckpointEmbeddingSources({ scopeType = null, scopeKey = null, model, dimensions, force = false }) {
+    const values = [model, dimensions];
+    const scopeClause = [];
+    if (scopeType) {
+      scopeClause.push('checkpoints.scope_type = ?');
+      values.push(scopeType);
+    }
+    if (scopeKey) {
+      scopeClause.push('checkpoints.scope_key = ?');
+      values.push(scopeKey);
+    }
+    const scopeSql = scopeClause.length ? `AND ${scopeClause.join(' AND ')}` : '';
+    const rows = this.db
+      .prepare(`
+        SELECT checkpoints.*, embedding_index.content_hash AS embedding_content_hash
+        FROM checkpoints
+        LEFT JOIN embedding_index
+          ON embedding_index.source_type = 'checkpoint'
+          AND embedding_index.record_id = checkpoints.id
+          AND embedding_index.model = ?
+          AND embedding_index.dimensions = ?
+        WHERE 1 = 1
+          ${scopeSql}
+        ORDER BY checkpoints.created_at ASC, checkpoints.id ASC
+      `)
+      .all(...values);
+    return rows
+      .map((row) => {
+        const checkpoint = hydrateCheckpoint(row);
+        return {
+          ...this.embeddingSourceForCheckpoint(checkpoint),
+          indexedContentHash: row.embedding_content_hash,
+        };
+      })
+      .filter((source) => force || source.indexedContentHash !== source.contentHash);
+  }
+
+  listMemoryCandidateEmbeddingSources({ scopeType = null, scopeKey = null, model, dimensions, force = false }) {
+    const values = [model, dimensions];
+    const scopeClause = [];
+    if (scopeType) {
+      scopeClause.push('memory_candidate_index.scope_type = ?');
+      values.push(scopeType);
+    }
+    if (scopeKey) {
+      scopeClause.push('memory_candidate_index.scope_key = ?');
+      values.push(scopeKey);
+    }
+    const scopeSql = scopeClause.length ? `AND ${scopeClause.join(' AND ')}` : '';
+    const rows = this.db
+      .prepare(`
+        SELECT
+          memory_candidate_index.*,
+          checkpoints.provider,
+          checkpoints.distill_run_id,
+          checkpoints.source_event_count,
+          checkpoints.created_at AS checkpoint_created_at,
+          embedding_index.content_hash AS embedding_content_hash
+        FROM memory_candidate_index
+        JOIN checkpoints ON checkpoints.id = memory_candidate_index.checkpoint_id
+        LEFT JOIN embedding_index
+          ON embedding_index.source_type = 'memory_candidate'
+          AND embedding_index.record_id = memory_candidate_index.id
+          AND embedding_index.model = ?
+          AND embedding_index.dimensions = ?
+        WHERE memory_candidate_index.status IN ('pending', 'promoted')
+          ${scopeSql}
+        ORDER BY memory_candidate_index.created_at ASC, memory_candidate_index.id ASC
+      `)
+      .all(...values);
+    return rows
+      .map((row) => {
+        const candidate = hydrateMemoryCandidate(row);
+        return {
+          ...this.embeddingSourceForMemoryCandidate(candidate),
+          indexedContentHash: row.embedding_content_hash,
+        };
+      })
+      .filter((source) => force || source.indexedContentHash !== source.contentHash);
+  }
+
+  upsertEmbedding({ sourceType, recordId, scopeType, scopeKey, model, dimensions, contentHash: hash, embedding }) {
+    this.ensureEmbeddingIndex(dimensions);
+    const sourceId = `${sourceType}:${recordId}`;
+    const timestamp = nowIso();
+    this.db.prepare('DELETE FROM embedding_vec WHERE source_id = ?').run(sourceId);
+    this.db
+      .prepare('INSERT INTO embedding_vec(source_id, embedding) VALUES (?, ?)')
+      .run(sourceId, JSON.stringify(embedding));
+    this.db
+      .prepare(`
+        INSERT INTO embedding_index (
+          source_id, source_type, scope_type, scope_key, record_id,
+          model, dimensions, content_hash, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(source_id) DO UPDATE SET
+          scope_type = excluded.scope_type,
+          scope_key = excluded.scope_key,
+          model = excluded.model,
+          dimensions = excluded.dimensions,
+          content_hash = excluded.content_hash,
+          updated_at = excluded.updated_at
+      `)
+      .run(sourceId, sourceType, scopeType, scopeKey, recordId, model, Number(dimensions), hash, timestamp, timestamp);
+  }
+
+  searchMemoryVectorIndex({ scopeType, scopeKey, embedding, limit = 50 }) {
+    const dimensions = embedding.length;
+    this.ensureEmbeddingIndex(dimensions);
+    return this.db
+      .prepare(`
+        SELECT
+          memories.*,
+          embedding_vec.distance AS vector_distance,
+          embedding_index.model AS embedding_model,
+          embedding_index.dimensions AS embedding_dimensions
+        FROM embedding_vec
+        JOIN embedding_index ON embedding_index.source_id = embedding_vec.source_id
+        JOIN memories ON memories.id = embedding_index.record_id
+        WHERE embedding_vec.embedding MATCH ?
+          AND k = ?
+          AND embedding_index.source_type = 'memory'
+          AND embedding_index.scope_type = ?
+          AND embedding_index.scope_key = ?
+          AND memories.status = 'active'
+        ORDER BY embedding_vec.distance ASC
+      `)
+      .all(JSON.stringify(embedding), limit, scopeType, scopeKey)
+      .map((row) => ({
+        memory: hydrateMemory(row),
+        distance: row.vector_distance,
+        model: row.embedding_model,
+        dimensions: row.embedding_dimensions,
+      }));
+  }
+
+  searchCheckpointVectorIndex({ scopeType, scopeKey, embedding, limit = 50 }) {
+    const dimensions = embedding.length;
+    this.ensureEmbeddingIndex(dimensions);
+    return this.db
+      .prepare(`
+        SELECT
+          checkpoints.*,
+          embedding_vec.distance AS vector_distance,
+          embedding_index.model AS embedding_model,
+          embedding_index.dimensions AS embedding_dimensions
+        FROM embedding_vec
+        JOIN embedding_index ON embedding_index.source_id = embedding_vec.source_id
+        JOIN checkpoints ON checkpoints.id = embedding_index.record_id
+        WHERE embedding_vec.embedding MATCH ?
+          AND k = ?
+          AND embedding_index.source_type = 'checkpoint'
+          AND embedding_index.scope_type = ?
+          AND embedding_index.scope_key = ?
+        ORDER BY embedding_vec.distance ASC
+      `)
+      .all(JSON.stringify(embedding), limit, scopeType, scopeKey)
+      .map((row) => ({
+        checkpoint: hydrateCheckpoint(row),
+        distance: row.vector_distance,
+        model: row.embedding_model,
+        dimensions: row.embedding_dimensions,
+      }));
+  }
+
+  searchMemoryCandidateVectorIndex({ scopeType, scopeKey, embedding, limit = 50 }) {
+    const dimensions = embedding.length;
+    this.ensureEmbeddingIndex(dimensions);
+    return this.db
+      .prepare(`
+        SELECT
+          memory_candidate_index.*,
+          checkpoints.provider,
+          checkpoints.distill_run_id,
+          checkpoints.source_event_count,
+          checkpoints.created_at AS checkpoint_created_at,
+          embedding_vec.distance AS vector_distance,
+          embedding_index.model AS embedding_model,
+          embedding_index.dimensions AS embedding_dimensions
+        FROM embedding_vec
+        JOIN embedding_index ON embedding_index.source_id = embedding_vec.source_id
+        JOIN memory_candidate_index ON memory_candidate_index.id = embedding_index.record_id
+        JOIN checkpoints ON checkpoints.id = memory_candidate_index.checkpoint_id
+        WHERE embedding_vec.embedding MATCH ?
+          AND k = ?
+          AND embedding_index.source_type = 'memory_candidate'
+          AND embedding_index.scope_type = ?
+          AND embedding_index.scope_key = ?
+          AND memory_candidate_index.status IN ('pending', 'promoted')
+        ORDER BY embedding_vec.distance ASC
+      `)
+      .all(JSON.stringify(embedding), limit, scopeType, scopeKey)
+      .map((row) => ({
+        candidate: hydrateMemoryCandidate(row),
+        distance: row.vector_distance,
+        model: row.embedding_model,
+        dimensions: row.embedding_dimensions,
+      }));
   }
 
   backfillMemoryCandidateIndex() {

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -422,7 +422,7 @@ export class ContextForgeStore {
     };
   }
 
-  ensureEmbeddingIndex(dimensions) {
+  ensureEmbeddingIndex(dimensions, { resetOnDimensionChange = false } = {}) {
     const parsedDimensions = validateDimensions(dimensions);
     if (!this.vectorStatus.available) {
       throw new Error(`sqlite-vec is not available: ${this.vectorStatus.error}`);
@@ -431,6 +431,12 @@ export class ContextForgeStore {
     const existing = this.db.prepare("SELECT value FROM schema_meta WHERE key = 'embedding_dimensions'").get();
     const existingDimensions = existing?.value ? Number(existing.value) : null;
     if (existingDimensions && existingDimensions !== parsedDimensions) {
+      if (!resetOnDimensionChange) {
+        throw new Error(
+          `Embedding dimensions changed from ${existingDimensions} to ${parsedDimensions}. ` +
+            'Run rebuildEmbeddings with force=true to reset and rebuild the vector index.',
+        );
+      }
       this.db.exec(`
         DROP TABLE IF EXISTS embedding_vec;
         DROP TABLE IF EXISTS embedding_index;
@@ -663,8 +669,18 @@ export class ContextForgeStore {
       .filter((source) => force || source.indexedContentHash !== source.contentHash);
   }
 
-  upsertEmbedding({ sourceType, recordId, scopeType, scopeKey, model, dimensions, contentHash: hash, embedding }) {
-    this.ensureEmbeddingIndex(dimensions);
+  upsertEmbedding({
+    sourceType,
+    recordId,
+    scopeType,
+    scopeKey,
+    model,
+    dimensions,
+    contentHash: hash,
+    embedding,
+    resetOnDimensionChange = false,
+  }) {
+    this.ensureEmbeddingIndex(dimensions, { resetOnDimensionChange });
     const sourceId = `${sourceType}:${recordId}`;
     const timestamp = nowIso();
     this.db.prepare('DELETE FROM embedding_vec WHERE source_id = ?').run(sourceId);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -2155,6 +2155,159 @@ test('search uses explainable FTS-backed ranking while keeping durable memory ca
   assert.equal(fetched.content, 'Use SQLite FTS for explainable retrieval ranking.');
 });
 
+test('embedding rebuild populates sqlite-vec index for hybrid retrieval', async () => {
+  const dataDir = await makeTempDir();
+  const provider = {
+    name: 'test-vector',
+    model: 'test-embedding',
+    dimensions: 3,
+    async embed(texts) {
+      return texts.map((text) => {
+        const value = String(text).toLowerCase();
+        if (value.includes('semantic fruit')) return [1, 0, 0];
+        if (value.includes('apple')) return [1, 0, 0];
+        if (value.includes('database')) return [0, 1, 0];
+        return [0, 0, 1];
+      });
+    },
+  };
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_EMBEDDINGS_PROVIDER: 'openai',
+      CONTEXTFORGE_EMBEDDINGS_DIMENSIONS: '3',
+    },
+    cwd: process.cwd(),
+    embeddingProviders: {
+      openai: provider,
+    },
+  });
+
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'repo-vector',
+    key: 'apple-note',
+    content: 'Apple orchards need pollination planning.',
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'repo-vector',
+    key: 'database-note',
+    content: 'Database migrations need rollback planning.',
+  });
+
+  const rebuilt = await app.rebuildEmbeddings({
+    scope: 'repo',
+    scopeKey: 'repo-vector',
+  });
+  assert.equal(rebuilt.embedded, 2);
+  assert.equal(rebuilt.dimensions, 3);
+  assert.deepEqual(rebuilt.bySourceType, { memory: 2 });
+
+  const results = await app.search({
+    scope: 'repo',
+    scopeKey: 'repo-vector',
+    query: 'semantic fruit',
+  });
+
+  assert.equal(results[0].memory.key, 'apple-note');
+  assert.equal(results[0].retrieval.method, 'vector');
+  assert.equal(results[0].retrieval.vectorDistance, 0);
+  assert.equal(results[0].retrieval.vectorModel, 'test-embedding');
+  assert.equal(results[0].retrieval.vectorDimensions, 3);
+
+  const info = app.dbInfo();
+  assert.equal(info.tables.embeddings, 2);
+  assert.equal(info.vector.sqliteVecAvailable, true);
+  assert.equal(info.vector.dimensions, 3);
+});
+
+test('distillCheckpoint embeds the new checkpoint and candidates when embeddings are enabled', async () => {
+  const dataDir = await makeTempDir();
+  const embeddingProvider = {
+    name: 'test-vector',
+    model: 'test-embedding',
+    dimensions: 3,
+    async embed(texts) {
+      return texts.map((text) => {
+        const value = String(text).toLowerCase();
+        if (value.includes('candidate')) return [0, 1, 0];
+        if (value.includes('checkpoint')) return [1, 0, 0];
+        return [0, 0, 1];
+      });
+    },
+  };
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'candidate_provider',
+      CONTEXTFORGE_EMBEDDINGS_PROVIDER: 'openai',
+      CONTEXTFORGE_EMBEDDINGS_DIMENSIONS: '3',
+    },
+    cwd: process.cwd(),
+    embeddingProviders: {
+      openai: embeddingProvider,
+    },
+    distillProviders: {
+      candidate_provider: async () => ({
+        summaryShort: 'Checkpoint summary.',
+        summaryText: 'Checkpoint detail for embedding.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'embedded-candidate',
+            content: 'Candidate content for embedding.',
+            reason: 'Candidate reason.',
+          },
+        ],
+        sourceEventCount: 1,
+        metadata: { synthetic: true },
+      }),
+    },
+  });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-distill-vector',
+    sessionId: 'distill-vector-session',
+    role: 'assistant',
+    content: 'Checkpoint should embed immediately after successful distillation.',
+  });
+
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-distill-vector',
+    sessionId: 'distill-vector-session',
+  });
+
+  assert.equal(checkpoint.embedding.embedded, 2);
+  assert.deepEqual(checkpoint.embedding.bySourceType, {
+    checkpoint: 1,
+    memory_candidate: 1,
+  });
+  assert.equal(app.dbInfo().tables.embeddings, 2);
+
+  const checkpointResults = await app.search({
+    scope: 'repo',
+    scopeKey: 'repo-distill-vector',
+    query: 'checkpoint search',
+  });
+  assert.equal(checkpointResults[0].type, 'checkpoint');
+  assert.equal(checkpointResults[0].checkpoint.id, checkpoint.id);
+  assert.equal(checkpointResults[0].retrieval.method, 'vector');
+
+  const candidateResults = await app.search({
+    scope: 'repo',
+    scopeKey: 'repo-distill-vector',
+    query: 'candidate search',
+  });
+  assert.equal(candidateResults[0].type, 'memory_candidate');
+  assert.equal(candidateResults[0].candidate.candidate.key, 'embedded-candidate');
+  assert.equal(candidateResults[0].retrieval.vectorModel, 'test-embedding');
+});
+
 test('search scores only FTS candidates when the index returns matches', () => {
   const memory = {
     id: 'memory-1',
@@ -2435,7 +2588,10 @@ test('distillCheckpoint uses a bounded recent raw-event window', async () => {
           openQuestions: [],
           memoryCandidates: [],
           sourceEventCount: input.rawEvents.length,
-          metadata: { synthetic: true },
+          metadata: {
+            providerNotes: 'synthetic provider output',
+            retrievalHooks: ['codex_exec', 'provider contract', 'synthetic raw events'],
+          },
         };
       },
     },
@@ -2744,7 +2900,10 @@ test('codex_exec provider distills synthetic raw events through a runner', async
             },
           ],
           sourceEventCount: 1,
-          metadata: { synthetic: true },
+          metadata: {
+            providerNotes: 'synthetic provider output',
+            retrievalHooks: ['codex_exec', 'provider contract', 'synthetic raw events'],
+          },
         }),
       };
     },
@@ -2766,13 +2925,18 @@ test('codex_exec provider distills synthetic raw events through a runner', async
 
   assert.equal(checkpoint.provider, 'codex_exec');
   assert.equal(checkpoint.sourceEventCount, 1);
-  assert.equal(checkpoint.metadata.providerMetadata.synthetic, true);
+  assert.equal(checkpoint.metadata.providerMetadata.providerNotes, 'synthetic provider output');
+  assert.deepEqual(checkpoint.metadata.providerMetadata.retrievalHooks, [
+    'codex_exec',
+    'provider contract',
+    'synthetic raw events',
+  ]);
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.command, 'codex-fake');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.model, 'gpt-test');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.reasoningEffort, 'low');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.timeoutMs, 1234);
-  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v1');
-  assert.equal(checkpoint.metadata.providerMetadata.codexExec.outputSchemaVersion, 'contextforge.checkpoint.v2');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v3');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.outputSchemaVersion, 'contextforge.checkpoint.v3');
   assert.match(invocation.prompt, /Return exactly one JSON object/);
   assert.deepEqual(invocation.args.slice(0, 2), ['exec', '--skip-git-repo-check']);
   assert.ok(invocation.args.includes('--output-schema'));
@@ -2782,6 +2946,7 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.equal(invocation.timeoutMs, 1234);
   const candidateSchema = schema.properties.memoryCandidates.items;
   assert.deepEqual(candidateSchema.required, Object.keys(candidateSchema.properties));
+  assert.deepEqual(schema.properties.metadata.required, ['providerNotes', 'retrievalHooks']);
 
   const runs = app.listDistillRuns({
     scope: 'repo',
@@ -2789,9 +2954,9 @@ test('codex_exec provider distills synthetic raw events through a runner', async
     sessionId: 'codex-session',
   });
   assert.equal(runs[0].status, 'succeeded');
-  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v1');
-  assert.equal(runs[0].inputMetadata.providerMetadata.outputSchemaVersion, 'contextforge.checkpoint.v2');
-  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v1');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v3');
+  assert.equal(runs[0].inputMetadata.providerMetadata.outputSchemaVersion, 'contextforge.checkpoint.v3');
+  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v3');
 });
 
 test('codex_exec records JSON brace fallback recovery metadata', async () => {
@@ -2812,7 +2977,7 @@ test('codex_exec records JSON brace fallback recovery metadata', async () => {
         memoryCandidates: [],
         sourceEventCount: 1,
         provider: 'codex_exec',
-        metadata: { providerNotes: 'synthetic recovery' },
+        metadata: { providerNotes: 'synthetic recovery', retrievalHooks: ['brace fallback', 'codex_exec JSON'] },
       })} suffix`,
     }),
   });
@@ -2994,8 +3159,8 @@ test('codex_exec parse failures preserve raw evidence', async () => {
   });
   assert.equal(runs[0].status, 'failed');
   assert.equal(runs[0].outputMetadata.providerFailed, true);
-  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v1');
-  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v1');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v3');
+  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v3');
 });
 
 test('CLI supports the v0 workflow with synthetic data', async () => {
@@ -3139,6 +3304,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'append_raw',
       'begin_session',
       'correct_memory',
+      'db_info',
       'deactivate_memory',
       'distill_checkpoint',
       'distill_usage',
@@ -3148,6 +3314,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'promote_memory',
       'promote_memory_candidate',
       'prune_raw_events',
+      'rebuild_embeddings',
       'reject_memory_candidate',
       'remember',
       'search',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -11,6 +11,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import Database from 'better-sqlite3';
 import { createContextForge } from '../src/core.js';
 import { validateDistillOutput } from '../src/distill/validate.js';
+import { createOpenAiEmbeddingProvider } from '../src/embeddings/index.js';
 import { createInterruptibleSleep, shouldSkipRecentFailedAutoDistill } from '../src/ingest/common.js';
 import { ingestCodexRolloutFile, watchCodexSessions } from '../src/ingest/codex.js';
 import { searchMemories } from '../src/retrieval/search.js';
@@ -2222,6 +2223,77 @@ test('embedding rebuild populates sqlite-vec index for hybrid retrieval', async 
   assert.equal(info.vector.dimensions, 3);
 });
 
+test('vector search still runs for Korean queries that have no lexical tokens', () => {
+  const memory = {
+    id: 'memory-korean',
+    key: 'korean-memory',
+    category: 'note',
+    content: '한국어 의미 검색은 벡터 경로로 동작해야 한다.',
+    tags: [],
+    importance: 0,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  const results = searchMemories(
+    {
+      searchMemoryVectorIndex: () => [{ memory, distance: 0, model: 'test-embedding', dimensions: 3 }],
+      listMemories: () => {
+        throw new Error('listMemories should not be called when the query has no lexical tokens.');
+      },
+    },
+    {
+      scopeType: 'repo',
+      scopeKey: 'repo-korean',
+      query: '체크포인트 후보',
+      queryEmbedding: [1, 0, 0],
+    },
+  );
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].memory.key, 'korean-memory');
+  assert.equal(results[0].retrieval.method, 'vector');
+});
+
+test('hybrid ranking keeps strong lexical matches ahead of weak vector-only matches', () => {
+  const exactMemory = {
+    id: 'memory-exact',
+    key: 'sqlite-vec-upsert',
+    category: 'decision',
+    content: 'Track sqlite-vec upsert behavior.',
+    tags: [],
+    importance: 0,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+  const vectorMemory = {
+    id: 'memory-vector',
+    key: 'unrelated-vector',
+    category: 'note',
+    content: 'A weak semantic neighbor.',
+    tags: [],
+    importance: 0,
+    updatedAt: '2026-01-02T00:00:00.000Z',
+  };
+
+  const results = searchMemories(
+    {
+      searchMemoryVectorIndex: () => [{ memory: vectorMemory, distance: 0.99, model: 'test-embedding', dimensions: 3 }],
+      listMemories: () => [exactMemory],
+    },
+    {
+      scopeType: 'repo',
+      scopeKey: 'repo-ranking',
+      query: 'sqlite-vec-upsert',
+      queryEmbedding: [1, 0, 0],
+    },
+  );
+
+  assert.equal(results.length, 2);
+  assert.equal(results[0].memory.key, 'sqlite-vec-upsert');
+  assert.equal(results[0].retrieval.method, 'lexical');
+  assert.equal(results[1].memory.key, 'unrelated-vector');
+  assert.equal(results[1].retrieval.method, 'vector');
+});
+
 test('distillCheckpoint embeds the new checkpoint and candidates when embeddings are enabled', async () => {
   const dataDir = await makeTempDir();
   const embeddingProvider = {
@@ -2308,7 +2380,68 @@ test('distillCheckpoint embeds the new checkpoint and candidates when embeddings
   assert.equal(candidateResults[0].retrieval.vectorModel, 'test-embedding');
 });
 
-test('search scores only FTS candidates when the index returns matches', () => {
+test('distillCheckpoint reports partial embedding progress when a later upsert fails', async () => {
+  const dataDir = await makeTempDir();
+  const embeddingProvider = {
+    name: 'test-vector',
+    model: 'test-embedding',
+    dimensions: 3,
+    async embed(texts) {
+      return texts.map((_, index) => (index === 0 ? [1, 0, 0] : [0, 1]));
+    },
+  };
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'partial_embedding_provider',
+      CONTEXTFORGE_EMBEDDINGS_PROVIDER: 'openai',
+      CONTEXTFORGE_EMBEDDINGS_DIMENSIONS: '3',
+    },
+    cwd: process.cwd(),
+    embeddingProviders: {
+      openai: embeddingProvider,
+    },
+    distillProviders: {
+      partial_embedding_provider: async () => ({
+        summaryShort: 'Checkpoint summary.',
+        summaryText: 'Checkpoint detail.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'bad-candidate-vector',
+            content: 'Candidate content.',
+            reason: 'The second vector has the wrong dimension.',
+          },
+        ],
+        sourceEventCount: 1,
+        metadata: {},
+      }),
+    },
+  });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-partial-embedding',
+    sessionId: 'partial-embedding-session',
+    role: 'assistant',
+    content: 'Create a checkpoint and candidate.',
+  });
+
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-partial-embedding',
+    sessionId: 'partial-embedding-session',
+  });
+
+  assert.equal(checkpoint.embedding.reason, 'embedding_failed');
+  assert.equal(checkpoint.embedding.embedded, 1);
+  assert.equal(checkpoint.embedding.partialFailure, true);
+  assert.deepEqual(checkpoint.embedding.bySourceType, { checkpoint: 1 });
+});
+
+test('search unions lexical candidates with FTS candidates', () => {
   const memory = {
     id: 'memory-1',
     key: 'indexed-memory',
@@ -2321,9 +2454,7 @@ test('search scores only FTS candidates when the index returns matches', () => {
   const results = searchMemories(
     {
       searchMemoryIndex: () => [{ memory, ftsRank: -0.0001 }],
-      listMemories: () => {
-        throw new Error('listMemories should not be called when FTS returns candidates.');
-      },
+      listMemories: () => [],
     },
     {
       scopeType: 'repo',
@@ -2335,6 +2466,74 @@ test('search scores only FTS candidates when the index returns matches', () => {
   assert.equal(results.length, 1);
   assert.equal(results[0].memory.key, 'indexed-memory');
   assert.equal(results[0].retrieval.method, 'fts5+lexical');
+});
+
+test('embedding dimension changes require an explicit forced rebuild', async () => {
+  const dataDir = await makeTempDir();
+  const provider = {
+    name: 'test-vector',
+    model: 'test-embedding',
+    dimensions: 3,
+    async embed(texts) {
+      return texts.map(() => Array.from({ length: provider.dimensions }, (_, index) => (index === 0 ? 1 : 0)));
+    },
+  };
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_EMBEDDINGS_PROVIDER: 'openai',
+      CONTEXTFORGE_EMBEDDINGS_DIMENSIONS: '3',
+    },
+    cwd: process.cwd(),
+    embeddingProviders: {
+      openai: provider,
+    },
+  });
+
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'repo-dimensions',
+    key: 'dimension-note',
+    content: 'Dimension changes should be explicit.',
+  });
+  await app.rebuildEmbeddings({ scope: 'repo', scopeKey: 'repo-dimensions' });
+
+  provider.dimensions = 2;
+  await assert.rejects(
+    () => app.rebuildEmbeddings({ scope: 'repo', scopeKey: 'repo-dimensions' }),
+    /Embedding dimensions changed from 3 to 2/,
+  );
+  const rebuilt = await app.rebuildEmbeddings({ scope: 'repo', scopeKey: 'repo-dimensions', force: true });
+  assert.equal(rebuilt.dimensions, 2);
+});
+
+test('OpenAI embeddings omit dimensions for legacy embedding models', async () => {
+  let requestBody = null;
+  const provider = createOpenAiEmbeddingProvider(
+    {
+      apiKey: 'test-key',
+      baseUrl: 'https://api.openai.test/v1',
+      model: 'text-embedding-ada-002',
+      dimensions: 1536,
+      timeoutMs: 1000,
+    },
+    {
+      fetchImpl: async (_url, options) => {
+        requestBody = JSON.parse(options.body);
+        return {
+          ok: true,
+          async json() {
+            return { data: [{ index: 0, embedding: Array.from({ length: 1536 }, () => 0) }] };
+          },
+        };
+      },
+    },
+  );
+
+  await provider.embed(['legacy model']);
+
+  assert.equal(requestBody.model, 'text-embedding-ada-002');
+  assert.equal(Object.hasOwn(requestBody, 'dimensions'), false);
 });
 
 test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {


### PR DESCRIPTION
## Summary
- add sqlite-vec backed derived embedding indexes for durable memories, checkpoints, and memory candidates
- add OpenAI embeddings provider configuration plus rebuildEmbeddings across CLI, remote API, and MCP
- expand search to return memory, checkpoint, and memory_candidate vector results with transparent retrieval metadata
- embed checkpoints/candidates after successful distillation and upgrade codex_exec prompt/schema to v3 with retrievalHooks
- add MCP db_info and update agent guidance for remote vs local storage authority
- bump package version to 0.2.0 and document the release in CHANGELOG

Closes #67

## Validation
- npm test
- git diff --check
- restarted contextforge-remote.service and verified dbInfo with embeddings enabled
- backfilled production embeddings: memory=11, checkpoint=1103, memory_candidate=2246
