### PR TITLE
[codex] Add bootstrap context guidance and tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- Expanded agent guidance for repo-scoped semantic continuation retrieval,
+  vector result verification boundaries, durable promotion criteria, and
+  memory-candidate review queue handling.
+- Added `bootstrapContext` to the core API, CLI, remote API, and MCP
+  `bootstrap_context` tool so agents can resolve startup memory context,
+  storage/vector readiness, trust hints, and live-state verification reminders
+  in one call.
+
 ## 0.2.0 - 2026-05-01
 
 - Added sqlite-vec backed derived embedding storage with startup `vec_version`

--- a/README.md
+++ b/README.md
@@ -1109,8 +1109,9 @@ each project. For loose continuation prompts like "yesterday", "continue",
 "previous work", issue/PR follow-up, or cross-agent handoff, agents should call
 `bootstrap_context` or `bootstrapContext` early. The bootstrap response reviews
 repo-scoped `memory`, `checkpoint`, and `memory_candidate` hits as context
-candidates, then reminds the agent to verify current branch, issue/PR, CI,
-migration, and runtime state against live sources before acting.
+candidates, optionally includes up to three shared-scope hits, then reminds the
+agent to verify current branch, issue/PR, CI, migration, and runtime state
+against live sources before acting.
 
 ## codex_exec Provider
 

--- a/README.md
+++ b/README.md
@@ -1105,7 +1105,12 @@ distillation cost discipline. It also includes separate `AGENTS.md` snippets
 for remote-canonical deployments and local/project-local stores. Keep
 repository `AGENTS.md` files short: include only a small ContextForge bootstrap
 snippet and link to the longer guide instead of copying every MCP rule into
-each project.
+each project. For loose continuation prompts like "yesterday", "continue",
+"previous work", issue/PR follow-up, or cross-agent handoff, agents should call
+`bootstrap_context` or `bootstrapContext` early. The bootstrap response reviews
+repo-scoped `memory`, `checkpoint`, and `memory_candidate` hits as context
+candidates, then reminds the agent to verify current branch, issue/PR, CI,
+migration, and runtime state against live sources before acting.
 
 ## codex_exec Provider
 

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -164,8 +164,9 @@ trust levels.
 1. Resolve the intended scope. Use `scope: "repo"` with `repoPath`, `cwd`, or an
    explicit `scopeKey`.
 2. Call `bootstrap_context` with a query derived from the user's task.
-3. Search shared scope only if user-wide conventions, deployment
-   policy, credentials locations, or cross-repo decisions may matter.
+3. Include shared scope only if user-wide conventions, deployment
+   policy, credentials locations, or cross-repo decisions may matter. Shared
+   bootstrap results are capped at three items.
 4. If `bootstrap_context` is unavailable, call `db_info` when storage mode,
    remote/local authority, schema version, raw retention, or vector readiness
    may affect the task, then call `search`.
@@ -417,8 +418,8 @@ Prefer distilling at meaningful boundaries:
 - `db_info`: inspect storage mode, table counts, raw retention, schema version,
   and sqlite-vec/embedding readiness.
 - `bootstrap_context`: resolve scoped startup context in one call. It searches
-  repo memory/checkpoints/candidates semantically, optionally includes shared
-  scope, and annotates trust plus verification hints.
+  repo memory/checkpoints/candidates semantically, optionally includes up to
+  three shared-scope results, and annotates trust plus verification hints.
 - `search`: retrieve scoped results. Results can include reviewed durable
   `memory`, recent-continuity `checkpoint`, and unreviewed
   `memory_candidate` records.

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -9,10 +9,15 @@ instruction file, or an MCP client system prompt.
 ```text
 Use ContextForge as a scoped memory sidecar.
 
-At the start of a project task, run a small ContextForge bootstrap. Resolve the
-repo scope with repoPath, cwd, or an explicit scopeKey, then search durable
-memory for the current repo and, when useful, shared scope. Prefer canonical
+At the start of a project task, call bootstrap_context when available. Pass
+repoPath, cwd, or an explicit scopeKey so ContextForge can resolve the repo
+scope, then use the returned trust and verification hints. Prefer canonical
 GitHub scope keys such as github.com/owner/repo.
+
+Use semantic repo retrieval early for loose continuation requests such as
+"yesterday", "continue", "previous work", issue/PR follow-up, or cross-agent
+handoff. Search results may include durable memories, recent checkpoints, and
+memory candidates; use all three as context candidates.
 
 Before relying on results, identify whether ContextForge is using remote
 canonical storage or local/project-local storage. Remote results are shared
@@ -24,8 +29,13 @@ Interpret search result types carefully:
 - `checkpoint`: recent session continuity, not canonical truth.
 - `memory_candidate`: unreviewed promotion candidate, useful for review.
 
-Use search first. Use get_memory only when you know the exact key. Use local
-scope only when the memory is machine-specific or explicitly requested.
+Use bootstrap_context first, then targeted search if more detail is needed. Use
+get_memory only when you know the exact key. Use local scope only when the
+memory is machine-specific or explicitly requested.
+
+Treat retrieved context as a lead, not live truth. Re-check current branch,
+issue/PR state, CI, migrations, and runtime status with git, GitHub, tests, or
+the live system before acting on time-sensitive claims.
 
 Capture important raw evidence with append_raw during long work. Distill raw
 evidence into checkpoints when a task reaches a meaningful boundary, when the
@@ -59,9 +69,9 @@ Recommended minimal `AGENTS.md` snippet:
 ```text
 Use ContextForge MCP for scoped project memory.
 
-At task start, run a small bootstrap: search repo memory for this task, and
-search shared memory only when cross-repo/user-wide policy may matter. Use
-scopeKey github.com/example/repo unless the user says otherwise.
+At task start, call bootstrap_context for this task. Include shared memory only
+when cross-repo/user-wide policy may matter. Use scopeKey
+github.com/example/repo unless the user says otherwise.
 
 Check whether ContextForge is remote canonical storage or local/project-local
 storage before treating retrieval results as shared state.
