### PR TITLE
[codex] Make distill raw stream conversation-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,11 +569,14 @@ node src/cli.js ingestCodexRollout \
   --distill auto
 ```
 
-`ingestCodexRollout` captures user, assistant, tool-call, and tool-result
-records, skips developer/system instructions, deduplicates previously ingested
-records by stable ingest ids, then checks `sessionStatus`. Use `--distill never`
-to capture only, `--distill auto` to distill when thresholds recommend it, or
-`--distill always` to force a checkpoint after ingest.
+`ingestCodexRollout` captures user and assistant conversation records, skips
+developer/system instructions, and leaves tool-call/tool-result payloads in the
+native Codex transcript. ContextForge raw events are distillation-ready
+conversation evidence, not a clone of the native JSONL log. The adapter
+deduplicates previously ingested records by stable ingest ids, then checks
+`sessionStatus`. Use `--distill never` to capture only, `--distill auto` to
+distill when thresholds recommend it, or `--distill always` to force a
+checkpoint after ingest.
 
 Codex-ingested raw events use a namespaced session id:
 `codex:<native-codex-session-id>`. Their metadata also includes
@@ -783,11 +786,19 @@ checkpoint by itself. After a checkpoint exists, the event threshold is paired
 with the interval threshold, and the character threshold can trigger on its own
 to avoid overrunning the provider input budget.
 
-Checkpoint distillation uses a bounded recent raw-event window. Very large
-sessions are not sent to the provider as one prompt; ContextForge selects at
-most `CONTEXTFORGE_DISTILL_MAX_EVENTS` and
-`CONTEXTFORGE_DISTILL_MAX_CHARS`, then records `sourceEventWindow` and
-`sourceRawEventIds` metadata on the run/checkpoint for auditability.
+Checkpoint distillation uses a bounded oldest-first conversation window after
+the latest checkpoint. Very large sessions are not sent to the provider as one
+prompt; ContextForge selects at most `CONTEXTFORGE_DISTILL_MAX_EVENTS` and
+`CONTEXTFORGE_DISTILL_MAX_CHARS` from eligible user/assistant events, then
+records `sourceEventWindow` and `sourceRawEventIds` metadata on the
+run/checkpoint for auditability. When a window is truncated, the next
+checkpoint continues after the last selected raw id so conversation evidence is
+drained sequentially rather than skipping older raw events.
+
+Tool output is evidence, not conversation memory. Long logs, DB dumps, and
+shell output should remain in the native transcript or an explicit artifact;
+checkpoints should preserve the assistant's interpreted verification facts,
+commands, paths, errors, and conclusions that matter for future continuation.
 
 Each successful `distillCheckpoint` also updates one scoped working summary for
 the session. Checkpoints remain immutable delta records for retrieval,

--- a/README.md
+++ b/README.md
@@ -551,8 +551,8 @@ Distillation cost is controlled by the threshold policy. `CONTEXTFORGE_DISTILL_M
 sets the normal minimum interval after a checkpoint, and
 `CONTEXTFORGE_DISTILL_CHAR_MIN_INTERVAL_MS` controls how soon a char-threshold
 trigger may create another checkpoint. By default the char trigger uses the same
-minimum interval, so one long tool output does not immediately force another
-LLM distillation right after a checkpoint.
+minimum interval, so one long conversation turn does not immediately force
+another LLM distillation right after a checkpoint.
 
 Codex TUI sessions can also be ingested from their rollout JSONL artifacts
 without routing raw transcript text through the model. This keeps raw capture
@@ -795,10 +795,22 @@ run/checkpoint for auditability. When a window is truncated, the next
 checkpoint continues after the last selected raw id so conversation evidence is
 drained sequentially rather than skipping older raw events.
 
+If a session has a large backlog, oldest-first draining may require several
+`distillCheckpoint` calls before the newest conversation turns appear in a
+checkpoint. This is intentional: ContextForge favors gap-free checkpoint
+chains over jumping straight to the newest tail.
+
 Tool output is evidence, not conversation memory. Long logs, DB dumps, and
 shell output should remain in the native transcript or an explicit artifact;
 checkpoints should preserve the assistant's interpreted verification facts,
 commands, paths, errors, and conclusions that matter for future continuation.
