### PR TITLE
[codex] Add session working summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,42 @@ most `CONTEXTFORGE_DISTILL_MAX_EVENTS` and
 `CONTEXTFORGE_DISTILL_MAX_CHARS`, then records `sourceEventWindow` and
 `sourceRawEventIds` metadata on the run/checkpoint for auditability.
 
+Each successful `distillCheckpoint` also updates one scoped working summary for
+the session. Checkpoints remain immutable delta records for retrieval,
+provenance, and memory-candidate review. The working summary is different: it
+is overwritten with the latest rolling task state for live continuation and
+handoff. When a previous working summary exists, the distillation provider
+receives it together with the new raw-event window so it can update current
+state instead of emitting a delta-only summary. Treat it as current session
+state, not reviewed durable memory.
+
+When a caller knows the session id, `bootstrapContext` can return the working
+summary and a recent raw tail alongside ordinary retrieval results:
+
+```bash
+node src/cli.js bootstrapContext \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --sessionId current-session-id \
+  --query "current task handoff" \
+  --rawTailLimit 5
+```
+
+The bootstrap response keeps these channels separate:
+
+- `results`: durable memories, checkpoints, and memory candidates from search.
+- `workingSummary`: latest rolling handoff state for the requested session.
+- `rawTail`: newest raw events for last-mile continuity.
+
+For a direct lookup, use:
+
+```bash
+node src/cli.js getWorkingSummary \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --sessionId current-session-id
+```
+
 Use an external scheduler if you want unattended checkpoints. For example, a
 systemd timer or cron job can call:
 
@@ -1112,6 +1148,11 @@ repo-scoped `memory`, `checkpoint`, and `memory_candidate` hits as context
 candidates, optionally includes up to three shared-scope hits, then reminds the
 agent to verify current branch, issue/PR, CI, migration, and runtime state
 against live sources before acting.
+
+When resuming a known session, pass `sessionId` to `bootstrap_context` or
+`bootstrapContext`. ContextForge will include the session's latest
+`workingSummary` separately from search results so agents can see current task
+state without treating it as canonical memory.
 
 ## codex_exec Provider
 

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -19,6 +19,10 @@ Use semantic repo retrieval early for loose continuation requests such as
 handoff. Search results may include durable memories, recent checkpoints, and
 memory candidates; use all three as context candidates.
 
+When resuming a known session, pass `sessionId` to bootstrap_context. Use the
+returned `workingSummary` as latest rolling handoff state, and keep it separate
+from reviewed durable memory and checkpoint retrieval results.
+
 Before relying on results, identify whether ContextForge is using remote
 canonical storage or local/project-local storage. Remote results are shared
 ContextForge state for the configured scope. Local/project-local results are
@@ -172,7 +176,10 @@ trust levels.
    may affect the task, then call `search`.
 5. If resuming a known session, call `session_status` for that `sessionId` to
    inspect recent checkpoint state.
-6. If the task depends on recent handoff state, call `list_memory_candidates`
+6. If the task needs live handoff state, pass `sessionId` to
+   `bootstrap_context` or call `get_working_summary`. Treat the returned
+   working summary as current session state, not durable truth.
+7. If the task depends on recent handoff state, call `list_memory_candidates`
    for the relevant session or checkpoint and review candidates before
    promoting anything.
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -115,6 +115,7 @@ function toCoreOptions(options) {
     intervalMs: options.intervalMs == null ? undefined : Number(options.intervalMs),
     iterations: options.iterations == null ? undefined : Number(options.iterations),
     charsPerToken: options.charsPerToken == null ? undefined : Number(options.charsPerToken),
+    rawTailLimit: options.rawTailLimit == null ? undefined : Number(options.rawTailLimit),
     batchSize: options.batchSize == null ? undefined : Number(options.batchSize),
     force: options.force === true || options.force === 'true',
   };