@@ -69,8 +79,14 @@ storage before treating retrieval results as shared state.
 Interpret search result types by trust level: memory is reviewed durable state,
 checkpoint is recent continuity, and memory_candidate is review material.
 
+For loose continuation prompts like "yesterday", "continue", "previous work",
+issue/PR follow-up, or cross-agent handoff, search ContextForge before guessing
+from the current checkout. Review `checkpoint` and `memory_candidate` hits as
+context candidates, then verify current state in git/GitHub/runtime.
+
 Keep durable memory intentional. After distilling a checkpoint, review
-list_memory_candidates and promote only stable, reviewed facts.
+list_memory_candidates and promote only stable, reviewed facts. Promote durable
+lessons, not whole worklogs.
 
 For full ContextForge MCP usage rules, follow docs/agent-instructions.md from
 the ContextForge repo or the equivalent shared memory guide.
@@ -89,15 +105,21 @@ machines, agents, or deployment hosts:
 Use ContextForge MCP for scoped project memory.
 
 This repo uses remote ContextForge as the canonical shared memory store. At
-task start, call db_info if storage authority is unclear, then search repo
-scope for this task. Use scopeKey github.com/example/repo unless the user says
-otherwise. Search shared scope only for user-wide policy, deployment,
-credential-location, or cross-repo conventions.
+task start, call bootstrap_context for this task. Use scopeKey
+github.com/example/repo unless the user says otherwise. Include shared scope
+only for user-wide policy, deployment, credential-location, or cross-repo
+conventions.
 
 Interpret search result types by trust level:
 - memory: reviewed durable fact or decision.
 - checkpoint: recent session continuity; verify important claims before acting.
 - memory_candidate: unreviewed promotion candidate and review material.
+
+For loose continuation prompts such as "yesterday", "continue", "previous
+work", issue/PR follow-up, or cross-agent handoff, search repo scope before
+guessing from the checkout. Use semantic hits from memory, checkpoint, and
+memory_candidate together as context candidates, then verify current branch,
+issue/PR state, CI, migrations, and runtime status with live sources.
 
 When distilling, treat checkpoints as compressed retrieval indexes. Preserve
 concrete names, numbers, intervals, APIs, paths, commands, errors, decisions,
@@ -117,9 +139,9 @@ Use ContextForge MCP for scoped local project memory.
 
 This repo uses local/project-local ContextForge storage. Treat retrieval as
 machine-local context, not shared canonical memory, unless the user explicitly
-says this store is authoritative. At task start, call db_info when storage mode
-matters, then search repo scope for this task. Use local scope only for
-machine-specific notes.
+says this store is authoritative. At task start, call bootstrap_context when
+available, or db_info plus search when bootstrap_context is unavailable. Use
+local scope only for machine-specific notes.
 
 Interpret search result types by trust level:
 - memory: reviewed durable fact for this local store.
@@ -134,15 +156,19 @@ promote only stable, scoped, non-secret facts.
 ## Startup Bootstrap
 
 At the beginning of a non-trivial project task, do a small bootstrap instead of
-loading a large memory dump.
+loading a large memory dump. Prefer the single `bootstrap_context` tool when it
+is available; it resolves scope, summarizes storage/vector readiness, searches
+repo semantic memory, optionally searches shared memory, and annotates result
+trust levels.
 
 1. Resolve the intended scope. Use `scope: "repo"` with `repoPath`, `cwd`, or an
    explicit `scopeKey`.
-2. Call `db_info` when storage mode, remote/local authority, schema version, raw
-   retention, or vector readiness may affect the task.
-3. Search repo scope with a query derived from the user's task.
-4. Search shared scope only if user-wide conventions, deployment
+2. Call `bootstrap_context` with a query derived from the user's task.
+3. Search shared scope only if user-wide conventions, deployment
    policy, credentials locations, or cross-repo decisions may matter.
+4. If `bootstrap_context` is unavailable, call `db_info` when storage mode,
+   remote/local authority, schema version, raw retention, or vector readiness
+   may affect the task, then call `search`.
 5. If resuming a known session, call `session_status` for that `sessionId` to
    inspect recent checkpoint state.
 6. If the task depends on recent handoff state, call `list_memory_candidates`
@@ -153,11 +179,33 @@ Keep bootstrap small. Prefer one or two targeted `search` calls over loading all
 memory. Do not load raw evidence during bootstrap unless the user asks for
 forensics or provenance.
 
+For vague continuation language such as "yesterday", "continue", "previous
+work", "pick this back up", issue/PR follow-up, or cross-agent handoff, treat
+ContextForge as the first recall step. Use semantic search over the repo scope
+before inferring from visible files alone. Include the issue number, PR number,
+branch name, feature name, failing command, or date phrase in the query when the
+user gives one.
+
 Example bootstrap sequence:
 
 ```json
-{ "tool": "search", "args": { "scope": "repo", "repoPath": "/path/to/repo", "query": "user task keywords", "limit": 5 } }
-{ "tool": "search", "args": { "scope": "shared", "query": "relevant shared policy keywords", "limit": 3 } }
+{ "tool": "bootstrap_context", "args": { "scope": "repo", "repoPath": "/path/to/repo", "query": "user task keywords", "includeShared": false, "limit": 8 } }
+```
+
+Example continuation query:
+
+```json
+{ "tool": "bootstrap_context", "args": { "scope": "repo", "scopeKey": "github.com/example/service", "query": "yesterday issue 123 migration follow-up previous work", "limit": 8 } }
+```
+
+Equivalent CLI:
+
+```bash
+node src/cli.js bootstrapContext \
+  --scope repo \
+  --scopeKey github.com/example/service \
+  --query "yesterday issue 123 migration follow-up previous work" \
+  --limit 8
 ```
 
 ## Retrieval Order