+Existing databases may still contain older `tool_call` or `tool_result`
+`raw_events` rows. Those rows are preserved and still visible through
+`listRawEvents`, but new distillation windows exclude them from
+`eventsSinceLastCheckpoint`, `charsSinceLastCheckpoint`, and provider input.
+The lower-level storage API intentionally remains permissive for legacy data
+and tests; the public `appendRaw` API and MCP `append_raw` tool enforce the
+`user`/`assistant` role boundary.
 
 Each successful `distillCheckpoint` also updates one scoped working summary for
 the session. Checkpoints remain immutable delta records for retrieval,

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -435,7 +435,10 @@ Prefer distilling at meaningful boundaries:
 - `correct_memory`: update a durable memory while preserving provenance.
 - `deactivate_memory`: remove a durable memory from retrieval without deleting
   history.
-- `append_raw`: capture scoped evidence for distillation and debugging.
+- `append_raw`: capture scoped user/assistant conversation evidence for
+  distillation and debugging. Tool output is evidence, not conversation memory;
+  keep tool-call/tool-result payloads in the native agent transcript or an
+  explicit artifact, and distill the assistant-interpreted verification facts.
 - `session_status`: inspect raw/checkpoint thresholds before distilling.
 - `distill_checkpoint`: create a recent-continuity checkpoint.
 - `distill_usage`: summarize distillation run counts, selected input size,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -270,7 +270,7 @@ Recommended order:
 1. current repository reality
 2. ContextForge durable memory from `repo + shared`
 3. checkpoints for recent continuity when requested
-4. raw evidence only when explicit
+4. raw conversation evidence only when explicit
 5. built-in agent memory and markdown fallback as supporting context
 
 Avoid:
@@ -279,6 +279,11 @@ Avoid:
 - auto-loading raw events
 - dumping giant memory files into prompt context
 - treating vector results as unexplainable truth
+
+ContextForge raw events are a distillation-ready conversation evidence stream,
+not a canonical clone of native agent transcripts. Store user/assistant
+dialogue for checkpointing; leave tool-call/tool-result payloads, long logs,
+DB dumps, and shell output in the native transcript or an explicit artifact.
 
 The default runtime should minimize prompt bloat by preloading only tiny
 bootstrap context, then using `search` and `getMemory` for detail.

--- a/src/core.js
+++ b/src/core.js
@@ -445,6 +445,10 @@ function checkpointTimestamp(checkpoint) {
   return checkpoint?.createdAt ? Date.parse(checkpoint.createdAt) : null;
 }
 