@@ -145,6 +146,7 @@ async function main() {
     getMemory: (app, coreOptions) => app.getMemory(coreOptions),
     appendRaw: (app, coreOptions) => app.appendRaw(coreOptions),
     listRawEvents: (app, coreOptions) => app.listRawEvents(coreOptions),
+    getWorkingSummary: (app, coreOptions) => app.getWorkingSummary(coreOptions),
     pruneRawEvents: (app, coreOptions) => app.pruneRawEvents(coreOptions),
     distillCheckpoint: (app, coreOptions) => app.distillCheckpoint(coreOptions),
     listDistillRuns: (app, coreOptions) => app.listDistillRuns(coreOptions),

--- a/src/core.js
+++ b/src/core.js
@@ -232,6 +232,14 @@ function bootstrapUseHint(result) {
   return 'Context candidate; verify before acting.';
 }
 
+function errorSummary(error) {
+  if (!error) return null;
+  return {
+    name: error.name || 'Error',
+    message: error.message || String(error),
+  };
+}
+
 function bootstrapResultSummary(result) {
   if (result.memory) {
     return {
@@ -263,6 +271,38 @@ function bootstrapResultSummary(result) {
     key: null,
     category: null,
     content: '',
+  };
+}
+
+function bootstrapWorkingSummary(summary) {
+  if (!summary) {
+    return null;
+  }
+  return {
+    type: 'working_summary',
+    id: summary.id,
+    sessionId: summary.sessionId,
+    conversationId: summary.conversationId,
+    content: truncateText(summary.summaryText, 1200),
+    summaryShort: summary.summaryShort,
+    sourceCheckpointId: summary.sourceCheckpointId,
+    distillRunId: summary.distillRunId,
+    sourceEventCount: summary.sourceEventCount,
+    updatedAt: summary.updatedAt,
+    trust: 'live_continuity',
+    verificationRequired: true,
+    whyUse:
+      'Latest rolling session state for handoff; useful for live continuation, but not reviewed durable memory.',
+  };
+}
+
+function bootstrapRawTailEvent(event) {
+  return {
+    id: event.id,
+    role: event.role,
+    content: truncateText(event.content, 800),
+    metadata: event.metadata,
+    createdAt: event.createdAt,
   };
 }
 
@@ -696,6 +736,8 @@ export function createContextForge(options = {}) {
       const limit = positiveNumber(options.limit == null ? 8 : Number(options.limit), 'limit');
       const sharedLimit = Math.min(3, limit);
       const includeShared = truthyOption(options.includeShared);
+      const rawTailLimit =
+        options.rawTailLimit == null ? 5 : positiveNumber(Number(options.rawTailLimit), 'rawTailLimit');
       return useStore(async (store) => {
         const info = buildDbInfo(store);
         const queryEmbedding = embeddingProvider
@@ -736,12 +778,22 @@ export function createContextForge(options = {}) {
           ...repoResults.map((result) => bootstrapResult(result, 'primary')),
           ...sharedResults.map((result) => bootstrapResult(result, 'shared')),
         ];
+        const sessionId = options.sessionId || null;
+        const workingSummary = sessionId
+          ? bootstrapWorkingSummary(store.getWorkingSummary({ ...scope, sessionId }))
+          : null;
+        const rawTail = sessionId
+          ? store
+              .listRecentRawEvents({ ...scope, sessionId, limit: rawTailLimit })
+              .map((event) => bootstrapRawTailEvent(event))
+          : [];
         return {
           scope,
           storage: storageBootstrapInfo(config, info),
           query: options.query,
           includeShared,
           sharedLimit: includeShared ? sharedLimit : null,
+          ...(sessionId ? { sessionId, workingSummary, rawTail, rawTailLimit } : {}),
           ...(sharedSkippedReason ? { sharedSkippedReason } : {}),
           summary: bootstrapSummary(results),
           results,
@@ -1146,6 +1198,12 @@ export function createContextForge(options = {}) {
       return useStore((store) => store.listRawEvents({ ...scope, sessionId: options.sessionId }));
     },
 
+    getWorkingSummary(options) {
+      const scope = normalizeScopeOptions(options, config);
+      requireOption(options.sessionId, 'sessionId');
+      return useStore((store) => store.getWorkingSummary({ ...scope, sessionId: options.sessionId }));
+    },
+
     async distillCheckpoint(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.sessionId, 'sessionId');
@@ -1157,6 +1215,7 @@ export function createContextForge(options = {}) {
       return useStore(async (store) => {
         const rawEvents = store.listRawEvents({ ...scope, sessionId: options.sessionId });
         const previousCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId });
+        const previousWorkingSummary = store.getWorkingSummary({ ...scope, sessionId: options.sessionId });
         const policy = {
           maxEvents: positiveNumber(
             options.maxEvents == null ? config.distillPolicy.maxEvents : Number(options.maxEvents),
@@ -1178,6 +1237,7 @@ export function createContextForge(options = {}) {
           decisions: 'string[]',
           todos: 'string[]',
           openQuestions: 'string[]',
+          workingSummary: 'string',
           memoryCandidates: 'object[]',
           sourceEventCount: 'number',
           provider: 'string',
@@ -1192,6 +1252,7 @@ export function createContextForge(options = {}) {
           inputMetadata: {
             rawEventIds: selectedRawEvents.map((event) => event.id),
             previousCheckpointId: previousCheckpoint?.id || null,
+            previousWorkingSummaryId: previousWorkingSummary?.id || null,
             requestedOutputSchema,
             providerMetadata,
             sourceProvenance,
@@ -1209,6 +1270,7 @@ export function createContextForge(options = {}) {
             },
             rawEvents: selectedRawEvents,
             previousCheckpoint,
+            previousWorkingSummary,
             requestedOutputSchema,
           });
         } catch (error) {
@@ -1239,7 +1301,7 @@ export function createContextForge(options = {}) {
           throw error;
         }
 
-        const checkpoint = store.insertCheckpoint({
+        const checkpointInput = {
           ...scope,
           sessionId: options.sessionId,
           conversationId,
@@ -1258,7 +1320,56 @@ export function createContextForge(options = {}) {
             sourceRawEventIds: selectedRawEvents.map((event) => event.id),
             sourceEventWindow: distillWindow.metadata,
           },
-        });
+        };
+
+        let checkpoint = null;
+        let checkpointError = null;
+        try {
+          checkpoint = store.insertCheckpoint(checkpointInput);
+        } catch (error) {
+          checkpointError = error;
+        }
+
+        let workingSummary = null;
+        let workingSummaryError = null;
+        try {
+          workingSummary = store.upsertWorkingSummary({
+            ...scope,
+            sessionId: options.sessionId,
+            conversationId,
+            summaryShort: output.summaryShort,
+            summaryText: output.workingSummary || output.summaryText,
+            sourceCheckpointId: checkpoint?.id || null,
+            distillRunId: distillRun.id,
+            sourceEventCount: output.sourceEventCount ?? selectedRawEvents.length,
+            metadata: {
+              providerMetadata: output.metadata,
+              sourceProvenance,
+              sourceRawEventIds: selectedRawEvents.map((event) => event.id),
+              sourceEventWindow: distillWindow.metadata,
+              checkpointId: checkpoint?.id || null,
+              checkpointInsertFailed: Boolean(checkpointError),
+            },
+          });
+        } catch (error) {
+          workingSummaryError = error;
+        }
+
+        if (checkpointError) {
+          store.failDistillRun({
+            id: distillRun.id,
+            error: checkpointError,
+            outputMetadata: {
+              checkpointFailed: true,
+              checkpointError: errorSummary(checkpointError),
+              workingSummaryUpdated: Boolean(workingSummary),
+              workingSummaryId: workingSummary?.id || null,
+              workingSummaryError: errorSummary(workingSummaryError),
+              providerMetadata: output.metadata,
+            },
+          });
+          throw checkpointError;
+        }
 
         store.completeDistillRun({
           id: distillRun.id,
@@ -1266,6 +1377,9 @@ export function createContextForge(options = {}) {
             checkpointId: checkpoint.id,
             provider: checkpoint.provider,
             memoryCandidateCount: output.memoryCandidates.length,
+            workingSummaryUpdated: Boolean(workingSummary),
+            workingSummaryId: workingSummary?.id || null,
+            workingSummaryError: errorSummary(workingSummaryError),
             providerMetadata: output.metadata,
           },
         });
@@ -1299,6 +1413,11 @@ export function createContextForge(options = {}) {
         return {
           ...checkpoint,
           memoryCandidateCount: output.memoryCandidates.length,
+          workingSummary: {
+            updated: Boolean(workingSummary),
+            id: workingSummary?.id || null,
+            error: errorSummary(workingSummaryError),
+          },
           embedding,
         };
       });

--- a/src/core.js
+++ b/src/core.js
@@ -278,6 +278,8 @@ function bootstrapWorkingSummary(summary) {
   if (!summary) {
     return null;
   }
+  const checkpointInsertFailed = Boolean(summary.metadata?.checkpointInsertFailed);
+  // Keep bootstrap small and avoid leaking provider metadata; expose only handoff-safe state flags.
   return {
     type: 'working_summary',
     id: summary.id,
@@ -288,6 +290,8 @@ function bootstrapWorkingSummary(summary) {
     sourceCheckpointId: summary.sourceCheckpointId,
     distillRunId: summary.distillRunId,
     sourceEventCount: summary.sourceEventCount,
+    degraded: checkpointInsertFailed,
+    checkpointInsertFailed,
     updatedAt: summary.updatedAt,
     trust: 'live_continuity',
     verificationRequired: true,
@@ -736,8 +740,12 @@ export function createContextForge(options = {}) {
       const limit = positiveNumber(options.limit == null ? 8 : Number(options.limit), 'limit');
       const sharedLimit = Math.min(3, limit);
       const includeShared = truthyOption(options.includeShared);
-      const rawTailLimit =
-        options.rawTailLimit == null ? 5 : positiveNumber(Number(options.rawTailLimit), 'rawTailLimit');
+      const sessionId = options.sessionId || null;
+      const rawTailLimit = sessionId
+        ? options.rawTailLimit == null
+          ? 5
+          : positiveNumber(Number(options.rawTailLimit), 'rawTailLimit')
+        : null;
       return useStore(async (store) => {
         const info = buildDbInfo(store);
         const queryEmbedding = embeddingProvider
@@ -778,7 +786,6 @@ export function createContextForge(options = {}) {
           ...repoResults.map((result) => bootstrapResult(result, 'primary')),
           ...sharedResults.map((result) => bootstrapResult(result, 'shared')),
         ];
-        const sessionId = options.sessionId || null;
         const workingSummary = sessionId
           ? bootstrapWorkingSummary(store.getWorkingSummary({ ...scope, sessionId }))
           : null;

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v3';
+export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v4';
 export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v4';
 
 const OUTPUT_SCHEMA = {

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v3';
-export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v3';
+export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v4';
 
 const OUTPUT_SCHEMA = {
   $id: CODEX_EXEC_OUTPUT_SCHEMA_VERSION,
@@ -13,6 +13,7 @@ const OUTPUT_SCHEMA = {
   required: [
     'summaryShort',
     'summaryText',
+    'workingSummary',
     'decisions',
     'todos',
     'openQuestions',
@@ -24,6 +25,7 @@ const OUTPUT_SCHEMA = {
   properties: {
     summaryShort: { type: 'string', minLength: 1 },
     summaryText: { type: 'string', minLength: 1 },
+    workingSummary: { type: 'string', minLength: 1 },
     decisions: { type: 'array', items: { type: 'string' } },
     todos: { type: 'array', items: { type: 'string' } },
     openQuestions: { type: 'array', items: { type: 'string' } },
@@ -119,6 +121,18 @@ function compactCheckpoint(checkpoint) {
   };
 }
 
+function compactWorkingSummary(summary) {
+  if (!summary) return null;
+  return {
+    id: summary.id,
+    summaryShort: summary.summaryShort,
+    summaryText: summary.summaryText,
+    sourceCheckpointId: summary.sourceCheckpointId,
+    sourceEventCount: summary.sourceEventCount,
+    updatedAt: summary.updatedAt,
+  };
+}
+
 function buildRawEventPayload(rawEvents, maxInputChars) {
   const events = [];
   let remaining = maxInputChars;
@@ -158,6 +172,9 @@ export function buildCodexExecPrompt(input, options = {}) {
       'Preserve uncertainty in openQuestions instead of inventing facts.',
       'Use only the raw events and previous checkpoint supplied in this request.',
       'Write the checkpoint as recent continuity for handoff and search, not as canonical durable truth.',
+      'Write workingSummary as the latest rolling session state for immediate continuation: current goal, completed work, active blockers, and next actions.',
+      'If previousWorkingSummary is supplied, update it with the new raw events instead of replacing it with a delta-only summary.',
+      'Do not make workingSummary a durable fact; it is live handoff state and may be overwritten by later distills.',
       'Optimize the checkpoint for future retrieval, not for a generic meeting-summary style. Preserve concrete hooks a future agent might search for.',
       'Preserve proper nouns, API names, command names, file paths, issue or PR numbers, model names, error strings, numeric thresholds, time intervals, and cadence details when they matter.',
       'Distinguish decision, rationale, risks, conditions, and next action. Do not say only that a topic was discussed.',
@@ -178,6 +195,7 @@ export function buildCodexExecPrompt(input, options = {}) {
     session: input.session,
     requestedOutputSchema: input.requestedOutputSchema,
     previousCheckpoint: compactCheckpoint(input.previousCheckpoint),
+    previousWorkingSummary: compactWorkingSummary(input.previousWorkingSummary),
     rawEvents: rawPayload.events,
   };
 

--- a/src/distill/providers/mock.js
+++ b/src/distill/providers/mock.js
@@ -24,6 +24,10 @@ export async function distillWithMockProvider(input) {
       `Roles: ${roles}`,
       `First event: ${firstUsefulLine(events)}`,
     ].join('\n'),
+    workingSummary: [
+      `Current session state for ${input.session.sessionId}: ${sourceEventCount} raw event(s) distilled.`,
+      `Latest useful event: ${firstUsefulLine(events)}`,
+    ].join('\n'),
     decisions: collectLines(events, /\b(decision|decide|decided)\b/i),
     todos: collectLines(events, /\b(todo|next|follow up|fix|implement)\b/i),
     openQuestions: collectLines(events, /\?/),

--- a/src/distill/validate.js
+++ b/src/distill/validate.js
@@ -59,6 +59,10 @@ export function validateDistillOutput(output) {
     decisions: output.decisions,
     todos: output.todos,
     openQuestions: output.openQuestions,
+    workingSummary:
+      typeof output.workingSummary === 'string' && output.workingSummary.trim()
+        ? output.workingSummary
+        : output.summaryText,
     memoryCandidates: output.memoryCandidates,
     sourceEventCount: output.sourceEventCount,
     provider: output.provider,

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -27,6 +27,7 @@ const MCP_INSTRUCTIONS = [
   'At the start of non-trivial project work, call bootstrap_context with repoPath, cwd, or an explicit scopeKey. It summarizes storage authority, vector readiness, repo semantic retrieval results, and trust hints in one response.',
   'If db_info shows remote storage, treat results as shared canonical ContextForge state for the configured scope. If it shows local or project-local storage, treat results as machine-local context unless the user confirms that store is authoritative.',
   'Search result types have different trust levels: memory is reviewed durable fact or decision; checkpoint is recent session continuity, not canonical truth; memory_candidate is an unreviewed promotion candidate for review.',
+  'When resuming a known session, pass sessionId to bootstrap_context or call get_working_summary to load latest rolling handoff state separately from durable memory and checkpoint search results.',
   'If working on a repository while the MCP process cwd is elsewhere, pass repoPath or cwd so repo scope resolves to that checkout; repoPath takes precedence when both are provided.',
   'Treat scopeKey as the canonical repo memory key; pass an explicit normalized GitHub key when local paths differ across machines or the checkout cannot infer the right remote.',
   'Use remember for reviewed durable facts the user or assistant intentionally wants saved.',
@@ -71,6 +72,8 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
       inputSchema: {
         ...scopedSchema,
         query: z.string(),
+        sessionId: z.string().optional(),
+        rawTailLimit: z.number().int().positive().optional(),
         includeShared: z.boolean().optional(),
         limit: z.number().int().positive().optional(),
         sharedScopeKey: z.string().optional(),
@@ -249,6 +252,25 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
       },
     },
     async (args) => jsonResult(await app.pruneRawEvents(args)),
+  );
+
+  server.registerTool(
+    'get_working_summary',
+    {
+      title: 'Get Working Summary',
+      description:
+        'Fetch the latest rolling working summary for one scoped session. This is live continuation state, not reviewed durable memory.',
+      inputSchema: {
+        ...scopedSchema,
+        sessionId: z.string(),
+      },
+      annotations: {
+        title: 'Get Working Summary',
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.getWorkingSummary(args)),
   );
 
   server.registerTool(

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -19,6 +19,7 @@ const REMOTE_METHODS = [
   'rebuildEmbeddings',
   'appendRaw',
   'listRawEvents',
+  'getWorkingSummary',
   'pruneRawEvents',
   'distillCheckpoint',
   'listDistillRuns',

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -399,8 +399,6 @@ export class ContextForgeStore {
         ON distill_runs(scope_type, scope_key, session_id, created_at);
       CREATE INDEX IF NOT EXISTS idx_working_summaries_scope
         ON working_summaries(scope_type, scope_key, updated_at);
-      CREATE INDEX IF NOT EXISTS idx_working_summaries_session
-        ON working_summaries(scope_type, scope_key, session_id);
       CREATE INDEX IF NOT EXISTS idx_memory_candidate_scope_status
         ON memory_candidate_index(scope_type, scope_key, status, created_at);
       CREATE INDEX IF NOT EXISTS idx_memory_candidate_checkpoint

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -4,7 +4,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import Database from 'better-sqlite3';
 import * as sqliteVec from 'sqlite-vec';
 
-export const SCHEMA_VERSION = 8;
+export const SCHEMA_VERSION = 9;
 
 function nowIso() {
   return new Date().toISOString();
@@ -98,6 +98,25 @@ function hydrateDistillRun(row) {
     errorStack: row.error_stack,
     createdAt: row.created_at,
     completedAt: row.completed_at,
+  };
+}
+
+function hydrateWorkingSummary(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    scopeType: row.scope_type,
+    scopeKey: row.scope_key,
+    sessionId: row.session_id,
+    conversationId: row.conversation_id,
+    summaryShort: row.summary_short,
+    summaryText: row.summary_text,
+    sourceCheckpointId: row.source_checkpoint_id,
+    distillRunId: row.distill_run_id,
+    sourceEventCount: row.source_event_count,
+    metadata: parseJson(row.metadata_json, {}),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
   };
 }
 
@@ -301,6 +320,25 @@ export class ContextForgeStore {
         completed_at TEXT
       );
 
+      CREATE TABLE IF NOT EXISTS working_summaries (
+        id TEXT PRIMARY KEY,
+        scope_type TEXT NOT NULL CHECK (scope_type IN ('shared', 'repo', 'local')),
+        scope_key TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        conversation_id TEXT,
+        summary_short TEXT NOT NULL,
+        summary_text TEXT NOT NULL,
+        source_checkpoint_id TEXT,
+        distill_run_id TEXT,
+        source_event_count INTEGER NOT NULL DEFAULT 0,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE (scope_type, scope_key, session_id),
+        FOREIGN KEY (source_checkpoint_id) REFERENCES checkpoints(id) ON DELETE SET NULL,
+        FOREIGN KEY (distill_run_id) REFERENCES distill_runs(id) ON DELETE SET NULL
+      );
+
       CREATE TABLE IF NOT EXISTS memory_events (
         id TEXT PRIMARY KEY,
         memory_id TEXT NOT NULL,
@@ -359,6 +397,10 @@ export class ContextForgeStore {
         ON checkpoints(scope_type, scope_key, session_id, created_at);
       CREATE INDEX IF NOT EXISTS idx_distill_runs_session
         ON distill_runs(scope_type, scope_key, session_id, created_at);
+      CREATE INDEX IF NOT EXISTS idx_working_summaries_scope
+        ON working_summaries(scope_type, scope_key, updated_at);
+      CREATE INDEX IF NOT EXISTS idx_working_summaries_session
+        ON working_summaries(scope_type, scope_key, session_id);
       CREATE INDEX IF NOT EXISTS idx_memory_candidate_scope_status
         ON memory_candidate_index(scope_type, scope_key, status, created_at);
       CREATE INDEX IF NOT EXISTS idx_memory_candidate_checkpoint
@@ -409,6 +451,7 @@ export class ContextForgeStore {
         rawEvents: count('raw_events'),
         checkpoints: count('checkpoints'),
         distillRuns: count('distill_runs'),
+        workingSummaries: count('working_summaries'),
         memoryEvents: count('memory_events'),
         memoryCandidates: count('memory_candidate_index'),
         embeddings: embeddingIndexExists ? count('embedding_index') : 0,
@@ -1176,6 +1219,23 @@ export class ContextForgeStore {
       .map(hydrateRawEvent);
   }
 
+  listRecentRawEvents({ scopeType, scopeKey, sessionId, limit = 5 }) {
+    const parsedLimit = Number(limit);
+    if (!Number.isInteger(parsedLimit) || parsedLimit <= 0) {
+      return [];
+    }
+    return this.db
+      .prepare(`
+        SELECT * FROM raw_events
+        WHERE scope_type = ? AND scope_key = ? AND session_id = ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?
+      `)
+      .all(scopeType, scopeKey, sessionId, parsedLimit)
+      .map(hydrateRawEvent)
+      .reverse();
+  }
+
   getLatestCheckpoint({ scopeType, scopeKey, sessionId }) {
     const row = this.db
       .prepare(`
@@ -1206,6 +1266,70 @@ export class ContextForgeStore {
           .all(scopeType, scopeKey);
 
     return rows.map(hydrateCheckpoint);
+  }
+
+  getWorkingSummary({ scopeType, scopeKey, sessionId }) {
+    const row = this.db
+      .prepare(`
+        SELECT * FROM working_summaries
+        WHERE scope_type = ? AND scope_key = ? AND session_id = ?
+      `)
+      .get(scopeType, scopeKey, sessionId);
+    return hydrateWorkingSummary(row);
+  }
+
+  upsertWorkingSummary({
+    scopeType,
+    scopeKey,
+    sessionId,
+    conversationId = null,
+    summaryShort,
+    summaryText,
+    sourceCheckpointId = null,
+    distillRunId = null,
+    sourceEventCount = 0,
+    metadata = {},
+  }) {
+    if (!sessionId) throw new Error('sessionId is required.');
+    if (!summaryShort) throw new Error('working summary summaryShort is required.');
+    if (!summaryText) throw new Error('working summary summaryText is required.');
+
+    const timestamp = nowIso();
+    const row = this.db
+      .prepare(`
+        INSERT INTO working_summaries (
+          id, scope_type, scope_key, session_id, conversation_id,
+          summary_short, summary_text, source_checkpoint_id, distill_run_id,
+          source_event_count, metadata_json, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(scope_type, scope_key, session_id) DO UPDATE SET
+          conversation_id = excluded.conversation_id,
+          summary_short = excluded.summary_short,
+          summary_text = excluded.summary_text,
+          source_checkpoint_id = excluded.source_checkpoint_id,
+          distill_run_id = excluded.distill_run_id,
+          source_event_count = excluded.source_event_count,
+          metadata_json = excluded.metadata_json,
+          updated_at = excluded.updated_at
+        RETURNING *
+      `)
+      .get(
+        randomUUID(),
+        scopeType,
+        scopeKey,
+        sessionId,
+        conversationId,
+        summaryShort,
+        summaryText,
+        sourceCheckpointId,
+        distillRunId,
+        Number(sourceEventCount),
+        json(metadata, {}),
+        timestamp,
+        timestamp,
+      );
+    return hydrateWorkingSummary(row);
   }
 
   listMemoryCandidates({

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -2596,6 +2596,7 @@ test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
   assert.equal(info.tables.rawEvents, 2);
   assert.equal(info.tables.checkpoints, 1);
   assert.equal(info.tables.distillRuns, 1);
+  assert.equal(info.tables.workingSummaries, 1);
 
   const runs = app.listDistillRuns({
     scope: 'repo',
@@ -2605,7 +2606,19 @@ test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
   assert.equal(runs.length, 1);
   assert.equal(runs[0].status, 'succeeded');
   assert.equal(runs[0].outputMetadata.checkpointId, checkpoint.id);
+  assert.equal(runs[0].outputMetadata.workingSummaryUpdated, true);
+  assert.ok(runs[0].outputMetadata.workingSummaryId);
   assert.equal(runs[0].inputMetadata.sourceEventWindow.selectedEventCount, 2);
+  assert.equal(runs[0].inputMetadata.previousWorkingSummaryId, null);
+
+  const workingSummary = app.getWorkingSummary({
+    scope: 'repo',
+    scopeKey: 'repo-a',
+    sessionId: session.sessionId,
+  });
+  assert.equal(workingSummary.sessionId, session.sessionId);
+  assert.equal(workingSummary.sourceCheckpointId, checkpoint.id);
+  assert.match(workingSummary.summaryText, /Current session state/);
 
   const statusAfter = app.sessionStatus({
     scope: 'repo',
@@ -2619,6 +2632,256 @@ test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
   assert.equal(statusAfter.latestCheckpointMemoryCandidateCount, 0);
   assert.equal(statusAfter.memoryCandidateHint, null);
   assert.equal(statusAfter.shouldDistill, false);
+});
+
+test('bootstrapContext includes working summary and recent raw tail separately from search results', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'working_summary_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      working_summary_provider: async () => ({
+        summaryShort: 'Working summary checkpoint.',
+        summaryText: 'Checkpoint delta: the agent implemented storage scaffolding.',
+        workingSummary: 'Current state: storage is done, bootstrap wiring is next.',
+        decisions: [],
+        todos: ['Wire bootstrapContext to include working summary.'],
+        openQuestions: [],
+        memoryCandidates: [],
+        sourceEventCount: 1,
+        metadata: { synthetic: true },
+      }),
+    },
+  });
+
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'repo-working',
+    key: 'durable-rule',
+    content: 'Durable memory remains reviewed canonical state.',
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-working',
+    sessionId: 'working-session',
+    role: 'user',
+    content: 'Implement working summaries.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-working',
+    sessionId: 'working-session',
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-working',
+    sessionId: 'working-session',
+    role: 'assistant',
+    content: 'Bootstrap wiring is now in progress.',
+  });
+
+  const bootstrap = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-working',
+    sessionId: 'working-session',
+    query: 'durable working summary bootstrap',
+    rawTailLimit: 1,
+  });
+
+  assert.equal(bootstrap.results.some((item) => item.type === 'memory' && item.key === 'durable-rule'), true);
+  assert.equal(bootstrap.workingSummary.type, 'working_summary');
+  assert.equal(bootstrap.workingSummary.trust, 'live_continuity');
+  assert.match(bootstrap.workingSummary.content, /storage is done/);
+  assert.equal(bootstrap.rawTail.length, 1);
+  assert.match(bootstrap.rawTail[0].content, /Bootstrap wiring/);
+});
+
+test('distillCheckpoint passes previous working summary to provider for rolling updates', async () => {
+  const dataDir = await makeTempDir();
+  const seenPreviousWorkingSummaries = [];
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'rolling_summary_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      rolling_summary_provider: async (input) => {
+        seenPreviousWorkingSummaries.push(input.previousWorkingSummary);
+        return {
+          summaryShort: 'Rolling summary checkpoint.',
+          summaryText: 'Checkpoint delta for rolling summary.',
+          workingSummary: input.previousWorkingSummary
+            ? `${input.previousWorkingSummary.summaryText}\nUpdated with second pass.`
+            : 'Initial rolling state.',
+          decisions: [],
+          todos: [],
+          openQuestions: [],
+          memoryCandidates: [],
+          sourceEventCount: input.rawEvents.length,
+          metadata: {},
+        };
+      },
+    },
+  });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-rolling',
+    sessionId: 'rolling-session',
+    role: 'user',
+    content: 'Initial raw event.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-rolling',
+    sessionId: 'rolling-session',
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-rolling',
+    sessionId: 'rolling-session',
+    role: 'assistant',
+    content: 'Second raw event.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-rolling',
+    sessionId: 'rolling-session',
+  });
+
+  assert.equal(seenPreviousWorkingSummaries[0], null);
+  assert.match(seenPreviousWorkingSummaries[1].summaryText, /Initial rolling state/);
+  const workingSummary = app.getWorkingSummary({
+    scope: 'repo',
+    scopeKey: 'repo-rolling',
+    sessionId: 'rolling-session',
+  });
+  assert.match(workingSummary.summaryText, /Updated with second pass/);
+});
+
+test('distillCheckpoint recovers when working summary update fails after checkpoint insert', async () => {
+  const dataDir = await makeTempDir();
+  const store = new ContextForgeStore({ dataDir });
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'summary_fail_provider',
+    },
+    cwd: process.cwd(),
+    store,
+    distillProviders: {
+      summary_fail_provider: async () => ({
+        summaryShort: 'Checkpoint survives.',
+        summaryText: 'The checkpoint should persist even if working summary update fails.',
+        workingSummary: 'This working summary update will fail.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [],
+        sourceEventCount: 1,
+        metadata: {},
+      }),
+    },
+  });
+  store.upsertWorkingSummary = () => {
+    throw new Error('synthetic working summary failure');
+  };
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-summary-fail',
+    sessionId: 'summary-fail-session',
+    role: 'assistant',
+    content: 'Checkpoint should still be inserted.',
+  });
+
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-summary-fail',
+    sessionId: 'summary-fail-session',
+  });
+
+  assert.equal(checkpoint.summaryShort, 'Checkpoint survives.');
+  assert.equal(checkpoint.workingSummary.updated, false);
+  assert.match(checkpoint.workingSummary.error.message, /synthetic working summary failure/);
+  const runs = app.listDistillRuns({
+    scope: 'repo',
+    scopeKey: 'repo-summary-fail',
+    sessionId: 'summary-fail-session',
+  });
+  assert.equal(runs[0].status, 'succeeded');
+  assert.equal(runs[0].outputMetadata.checkpointId, checkpoint.id);
+  assert.match(runs[0].outputMetadata.workingSummaryError.message, /synthetic working summary failure/);
+  app.close();
+});
+
+test('distillCheckpoint records working summary if checkpoint insert fails', async () => {
+  const dataDir = await makeTempDir();
+  const store = new ContextForgeStore({ dataDir });
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'checkpoint_fail_provider',
+    },
+    cwd: process.cwd(),
+    store,
+    distillProviders: {
+      checkpoint_fail_provider: async () => ({
+        summaryShort: 'Summary survives.',
+        summaryText: 'Checkpoint insert will fail.',
+        workingSummary: 'Current state can still be saved for handoff.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [],
+        sourceEventCount: 1,
+        metadata: {},
+      }),
+    },
+  });
+  store.insertCheckpoint = () => {
+    throw new Error('synthetic checkpoint insert failure');
+  };
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-checkpoint-fail',
+    sessionId: 'checkpoint-fail-session',
+    role: 'assistant',
+    content: 'Working summary should still be attempted.',
+  });
+
+  await assert.rejects(
+    () =>
+      app.distillCheckpoint({
+        scope: 'repo',
+        scopeKey: 'repo-checkpoint-fail',
+        sessionId: 'checkpoint-fail-session',
+      }),
+    /synthetic checkpoint insert failure/,
+  );
+
+  const workingSummary = app.getWorkingSummary({
+    scope: 'repo',
+    scopeKey: 'repo-checkpoint-fail',
+    sessionId: 'checkpoint-fail-session',
+  });
+  assert.match(workingSummary.summaryText, /still be saved/);
+  assert.equal(workingSummary.sourceCheckpointId, null);
+
+  const runs = app.listDistillRuns({
+    scope: 'repo',
+    scopeKey: 'repo-checkpoint-fail',
+    sessionId: 'checkpoint-fail-session',
+  });
+  assert.equal(runs[0].status, 'failed');
+  assert.equal(runs[0].outputMetadata.checkpointFailed, true);
+  assert.equal(runs[0].outputMetadata.workingSummaryUpdated, true);
+  app.close();
 });
 
 test('raw event TTL pruning is controlled by environment config', async () => {
@@ -3079,6 +3342,7 @@ test('codex_exec provider distills synthetic raw events through a runner', async
         stdout: JSON.stringify({
           summaryShort: 'Codex checkpoint for synthetic events.',
           summaryText: 'The user decided to test the codex_exec provider path.',
+          workingSummary: 'Current state: codex_exec provider path is under synthetic test.',
           decisions: ['Use codex_exec behind the provider contract.'],
           todos: ['Document setup expectations.'],
           openQuestions: [],
@@ -3135,7 +3399,7 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.reasoningEffort, 'low');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.timeoutMs, 1234);
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v3');
-  assert.equal(checkpoint.metadata.providerMetadata.codexExec.outputSchemaVersion, 'contextforge.checkpoint.v3');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.outputSchemaVersion, 'contextforge.checkpoint.v4');
   assert.match(invocation.prompt, /Return exactly one JSON object/);
   assert.deepEqual(invocation.args.slice(0, 2), ['exec', '--skip-git-repo-check']);
   assert.ok(invocation.args.includes('--output-schema'));
@@ -3154,7 +3418,7 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   });
   assert.equal(runs[0].status, 'succeeded');
   assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v3');
-  assert.equal(runs[0].inputMetadata.providerMetadata.outputSchemaVersion, 'contextforge.checkpoint.v3');
+  assert.equal(runs[0].inputMetadata.providerMetadata.outputSchemaVersion, 'contextforge.checkpoint.v4');
   assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v3');
 });
 
@@ -3170,6 +3434,7 @@ test('codex_exec records JSON brace fallback recovery metadata', async () => {
       stdout: `prefix ${JSON.stringify({
         summaryShort: 'Recovered checkpoint.',
         summaryText: 'The provider output needed brace fallback recovery.',
+        workingSummary: 'Current state: brace fallback recovery succeeded.',
         decisions: [],
         todos: [],
         openQuestions: [],
@@ -3625,6 +3890,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'distill_checkpoint',
       'distill_usage',
       'get_memory',
+      'get_working_summary',
       'list_memory_candidates',
       'list_memory_events',
       'promote_memory',
@@ -3647,6 +3913,9 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     assert.ok(distillTool.inputSchema.properties.maxChars);
     const distillUsageTool = toolList.tools.find((tool) => tool.name === 'distill_usage');
     assert.ok(distillUsageTool.inputSchema.properties.charsPerToken);
+    const bootstrapTool = toolList.tools.find((tool) => tool.name === 'bootstrap_context');
+    assert.ok(bootstrapTool.inputSchema.properties.sessionId);
+    assert.ok(bootstrapTool.inputSchema.properties.rawTailLimit);
 
     const rememberResult = await client.callTool({
       name: 'remember',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -2881,6 +2881,15 @@ test('distillCheckpoint records working summary if checkpoint insert fails', asy
   assert.equal(runs[0].status, 'failed');
   assert.equal(runs[0].outputMetadata.checkpointFailed, true);
   assert.equal(runs[0].outputMetadata.workingSummaryUpdated, true);
+
+  const bootstrap = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-checkpoint-fail',
+    sessionId: 'checkpoint-fail-session',
+    query: 'checkpoint failed handoff',
+  });
+  assert.equal(bootstrap.workingSummary.degraded, true);
+  assert.equal(bootstrap.workingSummary.checkpointInsertFailed, true);
   app.close();
 });
 
@@ -3398,7 +3407,7 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.model, 'gpt-test');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.reasoningEffort, 'low');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.timeoutMs, 1234);
-  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v3');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v4');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.outputSchemaVersion, 'contextforge.checkpoint.v4');
   assert.match(invocation.prompt, /Return exactly one JSON object/);
   assert.deepEqual(invocation.args.slice(0, 2), ['exec', '--skip-git-repo-check']);
@@ -3417,9 +3426,9 @@ test('codex_exec provider distills synthetic raw events through a runner', async
     sessionId: 'codex-session',
   });
   assert.equal(runs[0].status, 'succeeded');
-  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v3');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v4');
   assert.equal(runs[0].inputMetadata.providerMetadata.outputSchemaVersion, 'contextforge.checkpoint.v4');
-  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v3');
+  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v4');
 });
 
 test('codex_exec records JSON brace fallback recovery metadata', async () => {
@@ -3623,8 +3632,8 @@ test('codex_exec parse failures preserve raw evidence', async () => {
   });
   assert.equal(runs[0].status, 'failed');
   assert.equal(runs[0].outputMetadata.providerFailed, true);
-  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v3');
-  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v3');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v4');
+  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v4');
 });
 
 test('bootstrapContext returns semantic retrieval with trust and verification hints', async () => {
@@ -3680,9 +3689,11 @@ test('bootstrapContext returns semantic retrieval with trust and verification hi
     scopeKey: 'repo-bootstrap',
     query: 'indentation style examples',
     limit: 3,
+    rawTailLimit: 0,
   });
   const stableHit = stableResult.results.find((item) => item.key === 'indentation-style');
   assert.equal(stableHit.verificationRequired, false);
+  assert.equal(Object.hasOwn(stableResult, 'rawTailLimit'), false);
 });
 
 test('bootstrapContext reuses one query embedding across repo and shared retrieval', async () => {


### PR DESCRIPTION
## Summary
- add a scoped `working_summaries` layer for latest session handoff state
- update `distillCheckpoint` to write checkpoint deltas and rolling working summaries separately
- expose working summaries through bootstrap, CLI, MCP, and remote client APIs
- document checkpoint vs working-summary semantics and add regression coverage

Closes #71

## Validation
- `npm test`
- `git diff --check`