@@ -166,14 +214,16 @@ For most coding tasks, use this order:
 
 1. `db_info` when you need to know whether the server is remote canonical
    storage or local/project-local storage.
-2. `search` repo scope for the active project.
-3. `search` shared scope if the task may depend on user-wide or organization
+2. `bootstrap_context` repo scope for the active project when available.
+3. `search` repo scope if you need additional targeted retrieval after
+   bootstrap.
+4. `search` shared scope if the task may depend on user-wide or organization
    conventions.
-4. `get_memory` only for exact durable keys returned by search or supplied by
+5. `get_memory` only for exact durable keys returned by search or supplied by
    the user.
-5. Use checkpoints for recent continuity, not canonical truth.
-6. Use memory candidates only as review material, not as canonical memory.
-7. Avoid raw evidence unless debugging distillation, reconstructing provenance,
+6. Use checkpoints for recent continuity, not canonical truth.
+7. Use memory candidates only as review material, not as canonical memory.
+8. Avoid raw evidence unless debugging distillation, reconstructing provenance,
    or explicitly asked.
 
 When the agent process starts outside the target checkout, pass `repoPath` or
@@ -215,6 +265,17 @@ token only; embedding provider credentials belong to the remote server process.
 Vector-backed checkpoint and candidate hits are useful for "what happened last
 time?" queries. They are intentionally not a replacement for durable memory.
 
+Vector matches are context candidates, not live truth. Always verify
+time-sensitive or externally mutable state against the current source of truth:
+
+- current branch, staged changes, and commits: git
+- issue, PR, review, and CI state: GitHub or the relevant forge
+- runtime health, migrations, queues, and deployed version: the live system
+- generated artifacts or local files: the filesystem and current tests
+
+This separation is the core safety rule: use ContextForge to remember what may
+matter, then use live tools to decide what is true now.
+
 ## Writing Memory
 
 Use `remember` only for durable facts that should survive the session, such as:
@@ -224,6 +285,9 @@ Use `remember` only for durable facts that should survive the session, such as:
 - user preferences that affect future work
 - operational constraints or failure modes
 - decisions from merged PRs or resolved incidents
+- long-lived API contracts, permission rules, or domain boundaries
+- final issue/PR conclusions that affect future implementation
+- cross-agent lessons that change how future work should be approached
 
 Do not use durable memory for:
 
@@ -232,10 +296,19 @@ Do not use durable memory for:
 - unresolved CI output unless the uncertainty is itself important
 - raw logs or large transcripts
 - secrets, tokens, private customer data, or personal data
+- current branch location, draft status, or one-time command output
+- raw commit logs or facts that git/GitHub/runtime can answer more safely
 
 Use `correct_memory` when a durable memory is still conceptually the same key
 but its content changed. Use `deactivate_memory` when a durable memory should no
 longer appear in retrieval, while preserving provenance.
+
+Write promoted memories as durable lessons, not worklogs. A good durable memory
+is short enough to scan, includes the decision and rationale when relevant, and
+keeps retrieval hooks such as API names, issue numbers, commands, paths, or
+domain terms. If the important part is "what happened today", leave it in a
+checkpoint; if the important part is "how future agents should decide", promote
+it.
 
 ## Checkpoints And Candidates
 
@@ -275,6 +348,11 @@ Promote with `promote_memory_candidate` only after review. A good candidate is:
 - free of secrets and private runtime data
 - not duplicated by an existing durable memory
 
+At the end of a substantial task, review the candidate queue and usually select
+only one to three items for promotion. It is normal for many `memory_candidate`
+records to accumulate; treat them as a review queue, not as a backlog that must
+be emptied.
+
 Candidate records may include review signals such as `candidateType`,
 `confidence`, `stability`, `sensitivity`, `promotionRecommendation`, and
 `sourceEventIds`. Use those fields to prioritize review. Treat `ignore`,
@@ -284,6 +362,24 @@ reasons to skip or reject unless the user explicitly asks to keep them.
 If a candidate key looks wrong, too broad, or belongs to the wrong repo, do not
 promote it as-is. Use `remember` with a corrected key/content or leave it as a
 checkpoint candidate.
+
+Example candidate review:
+
+```json
+{ "tool": "list_memory_candidates", "args": { "scope": "repo", "scopeKey": "github.com/example/service", "sessionId": "session-123", "limit": 10, "promotionRecommendation": "promote" } }
+```
+
+Example promotion after review:
+
+```json
+{ "tool": "promote_memory_candidate", "args": { "candidateId": "candidate-uuid", "reason": "Stable API contract that future agents need for issue follow-up." } }
+```
+
+Example corrected durable write instead of promoting a noisy candidate:
+
+```json
+{ "tool": "remember", "args": { "scope": "repo", "scopeKey": "github.com/example/service", "key": "api-contract-widget-delete", "category": "decision", "content": "Widget delete endpoints must remain idempotent: missing widgets return 204 so retrying cleanup jobs is safe.", "tags": ["api-contract", "delete", "idempotency"], "importance": 4 } }
+```
 
 ## Raw Evidence And Retention
 
@@ -320,6 +416,9 @@ Prefer distilling at meaningful boundaries:
 
 - `db_info`: inspect storage mode, table counts, raw retention, schema version,
   and sqlite-vec/embedding readiness.
+- `bootstrap_context`: resolve scoped startup context in one call. It searches
+  repo memory/checkpoints/candidates semantically, optionally includes shared
+  scope, and annotates trust plus verification hints.
 - `search`: retrieve scoped results. Results can include reviewed durable
   `memory`, recent-continuity `checkpoint`, and unreviewed
   `memory_candidate` records.