+function isDistillableRawEvent(event) {
+  return event?.role === 'user' || event?.role === 'assistant';
+}
+
 function eventsAfterCheckpoint(events, checkpoint) {
   const sourceRawEventIds = Array.isArray(checkpoint?.metadata?.sourceRawEventIds)
     ? checkpoint.metadata.sourceRawEventIds
@@ -453,13 +457,13 @@ function eventsAfterCheckpoint(events, checkpoint) {
   if (lastSourceRawEventId) {
     const lastSourceIndex = events.findIndex((event) => event.id === lastSourceRawEventId);
     if (lastSourceIndex !== -1) {
-      return events.slice(lastSourceIndex + 1);
+      return events.slice(lastSourceIndex + 1).filter(isDistillableRawEvent);
     }
   }
 
   const checkpointTime = checkpointTimestamp(checkpoint);
-  if (!checkpointTime) return events;
-  return events.filter((event) => Date.parse(event.createdAt) > checkpointTime);
+  if (!checkpointTime) return events.filter(isDistillableRawEvent);
+  return events.filter((event) => isDistillableRawEvent(event) && Date.parse(event.createdAt) > checkpointTime);
 }
 
 function selectDistillWindow(rawEvents, latestCheckpoint, policy) {
@@ -469,14 +473,14 @@ function selectDistillWindow(rawEvents, latestCheckpoint, policy) {
   const maxEvents = policy.maxEvents;
   const maxChars = policy.maxChars;
 
-  for (let index = candidateEvents.length - 1; index >= 0; index -= 1) {
+  for (let index = 0; index < candidateEvents.length; index += 1) {
     if (selected.length >= maxEvents) break;
     const event = candidateEvents[index];
     const eventChars = String(event.content || '').length;
     if (selected.length > 0 && selectedChars + eventChars > maxChars) {
       break;
     }
-    selected.unshift(event);
+    selected.push(event);
     selectedChars += eventChars;
     if (selectedChars >= maxChars) {
       break;
@@ -1167,6 +1171,9 @@ export function createContextForge(options = {}) {
       requireOption(options.sessionId, 'sessionId');
       requireOption(options.role, 'role');
       requireOption(options.content, 'content');
+      if (options.role !== 'user' && options.role !== 'assistant') {
+        throw new Error('role must be one of: user, assistant');
+      }
       return useStore((store) => {
         pruneRawEventsIfDue(store);
         return store.appendRawEvent({

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v4';
+export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v5';
 export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v4';
 
 const OUTPUT_SCHEMA = {
@@ -170,7 +170,10 @@ export function buildCodexExecPrompt(input, options = {}) {
       'Return only JSON that matches the requested schema.',
       'Do not include Markdown, code fences, commentary, or private assumptions.',
       'Preserve uncertainty in openQuestions instead of inventing facts.',
-      'Use only the raw events and previous checkpoint supplied in this request.',
+      'Use only the conversation events and previous checkpoint supplied in this request.',
+      'rawEvents contains distillation-ready user/assistant conversation evidence only; it is not a native transcript clone.',
+      'Tool call and tool result payloads are not included by default. Tool output is evidence, not conversation memory.',
+      'When tool verification matters, summarize the assistant-interpreted conclusion instead of copying raw command output.',
       'Write the checkpoint as recent continuity for handoff and search, not as canonical durable truth.',
       'Write workingSummary as the latest rolling session state for immediate continuation: current goal, completed work, active blockers, and next actions.',
       'If previousWorkingSummary is supplied, update it with the new raw events instead of replacing it with a delta-only summary.',

--- a/src/ingest/claude_code.js
+++ b/src/ingest/claude_code.js
@@ -42,12 +42,6 @@ function textFromContent(content) {
     .map((item) => {
       if (!item || typeof item !== 'object') return '';
       if (item.type === 'text') return item.text || '';
-      if (item.type === 'tool_use') {
-        return JSON.stringify({ name: item.name || 'tool_use', input: item.input || {}, id: item.id || null }, null, 2);
-      }
-      if (item.type === 'tool_result') {
-        return typeof item.content === 'string' ? item.content : JSON.stringify(item.content ?? '', null, 2);
-      }
       return '';
     })
     .filter(Boolean)
@@ -60,16 +54,6 @@ function roleFromRecord(record) {
     return role;
   }
   return null;
-}
-
-function outputRoleFromContent(content, fallbackRole) {
-  if (Array.isArray(content) && content.some((item) => item?.type === 'tool_use')) {
-    return 'tool_call';
-  }
-  if (Array.isArray(content) && content.some((item) => item?.type === 'tool_result')) {
-    return 'tool_result';
-  }
-  return fallbackRole;
 }
 
 export function normalizeClaudeCodeRecord(record, context, options = {}) {
@@ -94,7 +78,7 @@ export function normalizeClaudeCodeRecord(record, context, options = {}) {
 
   const native = context.nativeSessionId || stripClaudeCodeSessionPrefix(context.sessionId) || null;
   return {
-    role: outputRoleFromContent(contentValue, role),
+    role,
     content: content.text,
     metadata: {
       source: 'claude_code_jsonl',

--- a/src/ingest/codex.js
+++ b/src/ingest/codex.js
@@ -47,22 +47,6 @@ function textFromContent(content) {
     .join('\n\n');
 }
 
-function normalizeFunctionCall(payload) {
-  const name = payload.name || payload.call?.name || 'tool_call';
-  const args = payload.arguments || payload.call?.arguments || {};
-  return {
-    role: 'tool_call',
-    content: JSON.stringify({ name, arguments: args }, null, 2),
-  };
-}
-
-function normalizeFunctionOutput(payload) {
-  return {
-    role: 'tool_result',
-    content: payload.output || payload.result || '',
-  };
-}
-
 export function normalizeCodexRolloutRecord(record, context, options = {}) {
   if (record.type === 'session_meta') {
     const nativeSessionId = record.payload?.id;
@@ -84,17 +68,13 @@ export function normalizeCodexRolloutRecord(record, context, options = {}) {
       role: payload.role,
       content: textFromContent(payload.content),
     };
-  } else if (payload.type === 'function_call') {
-    normalized = normalizeFunctionCall(payload);
-  } else if (payload.type === 'function_call_output') {
-    normalized = normalizeFunctionOutput(payload);
   }
 
   if (!normalized?.content) {
     return null;
   }
 
-      const content = truncate(normalized.content, options.maxContentChars || DEFAULT_MAX_CONTENT_CHARS);
+  const content = truncate(normalized.content, options.maxContentChars || DEFAULT_MAX_CONTENT_CHARS);
   return {
     role: normalized.role,
     content: content.text,

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -223,7 +223,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
         ...scopedSchema,
         sessionId: z.string(),
         conversationId: z.string().optional(),
-        role: z.string(),
+        role: z.enum(['user', 'assistant']),
         content: z.string(),
         metadata: metadataSchema.optional(),
       },

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -149,7 +149,10 @@ async function writeSyntheticClaudeCodeTranscript(filePath, sessionId = 'claude-
       timestamp: '2026-04-25T00:00:04.000Z',
       message: {
         role: 'assistant',
-        content: [{ type: 'text', text: 'I added Claude Code transcript ingestion.' }],
+        content: [
+          { type: 'text', text: 'I added Claude Code transcript ingestion.' },
+          { type: 'tool_use', id: 'toolu_2', name: 'TodoWrite', input: { todos: [] } },
+        ],
       },
     },
   ];
@@ -1246,10 +1249,10 @@ test('CLI ingests Codex rollout JSONL idempotently without capturing developer m
     { env },
   );
   const firstResult = JSON.parse(first.stdout);
-  assert.equal(firstResult.parsedEvents, 4);
-  assert.equal(firstResult.appendedEvents, 4);
+  assert.equal(firstResult.parsedEvents, 2);
+  assert.equal(firstResult.appendedEvents, 2);
   assert.equal(firstResult.skippedEvents, 0);
-  assert.equal(firstResult.status.rawEventCount, 4);
+  assert.equal(firstResult.status.rawEventCount, 2);
 
   const second = await execFileAsync(
     'node',
@@ -1269,8 +1272,8 @@ test('CLI ingests Codex rollout JSONL idempotently without capturing developer m
   );
   const secondResult = JSON.parse(second.stdout);
   assert.equal(secondResult.appendedEvents, 0);
-  assert.equal(secondResult.skippedEvents, 4);
-  assert.equal(secondResult.status.rawEventCount, 4);
+  assert.equal(secondResult.skippedEvents, 2);
+  assert.equal(secondResult.status.rawEventCount, 2);
 
   const rawEvents = await execFileAsync(
     'node',
@@ -1289,7 +1292,7 @@ test('CLI ingests Codex rollout JSONL idempotently without capturing developer m
   const events = JSON.parse(rawEvents.stdout);
   assert.deepEqual(
     events.map((event) => event.role),
-    ['user', 'tool_call', 'tool_result', 'assistant'],
+    ['user', 'assistant'],
   );
   assert.equal(events.some((event) => event.content.includes('Developer instructions')), false);
   assert.ok(events.every((event) => event.metadata.ingestId));
@@ -1331,7 +1334,7 @@ test('CLI ingest can auto-distill Codex rollout evidence', async () => {
     { env },
   );
   const result = JSON.parse(ingested.stdout);
-  assert.equal(result.appendedEvents, 4);
+  assert.equal(result.appendedEvents, 2);
   assert.equal(result.status.shouldDistill, true);
   assert.equal(result.checkpoint.sessionId, 'codex:codex-auto-distill-session');
   assert.equal(result.checkpoint.provider, 'mock');
@@ -1377,7 +1380,7 @@ test('Codex ingest preserves raw evidence when auto distill fails', async () => 
     charThreshold: 1,
   });
 
-  assert.equal(result.appendedEvents, 4);
+  assert.equal(result.appendedEvents, 2);
   assert.equal(result.checkpoint, null);
   assert.match(result.checkpointError.message, /synthetic provider failure/);
 
@@ -1386,7 +1389,7 @@ test('Codex ingest preserves raw evidence when auto distill fails', async () => 
     scopeKey: 'codex-auto-fail-repo',
     sessionId: 'codex:codex-auto-fail-session',
   });
-  assert.equal(events.length, 4);
+  assert.equal(events.length, 2);
   const runs = app.listDistillRuns({
     scope: 'repo',
     scopeKey: 'codex-auto-fail-repo',
@@ -1474,8 +1477,8 @@ test('CLI ingest works through remote storage mode', async () => {
       { env },
     );
     const result = JSON.parse(ingested.stdout);
-    assert.equal(result.appendedEvents, 4);
-    assert.equal(result.status.rawEventCount, 4);
+    assert.equal(result.appendedEvents, 2);
+    assert.equal(result.status.rawEventCount, 2);
 
     const app = createContextForge({ env, cwd: process.cwd() });
     const rawEvents = await app.listRawEvents({
@@ -1483,7 +1486,7 @@ test('CLI ingest works through remote storage mode', async () => {
       scopeKey: 'codex-remote-ingest-repo',
       sessionId: 'codex:codex-remote-ingest-session',
     });
-    assert.equal(rawEvents.length, 4);
+    assert.equal(rawEvents.length, 2);
   } finally {
     await remote.close();
   }
@@ -1516,8 +1519,8 @@ test('CLI ingests multiple Codex session rollout files safely', async () => {
   );
   const firstResult = JSON.parse(first.stdout);
   assert.equal(firstResult.filesScanned, 2);
-  assert.equal(firstResult.parsedEvents, 8);
-  assert.equal(firstResult.appendedEvents, 8);
+  assert.equal(firstResult.parsedEvents, 4);
+  assert.equal(firstResult.appendedEvents, 4);
   assert.equal(firstResult.skippedEvents, 0);
   assert.deepEqual(
     firstResult.fileResults.map((result) => result.sessionId).sort(),
@@ -1544,7 +1547,7 @@ test('CLI ingests multiple Codex session rollout files safely', async () => {
   const secondResult = JSON.parse(second.stdout);
   assert.equal(secondResult.filesScanned, 2);
   assert.equal(secondResult.appendedEvents, 0);
-  assert.equal(secondResult.skippedEvents, 8);
+  assert.equal(secondResult.skippedEvents, 4);
 
   const app = createContextForge({ env, cwd: process.cwd() });
   const firstEvents = app.listRawEvents({
@@ -1557,8 +1560,8 @@ test('CLI ingests multiple Codex session rollout files safely', async () => {
     scopeKey: 'codex-multi-session-repo',
     sessionId: 'codex:codex-session-second',
   });
-  assert.equal(firstEvents.length, 4);
-  assert.equal(secondEvents.length, 4);
+  assert.equal(firstEvents.length, 2);
+  assert.equal(secondEvents.length, 2);
 });
 
 test('repoPath ingest skips Codex session files from other working directories', async () => {
@@ -1632,17 +1635,17 @@ test('Codex sessions watch loop picks up new events without duplicates', async (
   });
 
   assert.equal(result.iterations, 2);
-  assert.equal(result.totals.appendedEvents, 5);
-  assert.equal(iterationResults[0].appendedEvents, 4);
+  assert.equal(result.totals.appendedEvents, 3);
+  assert.equal(iterationResults[0].appendedEvents, 2);
   assert.equal(iterationResults[1].appendedEvents, 1);
-  assert.equal(iterationResults[1].skippedEvents, 4);
+  assert.equal(iterationResults[1].skippedEvents, 2);
 
   const events = app.listRawEvents({
     scope: 'repo',
     scopeKey: 'codex-watch-repo',
     sessionId: 'codex:codex-watch-session',
   });
-  assert.equal(events.length, 5);
+  assert.equal(events.length, 3);
   assert.equal(events.at(-1).content, 'A new active TUI event arrived.');
 });
 
@@ -1680,7 +1683,7 @@ test('CLI Codex sessions scan is not capped by search limit defaults', async () 
   );
   const parsed = JSON.parse(result.stdout);
   assert.equal(parsed.filesScanned, 11);
-  assert.equal(parsed.appendedEvents, 44);
+  assert.equal(parsed.appendedEvents, 22);
 });
 
 test('CLI routes Codex global sessions through a repo registry', async () => {
@@ -1759,7 +1762,7 @@ test('CLI routes Codex global sessions through a repo registry', async () => {
   assert.equal(parsed.filesScanned, 4);
   assert.equal(parsed.routedFiles, 3);
   assert.equal(parsed.skippedFiles, 1);
-  assert.equal(parsed.appendedEvents, 12);
+  assert.equal(parsed.appendedEvents, 6);
   assert.deepEqual(
     parsed.fileResults
       .filter((item) => item.matchedRepo)
@@ -1781,7 +1784,7 @@ test('CLI routes Codex global sessions through a repo registry', async () => {
       scopeKey: 'github.com/example/frontend',
       sessionId: 'codex:codex-frontend',
     }).length,
-    4,
+    2,
   );
   assert.equal(
     app.listRawEvents({
@@ -1823,8 +1826,8 @@ test('CLI ingests Claude Code JSONL transcripts with agent provenance', async ()
   );
   const firstResult = JSON.parse(first.stdout);
   assert.equal(firstResult.filesScanned, 1);
-  assert.equal(firstResult.parsedEvents, 4);
-  assert.equal(firstResult.appendedEvents, 4);
+  assert.equal(firstResult.parsedEvents, 2);
+  assert.equal(firstResult.appendedEvents, 2);
   assert.equal(firstResult.fileResults[0].sessionId, 'claude_code:claude-native-session');
   assert.equal(firstResult.fileResults[0].warnings.length, 1);
 
@@ -1846,7 +1849,7 @@ test('CLI ingests Claude Code JSONL transcripts with agent provenance', async ()
   );
   const secondResult = JSON.parse(second.stdout);
   assert.equal(secondResult.appendedEvents, 0);
-  assert.equal(secondResult.skippedEvents, 4);
+  assert.equal(secondResult.skippedEvents, 2);
 
   const rawEvents = await execFileAsync(
     'node',
@@ -1865,7 +1868,11 @@ test('CLI ingests Claude Code JSONL transcripts with agent provenance', async ()
   const events = JSON.parse(rawEvents.stdout);
   assert.deepEqual(
     events.map((event) => event.role),
-    ['user', 'tool_call', 'tool_result', 'assistant'],
+    ['user', 'assistant'],
+  );
+  assert.deepEqual(
+    events.map((event) => event.content),
+    ['Continue the ContextForge Claude Code ingest work.', 'I added Claude Code transcript ingestion.'],
   );
   assert.ok(events.every((event) => event.metadata.sourceAgent === 'claude_code'));
   assert.ok(events.every((event) => event.metadata.sourceAdapter === 'claude_code_jsonl'));
@@ -1955,7 +1962,7 @@ test('CLI routes Claude Code global transcripts through a repo registry', async 
   assert.equal(parsed.filesScanned, 4);
   assert.equal(parsed.routedFiles, 3);
   assert.equal(parsed.skippedFiles, 1);
-  assert.equal(parsed.appendedEvents, 12);
+  assert.equal(parsed.appendedEvents, 6);
   assert.deepEqual(
     parsed.fileResults
       .filter((item) => item.matchedRepo)
@@ -1977,7 +1984,7 @@ test('CLI routes Claude Code global transcripts through a repo registry', async 
       scopeKey: 'github.com/example/frontend',
       sessionId: 'claude_code:claude-frontend',
     }).length,
-    4,
+    2,
   );
   assert.equal(
     app.listRawEvents({
@@ -2634,6 +2641,40 @@ test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
   assert.equal(statusAfter.shouldDistill, false);
 });
 
+test('appendRaw accepts only user and assistant conversation evidence roles', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  assert.throws(
+    () =>
+      app.appendRaw({
+        scope: 'repo',
+        scopeKey: 'repo-roles',
+        sessionId: 'role-session',
+        role: 'tool_result',
+        content: 'tool output belongs in the native transcript.',
+      }),
+    /role must be one of: user, assistant/,
+  );
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-roles',
+    sessionId: 'role-session',
+    role: 'assistant',
+    content: 'The assistant summarized the verification result.',
+  });
+
+  assert.equal(
+    app.listRawEvents({
+      scope: 'repo',
+      scopeKey: 'repo-roles',
+      sessionId: 'role-session',
+    }).length,
+    1,
+  );
+});
+
 test('bootstrapContext includes working summary and recent raw tail separately from search results', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({
@@ -3037,7 +3078,7 @@ test('sessionStatus continues after the last raw event covered by a checkpoint',
   assert.equal(status.distillWindow.firstRawEventId !== checkpoint.metadata.sourceRawEventIds[0], true);
 });
 
-test('distillCheckpoint uses a bounded recent raw-event window', async () => {
+test('distillCheckpoint drains bounded conversation windows oldest first', async () => {
   const dataDir = await makeTempDir();
   const seen = [];
   const app = createContextForge({
@@ -3053,7 +3094,7 @@ test('distillCheckpoint uses a bounded recent raw-event window', async () => {
         seen.push(input.rawEvents.map((event) => event.content));
         return {
           summaryShort: 'Window checkpoint.',
-          summaryText: 'The provider saw a bounded recent raw-event window.',
+          summaryText: 'The provider saw a bounded oldest-first conversation window.',
           decisions: [],
           todos: [],
           openQuestions: [],
@@ -3077,27 +3118,92 @@ test('distillCheckpoint uses a bounded recent raw-event window', async () => {
       content: `event-${index}`,
     });
   }
+  const rawBeforeLegacyTool = app.listRawEvents({
+    scope: 'repo',
+    scopeKey: 'repo-window',
+    sessionId: 'window-session',
+  });
+  const db = new Database(path.join(dataDir, 'contextforge.db'));
+  try {
+    const toolCreatedAt = new Date(Date.parse(rawBeforeLegacyTool[1].createdAt) + 1).toISOString();
+    db.prepare(
+      `INSERT INTO raw_events (
+        id, scope_type, scope_key, session_id, conversation_id,
+        role, content, metadata_json, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      'legacy-tool-result',
+      'repo',
+      'repo-window',
+      'window-session',
+      null,
+      'tool_result',
+      'legacy tool output should not enter distillation',
+      '{}',
+      toolCreatedAt,
+    );
+  } finally {
+    db.close();
+  }
 
   const status = app.sessionStatus({
     scope: 'repo',
     scopeKey: 'repo-window',
     sessionId: 'window-session',
   });
-  assert.equal(status.rawEventCount, 6);
+  assert.equal(status.rawEventCount, 7);
   assert.equal(status.distillWindow.candidateEventCount, 6);
   assert.equal(status.distillWindow.selectedEventCount, 3);
   assert.equal(status.distillWindow.truncated, true);
 
-  const checkpoint = await app.distillCheckpoint({
+  const firstCheckpoint = await app.distillCheckpoint({
     scope: 'repo',
     scopeKey: 'repo-window',
     sessionId: 'window-session',
   });
-  assert.deepEqual(seen[0], ['event-3', 'event-4', 'event-5']);
-  assert.equal(checkpoint.sourceEventCount, 3);
-  assert.equal(checkpoint.metadata.sourceRawEventIds.length, 3);
-  assert.equal(checkpoint.metadata.sourceEventWindow.selectedEventCount, 3);
-  assert.equal(checkpoint.metadata.sourceEventWindow.truncated, true);
+  assert.deepEqual(seen[0], ['event-0', 'event-1', 'event-2']);
+  assert.equal(firstCheckpoint.sourceEventCount, 3);
+  assert.equal(firstCheckpoint.metadata.sourceRawEventIds.length, 3);
+  assert.equal(firstCheckpoint.metadata.sourceEventWindow.selectedEventCount, 3);
+  assert.equal(firstCheckpoint.metadata.sourceEventWindow.truncated, true);
+
+  const statusAfterFirst = app.sessionStatus({
+    scope: 'repo',
+    scopeKey: 'repo-window',
+    sessionId: 'window-session',
+  });
+  assert.equal(statusAfterFirst.eventsSinceLastCheckpoint, 3);
+  assert.equal(statusAfterFirst.distillWindow.selectedEventCount, 3);
+  assert.deepEqual(
+    app
+      .listRawEvents({
+        scope: 'repo',
+        scopeKey: 'repo-window',
+        sessionId: 'window-session',
+      })
+      .filter(
+        (event) =>
+          statusAfterFirst.distillWindow.firstRawEventId === event.id ||
+          statusAfterFirst.distillWindow.lastRawEventId === event.id,
+      )
+      .map((event) => event.content),
+    ['event-3', 'event-5'],
+  );
+
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-window',
+    sessionId: 'window-session',
+  });
+  assert.deepEqual(seen[1], ['event-3', 'event-4', 'event-5']);
+
+  const statusAfterSecond = app.sessionStatus({
+    scope: 'repo',
+    scopeKey: 'repo-window',
+    sessionId: 'window-session',
+  });
+  assert.equal(statusAfterSecond.eventsSinceLastCheckpoint, 0);
+  assert.equal(statusAfterSecond.distillWindow.selectedEventCount, 0);
 
   const runs = app.listDistillRuns({
     scope: 'repo',
@@ -3105,7 +3211,8 @@ test('distillCheckpoint uses a bounded recent raw-event window', async () => {
     sessionId: 'window-session',
   });
   assert.equal(runs[0].inputMetadata.rawEventIds.length, 3);
-  assert.equal(runs[0].inputMetadata.sourceEventWindow.totalRawEventCount, 6);
+  assert.equal(runs[0].inputMetadata.sourceEventWindow.totalRawEventCount, 7);
+  assert.equal(runs[0].inputMetadata.sourceEventWindow.candidateEventCount, 6);
 });
 
 test('distillUsage summarizes estimated and actual provider usage', async () => {
@@ -3407,7 +3514,7 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.model, 'gpt-test');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.reasoningEffort, 'low');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.timeoutMs, 1234);
-  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v4');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v5');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.outputSchemaVersion, 'contextforge.checkpoint.v4');
   assert.match(invocation.prompt, /Return exactly one JSON object/);
   assert.deepEqual(invocation.args.slice(0, 2), ['exec', '--skip-git-repo-check']);
@@ -3426,9 +3533,9 @@ test('codex_exec provider distills synthetic raw events through a runner', async
     sessionId: 'codex-session',
   });
   assert.equal(runs[0].status, 'succeeded');
-  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v4');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v5');
   assert.equal(runs[0].inputMetadata.providerMetadata.outputSchemaVersion, 'contextforge.checkpoint.v4');
-  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v4');
+  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v5');
 });
 
 test('codex_exec records JSON brace fallback recovery metadata', async () => {
@@ -3632,8 +3739,8 @@ test('codex_exec parse failures preserve raw evidence', async () => {
   });
   assert.equal(runs[0].status, 'failed');
   assert.equal(runs[0].outputMetadata.providerFailed, true);
-  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v4');
-  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v4');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v5');
+  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v5');
 });
 
 test('bootstrapContext returns semantic retrieval with trust and verification hints', async () => {
@@ -3927,6 +4034,8 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     const bootstrapTool = toolList.tools.find((tool) => tool.name === 'bootstrap_context');
     assert.ok(bootstrapTool.inputSchema.properties.sessionId);
     assert.ok(bootstrapTool.inputSchema.properties.rawTailLimit);
+    const appendRawTool = toolList.tools.find((tool) => tool.name === 'append_raw');
+    assert.deepEqual(appendRawTool.inputSchema.properties.role.enum, ['user', 'assistant']);
 
     const rememberResult = await client.callTool({
       name: 'remember',
@@ -3992,6 +4101,18 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
         content: 'Decision: MCP agents should inspect session status before distilling.',
       },
     });
+    const invalidAppendResult = await client.callTool({
+      name: 'append_raw',
+      arguments: {
+        scope: 'repo',
+        scopeKey: 'mcp-repo',
+        sessionId: 'mcp-session',
+        role: 'tool_result',
+        content: 'tool output stays in the native transcript.',
+      },
+    });
+    assert.equal(invalidAppendResult.isError, true);
+    assert.match(invalidAppendResult.content[0].text, /Invalid arguments|tool_result/);
 
     const statusResult = await client.callTool({
       name: 'session_status',


### PR DESCRIPTION
## Summary
- redefine raw ingest as user/assistant conversation evidence instead of native transcript cloning
- skip Codex and Claude Code tool payloads while keeping native transcript provenance metadata
- drain distill windows oldest-first and exclude legacy tool rows from distill candidates
- document the pointer-only tool-output policy and update codex_exec prompt guidance

## Validation
- npm test
- node src/cli.js dbInfo
- ContextForge MCP session_status confirmed tool-heavy current session has zero post-checkpoint distill candidates