--- a/src/cli.js
+++ b/src/cli.js
@@ -71,6 +71,7 @@ function toCoreOptions(options) {
     limit: options.limit == null ? 10 : Number(options.limit),
     searchScopes: options.searchScopes,
     sharedScopeKey: options.sharedScopeKey,
+    includeShared: options.includeShared === true || options.includeShared === 'true',
     sessionId: options.sessionId,
     conversationId: options.conversationId,
     role: options.role,
@@ -127,6 +128,7 @@ async function main() {
   const { command, options } = parseArgs(process.argv);
   const commands = {
     dbInfo: (app) => app.dbInfo(),
+    bootstrapContext: (app, coreOptions) => app.bootstrapContext(coreOptions),
     doctorCodexExec: (app, coreOptions) => app.checkCodexExec(coreOptions),
     beginSession: (app, coreOptions) => app.beginSession(coreOptions),
     sessionStatus: (app, coreOptions) => app.sessionStatus(coreOptions),

--- a/src/core.js
+++ b/src/core.js
@@ -200,8 +200,8 @@ function resultTextForVerification(result) {
   return '';
 }
 
-function containsLiveStateSignal(result) {
-  return /\b(branch|pr|pull request|issue|ci|check|runtime|deploy|deployment|migration|migrate|server|service|queue|status|draft|merge|merged|commit|tag|release|rollback)\b/i.test(
+function requiresLiveStateVerification(result) {
+  return /\b(branch\w*|prs?|pull requests?|issues?|ci|checks?|runtimes?|deploy\w*|deployments?|migrations?|migrate\w*|servers?|services?|queues?|status|drafts?|merge\w*|merged|commits?|tags?|releases?|rollbacks?)\b/i.test(
     resultTextForVerification(result),
   );
 }
@@ -268,7 +268,10 @@ function bootstrapResultSummary(result) {
 
 function bootstrapResult(result, group) {
   const summary = bootstrapResultSummary(result);
-  const verificationRequired = result.type !== 'memory' || containsLiveStateSignal(result);
+  const verificationRequired =
+    result.type !== 'memory'
+      ? true
+      : requiresLiveStateVerification(result);
   return {
     group,
     type: result.type,
@@ -278,7 +281,7 @@ function bootstrapResult(result, group) {
     trust: bootstrapTrustForType(result.type),
     verificationRequired,
     whyUse: bootstrapUseHint(result),
-    score: result.score,
+    why: result.why,
     source: result.source,
     retrieval: result.retrieval,
     ...(summary.sessionId ? { sessionId: summary.sessionId } : {}),
@@ -307,7 +310,7 @@ function storageBootstrapInfo(config, info) {
   const vectorReady = Boolean(info.vector?.sqliteVecAvailable && info.embeddings?.enabled);
   return {
     mode: config.storageMode,
-    authority: config.storageMode === 'remote' ? 'canonical' : config.storageMode === 'local' ? 'local' : 'project_local',
+    authority: config.storageMode === 'remote' ? 'canonical' : config.storageMode === 'local' ? 'local' : 'project-local',
     vectorReady,
     sqliteVecAvailable: Boolean(info.vector?.sqliteVecAvailable),
     sqliteVecVersion: info.vector?.sqliteVecVersion || null,
@@ -554,6 +557,23 @@ export function createContextForge(options = {}) {
   };
   let lastRawPruneAt = 0;
 
+  function buildDbInfo(store) {
+    return {
+      ...store.dbInfo(),
+      storageMode: config.storageMode,
+      embeddings: {
+        provider: config.embeddings.provider,
+        model: config.embeddings.model,
+        dimensions: config.embeddings.dimensions,
+        enabled: Boolean(embeddingProvider),
+      },
+      rawRetention: {
+        ttlDays: config.rawRetention.ttlDays,
+        pruneIntervalMs: config.rawRetention.pruneIntervalMs,
+      },
+    };
+  }
+
   function pruneRawEventsIfDue(store, now = new Date()) {
     if (!config.rawRetention.ttlDays) {
       return null;
@@ -617,22 +637,24 @@ export function createContextForge(options = {}) {
     };
   }
 
+  function searchStoreWithScope(store, scope, options, queryEmbedding = null) {
+    return searchMemories(store, {
+      ...scope,
+      query: options.query,
+      limit: options.limit,
+      searchScopes: options.searchScopes,
+      sharedScopeKey: options.sharedScopeKey || config.defaultSharedScopeKey,
+      queryEmbedding,
+    });
+  }
+
   function searchWithScope(scope, options) {
-    const runSearch = (store, queryEmbedding = null) =>
-      searchMemories(store, {
-        ...scope,
-        query: options.query,
-        limit: options.limit,
-        searchScopes: options.searchScopes,
-        sharedScopeKey: options.sharedScopeKey || config.defaultSharedScopeKey,
-        queryEmbedding,
-      });
     if (!embeddingProvider) {
-      return useStore((store) => runSearch(store));
+      return useStore((store) => searchStoreWithScope(store, scope, options));
     }
     return useStore(async (store) => {
       const [queryEmbedding] = await embeddingProvider.embed([options.query]);
-      return runSearch(store, queryEmbedding);
+      return searchStoreWithScope(store, scope, options, queryEmbedding);
     });
   }
 
@@ -665,20 +687,7 @@ export function createContextForge(options = {}) {
     },
 
     dbInfo() {
-      return useStore((store) => ({
-        ...store.dbInfo(),
-        storageMode: config.storageMode,
-        embeddings: {
-          provider: config.embeddings.provider,
-          model: config.embeddings.model,
-          dimensions: config.embeddings.dimensions,
-          enabled: Boolean(embeddingProvider),
-        },
-        rawRetention: {
-          ttlDays: config.rawRetention.ttlDays,
-          pruneIntervalMs: config.rawRetention.pruneIntervalMs,
-        },
-      }));
+      return useStore((store) => buildDbInfo(store));
     },
 
     async bootstrapContext(options = {}) {
@@ -686,43 +695,62 @@ export function createContextForge(options = {}) {
       requireOption(options.query, 'query');
       const limit = positiveNumber(options.limit == null ? 8 : Number(options.limit), 'limit');
       const sharedLimit = Math.min(3, limit);
-      const info = await this.dbInfo();
-      const repoResults = await searchWithScope(scope, {
-        query: options.query,
-        limit,
-        sharedScopeKey: options.sharedScopeKey,
-      });
       const includeShared = truthyOption(options.includeShared);
-      const sharedResults =
-        includeShared && scope.scopeType !== 'shared'
-          ? await searchWithScope(
-              {
-                scopeType: 'shared',
-                scopeKey: options.sharedScopeKey || config.defaultSharedScopeKey,
-              },
-              {
-                query: options.query,
-                limit: sharedLimit,
-                sharedScopeKey: options.sharedScopeKey,
-              },
-            )
-          : [];
-      const results = [
-        ...repoResults.map((result) => bootstrapResult(result, 'primary')),
-        ...sharedResults.map((result) => bootstrapResult(result, 'shared')),
-      ];
-      return {
-        scope,
-        storage: storageBootstrapInfo(config, info),
-        query: options.query,
-        includeShared,
-        summary: bootstrapSummary(results),
-        results,
-        nextActions: [
-          'Verify current git/GitHub/CI/runtime/migration state before final claims or risky actions.',
-          'Review memory_candidate results at task end if durable lessons remain.',
-        ],
-      };
+      return useStore(async (store) => {
+        const info = buildDbInfo(store);
+        const queryEmbedding = embeddingProvider
+          ? (await embeddingProvider.embed([options.query]))[0]
+          : null;
+        const repoResults = searchStoreWithScope(
+          store,
+          scope,
+          {
+            query: options.query,
+            limit,
+            sharedScopeKey: options.sharedScopeKey,
+          },
+          queryEmbedding,
+        );
+        const sharedScopeKey = options.sharedScopeKey || config.defaultSharedScopeKey;
+        const sharedSkippedReason =
+          includeShared && scope.scopeType !== 'shared' && !sharedScopeKey
+            ? 'missing_shared_scope_key'
+            : null;
+        const sharedResults =
+          includeShared && scope.scopeType !== 'shared' && sharedScopeKey
+            ? searchStoreWithScope(
+                store,
+                {
+                  scopeType: 'shared',
+                  scopeKey: sharedScopeKey,
+                },
+                {
+                  query: options.query,
+                  limit: sharedLimit,
+                  sharedScopeKey,
+                },
+                queryEmbedding,
+              )
+            : [];
+        const results = [
+          ...repoResults.map((result) => bootstrapResult(result, 'primary')),
+          ...sharedResults.map((result) => bootstrapResult(result, 'shared')),
+        ];
+        return {
+          scope,
+          storage: storageBootstrapInfo(config, info),
+          query: options.query,
+          includeShared,
+          sharedLimit: includeShared ? sharedLimit : null,
+          ...(sharedSkippedReason ? { sharedSkippedReason } : {}),
+          summary: bootstrapSummary(results),
+          results,
+          nextActions: [
+            'Verify current git/GitHub/CI/runtime/migration state before final claims or risky actions.',
+            'Review memory_candidate results at task end if durable lessons remain.',
+          ],
+        };
+      });
     },
 
     checkCodexExec(options = {}) {

--- a/src/core.js
+++ b/src/core.js
@@ -167,6 +167,154 @@ function summarizeDistillUsage({ scope, sessionId, runs, charsPerToken = 4 }) {
   };
 }
 
+function truncateText(value, maxChars = 280) {
+  const text = String(value || '').replace(/\s+/g, ' ').trim();
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${text.slice(0, maxChars)}...`;
+}
+
+function resultTextForVerification(result) {
+  if (result.memory) {
+    return [result.memory.key, result.memory.category, result.memory.content, ...(result.memory.tags || [])].join(' ');
+  }
+  if (result.checkpoint) {
+    return [
+      result.checkpoint.summaryShort,
+      result.checkpoint.summaryText,
+      ...(result.checkpoint.decisions || []),
+      ...(result.checkpoint.todos || []),
+      ...(result.checkpoint.openQuestions || []),
+    ].join(' ');
+  }
+  if (result.candidate) {
+    return [
+      result.candidate.candidate.key,
+      result.candidate.candidate.category,
+      result.candidate.candidate.content,
+      result.candidate.candidate.reason,
+      ...(result.candidate.candidate.tags || []),
+    ].join(' ');
+  }
+  return '';
+}
+
+function containsLiveStateSignal(result) {
+  return /\b(branch|pr|pull request|issue|ci|check|runtime|deploy|deployment|migration|migrate|server|service|queue|status|draft|merge|merged|commit|tag|release|rollback)\b/i.test(
+    resultTextForVerification(result),
+  );
+}
+
+function bootstrapTrustForType(type) {
+  if (type === 'memory') {
+    return 'reviewed_durable';
+  }
+  if (type === 'checkpoint') {
+    return 'recent_continuity';
+  }
+  if (type === 'memory_candidate') {
+    return 'review_material';
+  }
+  return 'context_candidate';
+}
+
+function bootstrapUseHint(result) {
+  if (result.type === 'memory') {
+    return 'Reviewed durable state; use for decisions, but verify drift-prone facts against live sources.';
+  }
+  if (result.type === 'checkpoint') {
+    return 'Recent session continuity; useful for resuming work, but verify before acting.';
+  }
+  if (result.type === 'memory_candidate') {
+    return 'Unreviewed promotion candidate; useful context and review material, not canonical truth.';
+  }
+  return 'Context candidate; verify before acting.';
+}
+
+function bootstrapResultSummary(result) {
+  if (result.memory) {
+    return {
+      key: result.memory.key,
+      category: result.memory.category,
+      content: truncateText(result.memory.content),
+    };
+  }
+  if (result.checkpoint) {
+    return {
+      key: result.checkpoint.id,
+      category: 'checkpoint',
+      content: truncateText(result.checkpoint.summaryText || result.checkpoint.summaryShort),
+      sessionId: result.checkpoint.sessionId,
+      createdAt: result.checkpoint.createdAt,
+    };
+  }
+  if (result.candidate) {
+    return {
+      key: result.candidate.candidate.key,
+      category: result.candidate.candidate.category,
+      content: truncateText(result.candidate.candidate.content),
+      candidateId: result.candidate.id,
+      status: result.candidate.status,
+      checkpointId: result.candidate.checkpointId,
+    };
+  }
+  return {
+    key: null,
+    category: null,
+    content: '',
+  };
+}
+
+function bootstrapResult(result, group) {
+  const summary = bootstrapResultSummary(result);
+  const verificationRequired = result.type !== 'memory' || containsLiveStateSignal(result);
+  return {
+    group,
+    type: result.type,
+    key: summary.key,
+    category: summary.category,
+    content: summary.content,
+    trust: bootstrapTrustForType(result.type),
+    verificationRequired,
+    whyUse: bootstrapUseHint(result),
+    score: result.score,
+    source: result.source,
+    retrieval: result.retrieval,
+    ...(summary.sessionId ? { sessionId: summary.sessionId } : {}),
+    ...(summary.createdAt ? { createdAt: summary.createdAt } : {}),
+    ...(summary.candidateId ? { candidateId: summary.candidateId } : {}),
+    ...(summary.status ? { status: summary.status } : {}),
+    ...(summary.checkpointId ? { checkpointId: summary.checkpointId } : {}),
+  };
+}
+
+function bootstrapSummary(results) {
+  if (results.length === 0) {
+    return 'No relevant ContextForge results found for this bootstrap query.';
+  }
+  const counts = results.reduce((acc, result) => {
+    acc[result.type] = (acc[result.type] || 0) + 1;
+    return acc;
+  }, {});
+  const parts = Object.entries(counts)
+    .map(([type, count]) => `${count} ${type}`)
+    .join(', ');
+  return `Found ${results.length} relevant ContextForge result(s): ${parts}. Treat them as context candidates and verify live state before acting.`;
+}
+
+function storageBootstrapInfo(config, info) {
+  const vectorReady = Boolean(info.vector?.sqliteVecAvailable && info.embeddings?.enabled);
+  return {
+    mode: config.storageMode,
+    authority: config.storageMode === 'remote' ? 'canonical' : config.storageMode === 'local' ? 'local' : 'project_local',
+    vectorReady,
+    sqliteVecAvailable: Boolean(info.vector?.sqliteVecAvailable),
+    sqliteVecVersion: info.vector?.sqliteVecVersion || null,
+    embeddingProvider: info.embeddings?.provider || 'none',
+  };
+}
+
 function normalizeContentForRisk(value) {
   return String(value || '')
     .toLowerCase()
@@ -469,6 +617,25 @@ export function createContextForge(options = {}) {
     };
   }
 
+  function searchWithScope(scope, options) {
+    const runSearch = (store, queryEmbedding = null) =>
+      searchMemories(store, {
+        ...scope,
+        query: options.query,
+        limit: options.limit,
+        searchScopes: options.searchScopes,
+        sharedScopeKey: options.sharedScopeKey || config.defaultSharedScopeKey,
+        queryEmbedding,
+      });
+    if (!embeddingProvider) {
+      return useStore((store) => runSearch(store));
+    }
+    return useStore(async (store) => {
+      const [queryEmbedding] = await embeddingProvider.embed([options.query]);
+      return runSearch(store, queryEmbedding);
+    });
+  }
+
   function embeddingFailureResult(error) {
     const progress = error.embeddingProgress || {};
     return {
@@ -500,6 +667,7 @@ export function createContextForge(options = {}) {
     dbInfo() {
       return useStore((store) => ({
         ...store.dbInfo(),
+        storageMode: config.storageMode,
         embeddings: {
           provider: config.embeddings.provider,
           model: config.embeddings.model,
@@ -511,6 +679,50 @@ export function createContextForge(options = {}) {
           pruneIntervalMs: config.rawRetention.pruneIntervalMs,
         },
       }));
+    },
+
+    async bootstrapContext(options = {}) {
+      const scope = normalizeScopeOptions(options, config);
+      requireOption(options.query, 'query');
+      const limit = positiveNumber(options.limit == null ? 8 : Number(options.limit), 'limit');
+      const sharedLimit = Math.min(3, limit);
+      const info = await this.dbInfo();
+      const repoResults = await searchWithScope(scope, {
+        query: options.query,
+        limit,
+        sharedScopeKey: options.sharedScopeKey,
+      });
+      const includeShared = truthyOption(options.includeShared);
+      const sharedResults =
+        includeShared && scope.scopeType !== 'shared'
+          ? await searchWithScope(
+              {
+                scopeType: 'shared',
+                scopeKey: options.sharedScopeKey || config.defaultSharedScopeKey,
+              },
+              {
+                query: options.query,
+                limit: sharedLimit,
+                sharedScopeKey: options.sharedScopeKey,
+              },
+            )
+          : [];
+      const results = [
+        ...repoResults.map((result) => bootstrapResult(result, 'primary')),
+        ...sharedResults.map((result) => bootstrapResult(result, 'shared')),
+      ];
+      return {
+        scope,
+        storage: storageBootstrapInfo(config, info),
+        query: options.query,
+        includeShared,
+        summary: bootstrapSummary(results),
+        results,
+        nextActions: [
+          'Verify current git/GitHub/CI/runtime/migration state before final claims or risky actions.',
+          'Review memory_candidate results at task end if durable lessons remain.',
+        ],
+      };
     },
 
     checkCodexExec(options = {}) {
@@ -827,22 +1039,7 @@ export function createContextForge(options = {}) {
     search(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.query, 'query');
-      const runSearch = (store, queryEmbedding = null) =>
-        searchMemories(store, {
-          ...scope,
-          query: options.query,
-          limit: options.limit,
-          searchScopes: options.searchScopes,
-          sharedScopeKey: options.sharedScopeKey || config.defaultSharedScopeKey,
-          queryEmbedding,
-        });
-      if (!embeddingProvider) {
-        return useStore((store) => runSearch(store));
-      }
-      return useStore(async (store) => {
-        const [queryEmbedding] = await embeddingProvider.embed([options.query]);
-        return runSearch(store, queryEmbedding);
-      });
+      return searchWithScope(scope, options);
     },
 
     async rebuildEmbeddings(options = {}) {

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -67,7 +67,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Bootstrap Context',
       description:
-        'Resolve scoped ContextForge memory for a task in one call. Searches repo scope semantically across memory, checkpoint, and memory_candidate results, optionally includes shared scope, and annotates trust and verification hints for agents.',
+        'Resolve scoped ContextForge memory for a task in one call. Searches repo scope semantically across memory, checkpoint, and memory_candidate results, optionally includes up to 3 shared-scope results, and annotates trust and verification hints for agents.',
       inputSchema: {
         ...scopedSchema,
         query: z.string(),

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -24,7 +24,7 @@ function jsonResult(result) {
 
 const MCP_INSTRUCTIONS = [
   'Use ContextForge for scoped memory retrieval on demand.',
-  'At the start of non-trivial project work, run a small bootstrap: call db_info when storage mode or vector readiness matters, search repo scope for the task, and search shared scope only when cross-repo or user-wide policy may matter.',
+  'At the start of non-trivial project work, call bootstrap_context with repoPath, cwd, or an explicit scopeKey. It summarizes storage authority, vector readiness, repo semantic retrieval results, and trust hints in one response.',
   'If db_info shows remote storage, treat results as shared canonical ContextForge state for the configured scope. If it shows local or project-local storage, treat results as machine-local context unless the user confirms that store is authoritative.',
   'Search result types have different trust levels: memory is reviewed durable fact or decision; checkpoint is recent session continuity, not canonical truth; memory_candidate is an unreviewed promotion candidate for review.',
   'If working on a repository while the MCP process cwd is elsewhere, pass repoPath or cwd so repo scope resolves to that checkout; repoPath takes precedence when both are provided.',
@@ -60,6 +60,28 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
       },
     },
     async () => jsonResult(await app.dbInfo()),
+  );
+
+  server.registerTool(
+    'bootstrap_context',
+    {
+      title: 'Bootstrap Context',
+      description:
+        'Resolve scoped ContextForge memory for a task in one call. Searches repo scope semantically across memory, checkpoint, and memory_candidate results, optionally includes shared scope, and annotates trust and verification hints for agents.',
+      inputSchema: {
+        ...scopedSchema,
+        query: z.string(),
+        includeShared: z.boolean().optional(),
+        limit: z.number().int().positive().optional(),
+        sharedScopeKey: z.string().optional(),
+      },
+      annotations: {
+        title: 'Bootstrap Context',
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.bootstrapContext(args)),
   );
 
   server.registerTool(

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -2,6 +2,7 @@ import { normalizeScopeOptions } from '../scopes/index.js';
 
 const REMOTE_METHODS = [
   'dbInfo',
+  'bootstrapContext',
   'checkCodexExec',
   'beginSession',
   'sessionStatus',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -3362,6 +3362,46 @@ test('codex_exec parse failures preserve raw evidence', async () => {
   assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v3');
 });
 
+test('bootstrapContext returns semantic retrieval with trust and verification hints', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'repo-bootstrap',
+    key: 'issue-69-contract',
+    content: 'Issue 69 changed the bootstrap API contract for agents.',
+    category: 'decision',
+  });
+  app.remember({
+    scope: 'shared',
+    scopeKey: 'global',
+    key: 'agent-bootstrap-policy',
+    content: 'Agents should verify PR and CI state before acting on retrieved context.',
+    category: 'policy',
+  });
+
+  const result = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-bootstrap',
+    query: 'issue 69 bootstrap contract previous work',
+    includeShared: true,
+    limit: 5,
+  });
+
+  assert.deepEqual(result.scope, { scopeType: 'repo', scopeKey: 'repo-bootstrap' });
+  assert.equal(result.storage.mode, 'project-local');
+  assert.equal(result.storage.authority, 'project_local');
+  assert.match(result.summary, /Found/);
+  assert.ok(result.results.some((item) => item.group === 'primary' && item.key === 'issue-69-contract'));
+  assert.ok(result.results.some((item) => item.group === 'shared' && item.key === 'agent-bootstrap-policy'));
+  const repoHit = result.results.find((item) => item.key === 'issue-69-contract');
+  assert.equal(repoHit.trust, 'reviewed_durable');
+  assert.equal(repoHit.verificationRequired, true);
+  assert.match(repoHit.whyUse, /Reviewed durable/);
+  assert.ok(result.nextActions.some((item) => item.includes('Verify current git')));
+});
+
 test('CLI supports the v0 workflow with synthetic data', async () => {
   const dataDir = await makeTempDir();
   const env = { ...process.env, CONTEXTFORGE_DATA_DIR: dataDir };
@@ -3394,6 +3434,14 @@ test('CLI supports the v0 workflow with synthetic data', async () => {
     { env },
   );
   assert.match(search.stdout, /"key": "retrieval"/);
+
+  const bootstrap = await execFileAsync(
+    'node',
+    ['src/cli.js', 'bootstrapContext', '--scope', 'repo', '--scopeKey', 'cli-repo', '--query', 'durable previous work'],
+    { env },
+  );
+  assert.match(bootstrap.stdout, /"trust": "reviewed_durable"/);
+  assert.match(bootstrap.stdout, /"nextActions":/);
 
   await execFileAsync(
     'node',
@@ -3502,6 +3550,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     assert.deepEqual(toolNames, [
       'append_raw',
       'begin_session',
+      'bootstrap_context',
       'correct_memory',
       'db_info',
       'deactivate_memory',
@@ -3552,6 +3601,17 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       },
     });
     assert.equal(searchResult.structuredContent.result[0].memory.key, 'mcp-rule');
+
+    const bootstrapResult = await client.callTool({
+      name: 'bootstrap_context',
+      arguments: {
+        scope: 'repo',
+        scopeKey: 'mcp-repo',
+        query: 'retrieval demand previous work',
+      },
+    });
+    assert.equal(bootstrapResult.structuredContent.result.scope.scopeKey, 'mcp-repo');
+    assert.equal(bootstrapResult.structuredContent.result.results[0].trust, 'reviewed_durable');
 
     const repoPathResult = await client.callTool({
       name: 'remember',
@@ -3802,6 +3862,16 @@ test('remote storage mode delegates core calls and preserves scope semantics', a
     });
     assert.equal(repoResults.length, 1);
     assert.equal(repoResults[0].memory.scopeType, 'repo');
+
+    const bootstrap = await app.bootstrapContext({
+      scope: 'repo',
+      scopeKey: 'repo-remote',
+      query: 'remote shared scope previous work',
+      includeShared: true,
+    });
+    assert.equal(bootstrap.scope.scopeKey, 'repo-remote');
+    assert.ok(bootstrap.results.some((item) => item.group === 'primary' && item.key === 'storage-mode'));
+    assert.ok(bootstrap.results.some((item) => item.group === 'shared' && item.key === 'storage-mode'));
 
     await app.appendRaw({
       scope: 'repo',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -3370,8 +3370,15 @@ test('bootstrapContext returns semantic retrieval with trust and verification hi
     scope: 'repo',
     scopeKey: 'repo-bootstrap',
     key: 'issue-69-contract',
-    content: 'Issue 69 changed the bootstrap API contract for agents.',
+    content: 'Issues and PRs changed the bootstrap API contract for agents.',
     category: 'decision',
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'repo-bootstrap',
+    key: 'indentation-style',
+    content: 'Use four spaces for generated examples in this repo.',
+    category: 'preference',
   });
   app.remember({
     scope: 'shared',
@@ -3391,15 +3398,76 @@ test('bootstrapContext returns semantic retrieval with trust and verification hi
 
   assert.deepEqual(result.scope, { scopeType: 'repo', scopeKey: 'repo-bootstrap' });
   assert.equal(result.storage.mode, 'project-local');
-  assert.equal(result.storage.authority, 'project_local');
+  assert.equal(result.storage.authority, 'project-local');
   assert.match(result.summary, /Found/);
   assert.ok(result.results.some((item) => item.group === 'primary' && item.key === 'issue-69-contract'));
   assert.ok(result.results.some((item) => item.group === 'shared' && item.key === 'agent-bootstrap-policy'));
   const repoHit = result.results.find((item) => item.key === 'issue-69-contract');
   assert.equal(repoHit.trust, 'reviewed_durable');
   assert.equal(repoHit.verificationRequired, true);
+  assert.ok(Array.isArray(repoHit.why));
+  assert.equal(Object.hasOwn(repoHit, 'score'), false);
   assert.match(repoHit.whyUse, /Reviewed durable/);
   assert.ok(result.nextActions.some((item) => item.includes('Verify current git')));
+
+  const stableResult = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-bootstrap',
+    query: 'indentation style examples',
+    limit: 3,
+  });
+  const stableHit = stableResult.results.find((item) => item.key === 'indentation-style');
+  assert.equal(stableHit.verificationRequired, false);
+});
+
+test('bootstrapContext reuses one query embedding across repo and shared retrieval', async () => {
+  const dataDir = await makeTempDir();
+  let embedCalls = 0;
+  const provider = {
+    name: 'test-vector',
+    model: 'test-embedding',
+    dimensions: 3,
+    async embed(texts) {
+      embedCalls += 1;
+      return texts.map(() => [1, 0, 0]);
+    },
+  };
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_EMBEDDINGS_PROVIDER: 'openai',
+      CONTEXTFORGE_EMBEDDINGS_DIMENSIONS: '3',
+    },
+    cwd: process.cwd(),
+    embeddingProviders: {
+      openai: provider,
+    },
+  });
+
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'repo-bootstrap-embed',
+    key: 'repo-bootstrap-memory',
+    content: 'Repo bootstrap retrieval should reuse embeddings.',
+  });
+  app.remember({
+    scope: 'shared',
+    scopeKey: 'global',
+    key: 'shared-bootstrap-memory',
+    content: 'Shared bootstrap retrieval should reuse embeddings.',
+  });
+
+  const result = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-bootstrap-embed',
+    query: 'bootstrap retrieval',
+    includeShared: true,
+  });
+
+  assert.equal(embedCalls, 1);
+  assert.equal(result.sharedLimit, 3);
+  assert.ok(result.results.some((item) => item.group === 'primary'));
+  assert.ok(result.results.some((item) => item.group === 'shared'));
 });
 
 test('CLI supports the v0 workflow with synthetic data', async () => {


### PR DESCRIPTION
## Summary
- add core/CLI/remote/MCP bootstrapContext support for one-call agent startup context
- annotate bootstrap results with trust, verificationRequired, and whyUse hints
- expand agent instructions for semantic continuation retrieval, live-state verification, and candidate promotion discipline

Closes #69

## Tests
- npm test
- git diff --check