### PR TITLE
[codex] Add memory resume and closeout wrappers

### DIFF
--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -9,7 +9,9 @@ instruction file, or an MCP client system prompt.
 ```text
 Use ContextForge as a scoped memory sidecar.
 
-At the start of a project task, call bootstrap_context when available. Pass
+At the start of a project task, call bootstrap_context when available. For
+start/resume wording such as "continue", "previous work", "어제 하던 거 이어서",
+or "지난 환경 작업과 동기화", call sync_resume_context when available. Pass
 repoPath, cwd, or an explicit scopeKey so ContextForge can resolve the repo
 scope, then use the returned trust and verification hints. Prefer canonical
 GitHub scope keys such as github.com/owner/repo.
@@ -30,8 +32,11 @@ machine-local context unless the user says that store is authoritative.
 
 Interpret search result types carefully:
 - `memory`: reviewed durable fact, decision, preference, or runbook note.
-- `checkpoint`: recent session continuity, not canonical truth.
-- `memory_candidate`: unreviewed promotion candidate, useful for review.
+- `checkpoint`: credible recent handoff state for continuity, planning, prior
+  intent, recent decisions, and unfinished work; verify mutable live state with
+  git/GitHub/CI/runtime/migrations before acting.
+- `memory_candidate`: unreviewed promotion material, useful for review, not
+  durable truth.
 
 Use bootstrap_context first, then targeted search if more detail is needed. Use
 get_memory only when you know the exact key. Use local scope only when the
@@ -45,11 +50,18 @@ Capture important raw evidence with append_raw during long work. Distill raw
 evidence into checkpoints when a task reaches a meaningful boundary, when the
 session_status thresholds recommend it, or before handing off work.
 
-After distill_checkpoint, inspect list_memory_candidates. Promote candidates
-only when they are reviewed, clearly durable, and useful beyond the current
-checkpoint. Use promote_memory_candidate for a reviewed candidate, remember for
-new reviewed durable facts, correct_memory for changed facts, and
-deactivate_memory for stale facts.
+At closeout triggers only, inspect memory candidates with
+suggest_memory_promotions when available, otherwise list_memory_candidates for
+the current session/latest checkpoint. Promote candidates only when they are
+reviewed, clearly durable, and useful beyond the current checkpoint. Use
+promote_memory_candidate for a reviewed candidate, remember for new reviewed
+durable facts, correct_memory for changed facts, and deactivate_memory for
+stale facts.
+
+For user corrections such as "that is wrong", "그거 아니야", "그건 X가 아니라
+Y야", or "기억 수정해", call reconcile_memory when available. Show the basis
+for prior memory, treat user correction as strong evidence but not automatic
+truth, and verify mutable live state before changing memory.
 
 Do not automatically promote every candidate. Keep durable memory small,
 actionable, and scoped.
@@ -80,17 +92,20 @@ github.com/example/repo unless the user says otherwise.
 Check whether ContextForge is remote canonical storage or local/project-local
 storage before treating retrieval results as shared state.
 
-Interpret search result types by trust level: memory is reviewed durable state,
-checkpoint is recent continuity, and memory_candidate is review material.
+Interpret search result types by trust role: memory is reviewed durable state,
+checkpoint is credible recent handoff state for continuity and planning, and
+memory_candidate is review material.
 
 For loose continuation prompts like "yesterday", "continue", "previous work",
-issue/PR follow-up, or cross-agent handoff, search ContextForge before guessing
-from the current checkout. Review `checkpoint` and `memory_candidate` hits as
-context candidates, then verify current state in git/GitHub/runtime.
+issue/PR follow-up, or cross-agent handoff, call `sync_resume_context` when
+available before guessing from the current checkout. Use checkpoints actively
+for prior intent, recent decisions, and unfinished work, then verify current
+state in git/GitHub/CI/runtime/migrations. Do not propose memory promotions
+during resume sync.
 
-Keep durable memory intentional. After distilling a checkpoint, review
-list_memory_candidates and promote only stable, reviewed facts. Promote durable
-lessons, not whole worklogs.
+Keep durable memory intentional. At closeout triggers only, call
+suggest_memory_promotions when available and propose at most one to three
+stable, reviewed facts. Promote durable lessons, not whole worklogs.
 
 For full ContextForge MCP usage rules, follow docs/agent-instructions.md from
 the ContextForge repo or the equivalent shared memory guide.
@@ -179,9 +194,10 @@ trust levels.
 6. If the task needs live handoff state, pass `sessionId` to
    `bootstrap_context` or call `get_working_summary`. Treat the returned
    working summary as current session state, not durable truth.
-7. If the task depends on recent handoff state, call `list_memory_candidates`
-   for the relevant session or checkpoint and review candidates before
-   promoting anything.
+7. If the task depends on recent handoff state, call `sync_resume_context` when
+   available. Treat checkpoints as credible recent handoff state and memory
+   candidates as review material only. Do not propose promotions during resume
+   sync.
 
 Keep bootstrap small. Prefer one or two targeted `search` calls over loading all
 memory. Do not load raw evidence during bootstrap unless the user asks for
@@ -229,7 +245,9 @@ For most coding tasks, use this order:
    conventions.
 5. `get_memory` only for exact durable keys returned by search or supplied by
    the user.
-6. Use checkpoints for recent continuity, not canonical truth.
+6. Use checkpoints as credible recent handoff state for continuity, planning,
+   prior intent, recent decisions, and unfinished work; verify mutable live
+   state before acting.
 7. Use memory candidates only as review material, not as canonical memory.
 8. Avoid raw evidence unless debugging distillation, reconstructing provenance,
    or explicitly asked.
@@ -333,20 +351,22 @@ Distillation providers should populate `metadata.retrievalHooks` with concise
 future-search keywords. Those hooks are embedded with the checkpoint so later
 queries can find the right session even when the exact summary wording differs.
 
-After `distill_checkpoint`, call `list_memory_candidates` for the same
-`sessionId` or `checkpointId` when:
+At closeout triggers, call `suggest_memory_promotions` when available. If it is
+unavailable, call `list_memory_candidates` for the same `sessionId` or
+`checkpointId` when:
 
 - a long implementation thread ends
 - a PR or issue reaches a stable decision
 - the user asks what should be remembered
-- the agent is preparing a handoff
+- the user explicitly asks to stop here or wrap up
 - repeated future work would benefit from a durable note
 
 The MCP result makes candidate discovery explicit. If `distill_checkpoint`
-returns `memoryCandidateCount > 0`, call `list_memory_candidates` before ending
-the task or deciding what to promote. If `session_status` reports
+returns `memoryCandidateCount > 0`, use `suggest_memory_promotions` before
+deciding what to propose. If `session_status` reports
 `latestCheckpointMemoryCandidateCount > 0`, use the latest checkpoint id or the
-session id to review those candidates.
+session id to review those candidates. Do not review promotion candidates during
+start/resume sync.
 
 Promote with `promote_memory_candidate` only after review. A good candidate is:
 
@@ -389,6 +409,13 @@ Example corrected durable write instead of promoting a noisy candidate:
 { "tool": "remember", "args": { "scope": "repo", "scopeKey": "github.com/example/service", "key": "api-contract-widget-delete", "category": "decision", "content": "Widget delete endpoints must remain idempotent: missing widgets return 204 so retrying cleanup jobs is safe.", "tags": ["api-contract", "delete", "idempotency"], "importance": 4 } }
 ```
 
+For user corrections, use reconcile_memory before directly changing memory. It
+searches durable memories, checkpoints, and candidates, shows why prior agents
+may have believed the stale fact, and proposes correct/deactivate/reject
+actions. In `apply_safe` mode, only apply unambiguous durable corrections or
+candidate rejections; never edit checkpoints directly. Mutable live-state
+corrections still require git/GitHub/CI/runtime/migration verification first.
+
 ## Raw Evidence And Retention
 
 Raw evidence exists for auditability and future distillation. It should be
@@ -427,6 +454,8 @@ Prefer distilling at meaningful boundaries:
 - `bootstrap_context`: resolve scoped startup context in one call. It searches
   repo memory/checkpoints/candidates semantically, optionally includes up to
   three shared-scope results, and annotates trust plus verification hints.
+- `sync_resume_context`: build a start/resume handoff package. Checkpoints are
+  credible recent handoff state; candidates are review material only.
 - `search`: retrieve scoped results. Results can include reviewed durable
   `memory`, recent-continuity `checkpoint`, and unreviewed
   `memory_candidate` records.
@@ -445,6 +474,10 @@ Prefer distilling at meaningful boundaries:
   estimated input tokens, elapsed time, and actual provider usage when recorded.
 - `list_memory_candidates`: inspect checkpoint-generated durable-memory
   candidates.
+- `suggest_memory_promotions`: closeout-only selector that proposes at most one
+  to three durable memory promotions and never promotes automatically.
+- `reconcile_memory`: reconcile user corrections against durable memories,
+  checkpoints, and memory candidates.
 - `promote_memory_candidate`: promote a reviewed candidate by candidate id.
 - `reject_memory_candidate`: reject a reviewed candidate that should not become
   durable memory.

--- a/src/core.js
+++ b/src/core.js
@@ -211,7 +211,7 @@ function bootstrapTrustForType(type) {
     return 'reviewed_durable';
   }
   if (type === 'checkpoint') {
-    return 'recent_continuity';
+    return 'credible_recent_handoff';
   }
   if (type === 'memory_candidate') {
     return 'review_material';
@@ -224,7 +224,7 @@ function bootstrapUseHint(result) {
     return 'Reviewed durable state; use for decisions, but verify drift-prone facts against live sources.';
   }
   if (result.type === 'checkpoint') {
-    return 'Recent session continuity; useful for resuming work, but verify before acting.';
+    return 'Credible recent handoff state; use actively for continuity and planning, but verify mutable live state before acting.';
   }
   if (result.type === 'memory_candidate') {
     return 'Unreviewed promotion candidate; useful context and review material, not canonical truth.';
@@ -468,14 +468,27 @@ const DURABLE_PROPOSAL_CATEGORIES = new Set([
   'environment',
 ]);
 
-function compactMemoryCandidate(candidate) {
+function compactBootstrapCandidate(result) {
   return {
-    candidateId: candidate.candidateId || candidate.id,
-    key: candidate.key || candidate.candidate?.key || null,
-    category: candidate.category || candidate.candidate?.category || null,
-    content: truncateText(candidate.content || candidate.candidate?.content, 240),
-    status: candidate.status || null,
-    checkpointId: candidate.checkpointId || null,
+    candidateId: result.candidateId || null,
+    key: result.key || null,
+    category: result.category || null,
+    content: truncateText(result.content, 240),
+    status: result.status || null,
+    checkpointId: result.checkpointId || null,
+    trust: 'review_material',
+    useHint: 'Useful context and review material, not durable truth or a promotion proposal.',
+  };
+}
+
+function compactIndexedCandidate(indexedCandidate) {
+  return {
+    candidateId: indexedCandidate.id,
+    key: indexedCandidate.candidate?.key || null,
+    category: indexedCandidate.candidate?.category || null,
+    content: truncateText(indexedCandidate.candidate?.content, 240),
+    status: indexedCandidate.status || null,
+    checkpointId: indexedCandidate.checkpointId || null,
     trust: 'review_material',
     useHint: 'Useful context and review material, not durable truth or a promotion proposal.',
   };
@@ -585,7 +598,7 @@ function candidateWarningReason(warnings) {
   return warnings.map((warning) => warning.code).join(', ');
 }
 
-function scorePromotionCandidate(indexedCandidate, warnings, trigger) {
+function scorePromotionCandidate(indexedCandidate, warnings) {
   if (warnings.some((warning) => AUTO_SKIP_WARNING_CODES.has(warning.code))) {
     return 0;
   }
@@ -598,7 +611,6 @@ function scorePromotionCandidate(indexedCandidate, warnings, trigger) {
   if (/\b(pr|issue|ci|api|migration|deploy|rollback|command|test|runtime)\b/i.test(candidate.reason || candidate.content || '')) {
     score += 1;
   }
-  if (trigger === 'manual_closeout') score += 0.25;
   return score;
 }
 
@@ -625,74 +637,35 @@ function promotionProposal(indexedCandidate, warnings, rank) {
 }
 
 function summarizeBasisResult(result) {
-  if (result.key != null && result.content != null && !result.memory && !result.checkpoint && !result.candidate) {
-    return {
-      type: result.type,
-      key: result.key,
-      category: result.category || null,
-      content: truncateText(result.content, 500),
-      trust: result.trust || bootstrapTrustForType(result.type),
-      whyUse: result.whyUse || bootstrapUseHint(result),
-      verificationRequired: Boolean(result.verificationRequired),
-      source: result.source || null,
-      retrieval: result.retrieval || null,
-      memoryId: result.memoryId || null,
-      checkpointId: result.checkpointId || (result.type === 'checkpoint' ? result.key : null),
-      candidateId: result.candidateId || null,
-      sessionId: result.sessionId || null,
-      status: result.status || null,
-    };
-  }
-  const base = {
+  return {
     type: result.type,
-    key: null,
-    content: '',
-    trust: bootstrapTrustForType(result.type),
-    whyUse: bootstrapUseHint(result),
-    verificationRequired: result.type !== 'memory' || requiresLiveStateVerification(result),
+    key: result.key,
+    category: result.category || null,
+    content: truncateText(result.content, 500),
+    trust: result.trust || bootstrapTrustForType(result.type),
+    whyUse: result.whyUse || bootstrapUseHint(result),
+    verificationRequired: Boolean(result.verificationRequired),
     source: result.source || null,
     retrieval: result.retrieval || null,
+    memoryId: result.memoryId || null,
+    checkpointId: result.checkpointId || (result.type === 'checkpoint' ? result.key : null),
+    candidateId: result.candidateId || null,
+    sessionId: result.sessionId || null,
+    status: result.status || null,
   };
-  if (result.memory) {
-    return {
-      ...base,
-      key: result.memory.key,
-      category: result.memory.category,
-      content: truncateText(result.memory.content, 500),
-      memoryId: result.memory.id,
-    };
-  }
-  if (result.checkpoint) {
-    return {
-      ...base,
-      key: result.checkpoint.id,
-      category: 'checkpoint',
-      content: truncateText(result.checkpoint.summaryText || result.checkpoint.summaryShort, 500),
-      checkpointId: result.checkpoint.id,
-      sessionId: result.checkpoint.sessionId,
-      trust: 'credible_recent_handoff',
-      whyUse:
-        'Checkpoint basis explains why prior agents may have believed this; do not edit checkpoints directly.',
-    };
-  }
-  if (result.candidate) {
-    return {
-      ...base,
-      key: result.candidate.candidate.key,
-      category: result.candidate.candidate.category,
-      content: truncateText(result.candidate.candidate.content, 500),
-      candidateId: result.candidate.id,
-      checkpointId: result.candidate.checkpointId,
-      status: result.candidate.status,
-    };
-  }
-  return base;
 }
 
 function isLiveStateCorrection(text) {
-  return /\b(branch\w*|prs?|pull requests?|issues?|ci|checks?|runtimes?|deploy\w*|deployments?|migrations?|migrate\w*|servers?|services?|queues?|status|drafts?|merge\w*|merged|commits?|tags?|releases?|rollbacks?)\b/i.test(
-    String(text || ''),
-  );
+  const value = String(text || '');
+  return [
+    /\bpr\s*#?\d+\b/i,
+    /\bpull request\s*#?\d+\b/i,
+    /\bissue\s*#?\d+\b/i,
+    /\b(branch|commit|tag|release)\s+[\w./-]+\b/i,
+    /\b(merged?|deployed|released|rolled back|rollback)\s+(to|into|from|on|in)\b/i,
+    /\b(ci|check run|github action|workflow run|migration|runtime|deployment|server|service|queue)\s+(failed|passing|passed|running|stopped|down|up|merged|deployed|current|pending)\b/i,
+    /\b(alembic|migration|migrations)\s+(current|heads?|upgraded?|downgraded?|applied|pending)\b/i,
+  ].some((pattern) => pattern.test(value));
 }
 
 function checkpointTimestamp(checkpoint) {
@@ -1099,8 +1072,11 @@ export function createContextForge(options = {}) {
       }
       if (bootstrap.sessionId && memoryCandidateResults.length === 0) {
         const latestCandidates = useStore((store) => {
-          const latestCheckpoint = store.getLatestCheckpoint({ ...bootstrap.scope, sessionId: bootstrap.sessionId });
-          return latestCheckpoint
+          const latestCheckpoint =
+            recentCheckpoints[0]?.key && recentCheckpoints[0]?.retrieval?.method === 'latest_checkpoint'
+              ? { id: recentCheckpoints[0].key }
+              : store.getLatestCheckpoint({ ...bootstrap.scope, sessionId: bootstrap.sessionId });
+          return latestCheckpoint?.id
             ? store.listMemoryCandidates({
                 ...bootstrap.scope,
                 checkpointId: latestCheckpoint.id,
@@ -1127,7 +1103,11 @@ export function createContextForge(options = {}) {
           recentCheckpoints,
           memoryCandidates: {
             count: memoryCandidateResults.length,
-            items: memoryCandidateResults.slice(0, 3).map(compactMemoryCandidate),
+            items: memoryCandidateResults
+              .slice(0, 3)
+              .map((candidate) =>
+                candidate.candidate ? compactIndexedCandidate(candidate) : compactBootstrapCandidate(candidate),
+              ),
             trust: 'review_material',
             useHint: 'Review material only; do not turn these into promotion proposals during resume sync.',
           },
@@ -1322,7 +1302,7 @@ export function createContextForge(options = {}) {
       );
     },
 
-    suggestMemoryPromotions(options = {}) {
+    async suggestMemoryPromotions(options = {}) {
       const scope = normalizeScopeOptions(options, config);
       const trigger = options.trigger;
       if (!CLOSEOUT_TRIGGERS.has(trigger)) {
@@ -1332,7 +1312,19 @@ export function createContextForge(options = {}) {
       if (allowScopeFallback && trigger !== 'manual_closeout') {
         throw new Error('allowScopeFallback is only allowed with trigger=manual_closeout.');
       }
-      const limit = Math.min(3, positiveNumber(options.limit == null ? 3 : Number(options.limit), 'limit'));
+      const requestedLimit = positiveNumber(options.limit == null ? 3 : Number(options.limit), 'limit');
+      const limit = Math.min(3, requestedLimit);
+      const warnings =
+        requestedLimit > 3
+          ? [
+              {
+                code: 'limit_capped',
+                message: 'suggest_memory_promotions returns at most 3 proposals.',
+                requestedLimit,
+                effectiveLimit: limit,
+              },
+            ]
+          : [];
       const scanLimit = positiveNumber(options.scanLimit == null ? 10 : Number(options.scanLimit), 'scanLimit');
       const promotionRecommendation = options.promotionRecommendation || 'promote';
 
@@ -1359,6 +1351,7 @@ export function createContextForge(options = {}) {
             },
             proposals: [],
             skipped: [],
+            warnings,
             nextActions: [
               'Provide sessionId or checkpointId to review current closeout candidates.',
               'Use allowScopeFallback=true only with trigger=manual_closeout when intentionally reviewing the scope backlog.',
@@ -1379,6 +1372,7 @@ export function createContextForge(options = {}) {
             },
             proposals: [],
             skipped: [],
+            warnings,
             nextActions: [
               'No latest checkpoint was found for this session; distill a checkpoint before reviewing promotions.',
               'Do not promote automatically.',
@@ -1397,7 +1391,7 @@ export function createContextForge(options = {}) {
         });
         const assessed = candidates.map((candidate) => {
           const warnings = promotionCandidateWarnings(store, scope, candidate);
-          const score = scorePromotionCandidate(candidate, warnings, trigger);
+          const score = scorePromotionCandidate(candidate, warnings);
           return { candidate, warnings, score };
         });
         const selected = assessed
@@ -1421,6 +1415,7 @@ export function createContextForge(options = {}) {
               candidateId: item.candidate.id,
               reason: candidateWarningReason(item.warnings) || 'low_score',
             })),
+          warnings,
           nextActions: [
             'Ask the user to choose: promote, edit then promote, skip, or reject.',
             'Do not promote automatically.',
@@ -1453,24 +1448,21 @@ export function createContextForge(options = {}) {
       const liveState = isLiveStateCorrection(`${options.query}\n${options.correction}`);
       return useStore((store) => {
         const basis = (bootstrap.results || []).slice(0, limit).map(summarizeBasisResult);
-        if (options.sessionId && !basis.some((item) => item.type === 'checkpoint')) {
-          const latestCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId });
-          if (latestCheckpoint) {
-            basis.push(checkpointBasisResult(latestCheckpoint));
-          }
+        const latestCheckpoint = options.sessionId
+          ? store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId })
+          : null;
+        if (latestCheckpoint && !basis.some((item) => item.type === 'checkpoint')) {
+          basis.push(checkpointBasisResult(latestCheckpoint));
         }
-        if (options.sessionId && !basis.some((item) => item.type === 'memory_candidate')) {
-          const latestCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId });
-          if (latestCheckpoint) {
-            const latestCandidates = store.listMemoryCandidates({
-              ...scope,
-              checkpointId: latestCheckpoint.id,
-              status: 'pending',
-              sort: 'recommendation',
-              limit: candidateLimit,
-            });
-            basis.push(...latestCandidates.map(indexedCandidateBasisResult));
-          }
+        if (latestCheckpoint && !basis.some((item) => item.type === 'memory_candidate')) {
+          const latestCandidates = store.listMemoryCandidates({
+            ...scope,
+            checkpointId: latestCheckpoint.id,
+            status: 'pending',
+            sort: 'recommendation',
+            limit: candidateLimit,
+          });
+          basis.push(...latestCandidates.map(indexedCandidateBasisResult));
         }
         const durableBasis = basis.filter((item) => item.type === 'memory');
         const checkpointBasis = basis.filter((item) => item.type === 'checkpoint');
@@ -1522,27 +1514,34 @@ export function createContextForge(options = {}) {
           } else if (durableBasis.length === 1) {
             const durable = durableBasis[0];
             const previous = store.getMemory({ ...scope, key: durable.key });
-            const corrected = store.rememberMemory({
-              ...scope,
-              key: durable.key,
-              content: options.correction,
-              category: durable.category || 'note',
-              tags: [],
-              importance: undefined,
-              supersedesMemoryId: previous?.id || durable.memoryId || undefined,
-              eventType: 'correct',
-              eventMetadata: {
+            if (!previous) {
+              warnings.push({
+                code: 'durable_memory_not_found',
+                message: `Memory ${durable.key} was not found when applying correction; no correction was applied.`,
+              });
+            } else {
+              const corrected = store.rememberMemory({
+                ...scope,
                 key: durable.key,
-                previousMemoryId: previous?.id || durable.memoryId || null,
-                previousContent: previous?.content || durable.content,
-                reason: 'Applied via reconcile_memory apply_safe.',
-              },
-            });
-            appliedActions.push({
-              action: 'correct_memory',
-              key: corrected.key,
-              memoryId: corrected.id,
-            });
+                content: options.correction,
+                category: previous.category,
+                tags: previous.tags,
+                importance: previous.importance,
+                supersedesMemoryId: previous.id,
+                eventType: 'correct',
+                eventMetadata: {
+                  key: durable.key,
+                  previousMemoryId: previous.id,
+                  previousContent: previous.content,
+                  reason: 'Applied via reconcile_memory apply_safe.',
+                },
+              });
+              appliedActions.push({
+                action: 'correct_memory',
+                key: corrected.key,
+                memoryId: corrected.id,
+              });
+            }
           } else if (durableBasis.length > 1) {
             warnings.push({
               code: 'ambiguous_durable_memory',
@@ -1550,7 +1549,7 @@ export function createContextForge(options = {}) {
             });
           }
 
-          if (!liveState) {
+          if (!liveState && appliedActions.some((item) => item.action === 'correct_memory')) {
             for (const item of candidateBasis) {
               const candidate = store.getMemoryCandidate({
                 ...scope,

--- a/src/core.js
+++ b/src/core.js
@@ -1052,6 +1052,9 @@ export function createContextForge(options = {}) {
       const durableMemories = [];
       const recentCheckpoints = [];
       const memoryCandidateResults = [];
+      const latestCheckpoint = bootstrap.sessionId
+        ? useStore((store) => store.getLatestCheckpoint({ ...bootstrap.scope, sessionId: bootstrap.sessionId }))
+        : null;
 
       for (const result of bootstrap.results || []) {
         if (result.type === 'memory') {
@@ -1062,29 +1065,18 @@ export function createContextForge(options = {}) {
           memoryCandidateResults.push(result);
         }
       }
-      if (bootstrap.sessionId && recentCheckpoints.length === 0) {
-        const latestCheckpoint = useStore((store) =>
-          store.getLatestCheckpoint({ ...bootstrap.scope, sessionId: bootstrap.sessionId }),
-        );
-        if (latestCheckpoint) {
-          recentCheckpoints.push(checkpointHandoffResult(latestCheckpoint));
-        }
+      if (latestCheckpoint && recentCheckpoints.length === 0) {
+        recentCheckpoints.push(checkpointHandoffResult(latestCheckpoint));
       }
-      if (bootstrap.sessionId && memoryCandidateResults.length === 0) {
+      if (latestCheckpoint && memoryCandidateResults.length === 0) {
         const latestCandidates = useStore((store) => {
-          const latestCheckpoint =
-            recentCheckpoints[0]?.key && recentCheckpoints[0]?.retrieval?.method === 'latest_checkpoint'
-              ? { id: recentCheckpoints[0].key }
-              : store.getLatestCheckpoint({ ...bootstrap.scope, sessionId: bootstrap.sessionId });
-          return latestCheckpoint?.id
-            ? store.listMemoryCandidates({
-                ...bootstrap.scope,
-                checkpointId: latestCheckpoint.id,
-                status: 'pending',
-                sort: 'recommendation',
-                limit: 3,
-              })
-            : [];
+          return store.listMemoryCandidates({
+            ...bootstrap.scope,
+            checkpointId: latestCheckpoint.id,
+            status: 'pending',
+            sort: 'recommendation',
+            limit: 3,
+          });
         });
         memoryCandidateResults.push(...latestCandidates);
       }
@@ -1351,7 +1343,7 @@ export function createContextForge(options = {}) {
             },
             proposals: [],
             skipped: [],
-            warnings,
+            requestWarnings: warnings,
             nextActions: [
               'Provide sessionId or checkpointId to review current closeout candidates.',
               'Use allowScopeFallback=true only with trigger=manual_closeout when intentionally reviewing the scope backlog.',
@@ -1372,7 +1364,7 @@ export function createContextForge(options = {}) {
             },
             proposals: [],
             skipped: [],
-            warnings,
+            requestWarnings: warnings,
             nextActions: [
               'No latest checkpoint was found for this session; distill a checkpoint before reviewing promotions.',
               'Do not promote automatically.',
@@ -1415,7 +1407,7 @@ export function createContextForge(options = {}) {
               candidateId: item.candidate.id,
               reason: candidateWarningReason(item.warnings) || 'low_score',
             })),
-          warnings,
+          requestWarnings: warnings,
           nextActions: [
             'Ask the user to choose: promote, edit then promote, skip, or reject.',
             'Do not promote automatically.',
@@ -1549,7 +1541,7 @@ export function createContextForge(options = {}) {
             });
           }
 
-          if (!liveState && appliedActions.some((item) => item.action === 'correct_memory')) {
+          if (!liveState) {
             for (const item of candidateBasis) {
               const candidate = store.getMemoryCandidate({
                 ...scope,

--- a/src/core.js
+++ b/src/core.js
@@ -441,6 +441,260 @@ function candidatePromotionWarnings(store, scope, { key, content, candidate }) {
   return warnings;
 }
 
+const CLOSEOUT_TRIGGERS = new Set([
+  'agent_merged_pr',
+  'user_merged_then_synced',
+  'user_declared_work_done',
+  'manual_closeout',
+]);
+
+const AUTO_SKIP_WARNING_CODES = new Set([
+  'duplicate_key',
+  'existing_key_conflict',
+  'duplicate_content',
+  'high_sensitivity',
+  'recommendation_not_promote',
+  'low_confidence',
+  'low_stability',
+  'temporary_candidate',
+]);
+
+const DURABLE_PROPOSAL_CATEGORIES = new Set([
+  'decision',
+  'runbook',
+  'api-contract',
+  'failure-mode',
+  'preference',
+  'environment',
+]);
+
+function compactMemoryCandidate(candidate) {
+  return {
+    candidateId: candidate.candidateId || candidate.id,
+    key: candidate.key || candidate.candidate?.key || null,
+    category: candidate.category || candidate.candidate?.category || null,
+    content: truncateText(candidate.content || candidate.candidate?.content, 240),
+    status: candidate.status || null,
+    checkpointId: candidate.checkpointId || null,
+    trust: 'review_material',
+    useHint: 'Useful context and review material, not durable truth or a promotion proposal.',
+  };
+}
+
+function resumeCheckpoint(result) {
+  return {
+    ...result,
+    trust: 'credible_recent_handoff',
+    useHint:
+      'Use actively for continuity, planning, prior intent, recent decisions, and unfinished work. Verify only mutable live state such as git, GitHub, CI, runtime, and migrations before acting.',
+    whyUse:
+      'Credible recent handoff state for continuity and planning; verify mutable live state before acting.',
+  };
+}
+
+function checkpointHandoffResult(checkpoint, group = 'session') {
+  return resumeCheckpoint({
+    group,
+    type: 'checkpoint',
+    key: checkpoint.id,
+    category: 'checkpoint',
+    content: truncateText(checkpoint.summaryText || checkpoint.summaryShort),
+    verificationRequired: true,
+    why: [],
+    source: {
+      scopeType: checkpoint.scopeType,
+      scopeKey: checkpoint.scopeKey,
+      role: group,
+    },
+    retrieval: {
+      method: 'latest_checkpoint',
+      ftsRank: null,
+      vectorDistance: null,
+      vectorModel: null,
+      vectorDimensions: null,
+    },
+    sessionId: checkpoint.sessionId,
+    createdAt: checkpoint.createdAt,
+  });
+}
+
+function checkpointBasisResult(checkpoint) {
+  return {
+    type: 'checkpoint',
+    key: checkpoint.id,
+    category: 'checkpoint',
+    content: truncateText(checkpoint.summaryText || checkpoint.summaryShort, 500),
+    trust: 'credible_recent_handoff',
+    whyUse: 'Checkpoint basis explains why prior agents may have believed this; do not edit checkpoints directly.',
+    verificationRequired: true,
+    source: {
+      scopeType: checkpoint.scopeType,
+      scopeKey: checkpoint.scopeKey,
+      role: 'latest_checkpoint',
+    },
+    retrieval: {
+      method: 'latest_checkpoint',
+      ftsRank: null,
+      vectorDistance: null,
+      vectorModel: null,
+      vectorDimensions: null,
+    },
+    checkpointId: checkpoint.id,
+    sessionId: checkpoint.sessionId,
+  };
+}
+
+function indexedCandidateBasisResult(indexedCandidate) {
+  return {
+    type: 'memory_candidate',
+    key: indexedCandidate.candidate?.key || null,
+    category: indexedCandidate.candidate?.category || null,
+    content: truncateText(indexedCandidate.candidate?.content, 500),
+    trust: 'review_material',
+    whyUse: 'Unreviewed promotion material; useful context and review material, not durable truth.',
+    verificationRequired: true,
+    source: {
+      scopeType: indexedCandidate.scopeType,
+      scopeKey: indexedCandidate.scopeKey,
+      role: 'latest_checkpoint',
+    },
+    retrieval: {
+      method: 'latest_checkpoint_candidates',
+      ftsRank: null,
+      vectorDistance: null,
+      vectorModel: null,
+      vectorDimensions: null,
+    },
+    candidateId: indexedCandidate.id,
+    checkpointId: indexedCandidate.checkpointId,
+    status: indexedCandidate.status,
+  };
+}
+
+function promotionCandidateWarnings(store, scope, indexedCandidate) {
+  const candidate = indexedCandidate.candidate || {};
+  return candidatePromotionWarnings(store, scope, {
+    key: candidate.key,
+    content: candidate.content,
+    candidate,
+  });
+}
+
+function candidateWarningReason(warnings) {
+  if (!warnings.length) return null;
+  return warnings.map((warning) => warning.code).join(', ');
+}
+
+function scorePromotionCandidate(indexedCandidate, warnings, trigger) {
+  if (warnings.some((warning) => AUTO_SKIP_WARNING_CODES.has(warning.code))) {
+    return 0;
+  }
+  const candidate = indexedCandidate.candidate || {};
+  let score = 1;
+  if (candidate.promotionRecommendation === 'promote') score += 4;
+  if (Number(candidate.confidence) >= 0.7) score += 2;
+  if (Number(candidate.stability) >= 0.7) score += 2;
+  if (DURABLE_PROPOSAL_CATEGORIES.has(candidate.category)) score += 1;
+  if (/\b(pr|issue|ci|api|migration|deploy|rollback|command|test|runtime)\b/i.test(candidate.reason || candidate.content || '')) {
+    score += 1;
+  }
+  if (trigger === 'manual_closeout') score += 0.25;
+  return score;
+}
+
+function promotionProposal(indexedCandidate, warnings, rank) {
+  const candidate = indexedCandidate.candidate || {};
+  return {
+    rank,
+    candidateId: indexedCandidate.id,
+    scope: indexedCandidate.scopeType,
+    scopeKey: indexedCandidate.scopeKey,
+    key: candidate.key,
+    category: candidate.category,
+    content: candidate.content,
+    evidence: {
+      reason: candidate.reason || null,
+      sourceEventIds: candidate.sourceEventIds || [],
+      checkpointId: indexedCandidate.checkpointId,
+      sessionId: indexedCandidate.sessionId,
+    },
+    whyDurable: candidate.reason || 'Candidate appears stable and useful beyond the current checkpoint.',
+    warnings,
+    recommendedAction: 'ask_user',
+  };
+}
+
+function summarizeBasisResult(result) {
+  if (result.key != null && result.content != null && !result.memory && !result.checkpoint && !result.candidate) {
+    return {
+      type: result.type,
+      key: result.key,
+      category: result.category || null,
+      content: truncateText(result.content, 500),
+      trust: result.trust || bootstrapTrustForType(result.type),
+      whyUse: result.whyUse || bootstrapUseHint(result),
+      verificationRequired: Boolean(result.verificationRequired),
+      source: result.source || null,
+      retrieval: result.retrieval || null,
+      memoryId: result.memoryId || null,
+      checkpointId: result.checkpointId || (result.type === 'checkpoint' ? result.key : null),
+      candidateId: result.candidateId || null,
+      sessionId: result.sessionId || null,
+      status: result.status || null,
+    };
+  }
+  const base = {
+    type: result.type,
+    key: null,
+    content: '',
+    trust: bootstrapTrustForType(result.type),
+    whyUse: bootstrapUseHint(result),
+    verificationRequired: result.type !== 'memory' || requiresLiveStateVerification(result),
+    source: result.source || null,
+    retrieval: result.retrieval || null,
+  };
+  if (result.memory) {
+    return {
+      ...base,
+      key: result.memory.key,
+      category: result.memory.category,
+      content: truncateText(result.memory.content, 500),
+      memoryId: result.memory.id,
+    };
+  }
+  if (result.checkpoint) {
+    return {
+      ...base,
+      key: result.checkpoint.id,
+      category: 'checkpoint',
+      content: truncateText(result.checkpoint.summaryText || result.checkpoint.summaryShort, 500),
+      checkpointId: result.checkpoint.id,
+      sessionId: result.checkpoint.sessionId,
+      trust: 'credible_recent_handoff',
+      whyUse:
+        'Checkpoint basis explains why prior agents may have believed this; do not edit checkpoints directly.',
+    };
+  }
+  if (result.candidate) {
+    return {
+      ...base,
+      key: result.candidate.candidate.key,
+      category: result.candidate.candidate.category,
+      content: truncateText(result.candidate.candidate.content, 500),
+      candidateId: result.candidate.id,
+      checkpointId: result.candidate.checkpointId,
+      status: result.candidate.status,
+    };
+  }
+  return base;
+}
+
+function isLiveStateCorrection(text) {
+  return /\b(branch\w*|prs?|pull requests?|issues?|ci|checks?|runtimes?|deploy\w*|deployments?|migrations?|migrate\w*|servers?|services?|queues?|status|drafts?|merge\w*|merged|commits?|tags?|releases?|rollbacks?)\b/i.test(
+    String(text || ''),
+  );
+}
+
 function checkpointTimestamp(checkpoint) {
   return checkpoint?.createdAt ? Date.parse(checkpoint.createdAt) : null;
 }
@@ -816,6 +1070,91 @@ export function createContextForge(options = {}) {
       });
     },
 
+    async syncResumeContext(options = {}) {
+      requireOption(options.query, 'query');
+      const bootstrap = await this.bootstrapContext({
+        ...options,
+        limit: options.limit == null ? 8 : options.limit,
+      });
+      const durableMemories = [];
+      const recentCheckpoints = [];
+      const memoryCandidateResults = [];
+
+      for (const result of bootstrap.results || []) {
+        if (result.type === 'memory') {
+          durableMemories.push(result);
+        } else if (result.type === 'checkpoint') {
+          recentCheckpoints.push(resumeCheckpoint(result));
+        } else if (result.type === 'memory_candidate') {
+          memoryCandidateResults.push(result);
+        }
+      }
+      if (bootstrap.sessionId && recentCheckpoints.length === 0) {
+        const latestCheckpoint = useStore((store) =>
+          store.getLatestCheckpoint({ ...bootstrap.scope, sessionId: bootstrap.sessionId }),
+        );
+        if (latestCheckpoint) {
+          recentCheckpoints.push(checkpointHandoffResult(latestCheckpoint));
+        }
+      }
+      if (bootstrap.sessionId && memoryCandidateResults.length === 0) {
+        const latestCandidates = useStore((store) => {
+          const latestCheckpoint = store.getLatestCheckpoint({ ...bootstrap.scope, sessionId: bootstrap.sessionId });
+          return latestCheckpoint
+            ? store.listMemoryCandidates({
+                ...bootstrap.scope,
+                checkpointId: latestCheckpoint.id,
+                status: 'pending',
+                sort: 'recommendation',
+                limit: 3,
+              })
+            : [];
+        });
+        memoryCandidateResults.push(...latestCandidates);
+      }
+
+      return {
+        kind: 'resume_context',
+        scope: bootstrap.scope,
+        storage: bootstrap.storage,
+        query: bootstrap.query,
+        includeShared: bootstrap.includeShared,
+        ...(bootstrap.sessionId ? { sessionId: bootstrap.sessionId } : {}),
+        handoff: {
+          workingSummary: bootstrap.workingSummary || null,
+          rawTail: bootstrap.rawTail || [],
+          durableMemories,
+          recentCheckpoints,
+          memoryCandidates: {
+            count: memoryCandidateResults.length,
+            items: memoryCandidateResults.slice(0, 3).map(compactMemoryCandidate),
+            trust: 'review_material',
+            useHint: 'Review material only; do not turn these into promotion proposals during resume sync.',
+          },
+        },
+        trustPolicy: {
+          durableMemory: 'canonical long-term guidance when reviewed and active',
+          checkpoint:
+            'credible recent handoff state; use actively for continuity, planning, prior intent, recent decisions, and unfinished work',
+          memoryCandidate: 'review material only, not durable truth and not a resume-time promotion proposal',
+          liveState: 'final authority for mutable branch, PR, issue, CI, runtime, deployment, and migration state',
+        },
+        suggestedLiveChecks: [
+          'git status --short --branch',
+          'git remote -v',
+          'git rev-list --left-right --count HEAD...@{u}',
+          'gh pr view/list or gh issue view/list when ids are known',
+          'run project-specific CI/runtime/migration checks when relevant',
+        ],
+        nextActions: [
+          'Summarize the last known task state and safe next action.',
+          'Use checkpoint handoff actively for continuity, planning, prior intent, recent decisions, and unfinished work.',
+          'Verify only mutable live state such as git, GitHub, CI, runtime, and migrations before acting.',
+          'Do not propose memory promotions during resume sync.',
+        ],
+      };
+    },
+
     checkCodexExec(options = {}) {
       return checkCodexExecProvider({
         ...codexExec,
@@ -981,6 +1320,290 @@ export function createContextForge(options = {}) {
           limit: options.limit == null ? null : Number(options.limit),
         }),
       );
+    },
+
+    suggestMemoryPromotions(options = {}) {
+      const scope = normalizeScopeOptions(options, config);
+      const trigger = options.trigger;
+      if (!CLOSEOUT_TRIGGERS.has(trigger)) {
+        throw new Error('trigger must be a closeout trigger.');
+      }
+      const allowScopeFallback = truthyOption(options.allowScopeFallback);
+      if (allowScopeFallback && trigger !== 'manual_closeout') {
+        throw new Error('allowScopeFallback is only allowed with trigger=manual_closeout.');
+      }
+      const limit = Math.min(3, positiveNumber(options.limit == null ? 3 : Number(options.limit), 'limit'));
+      const scanLimit = positiveNumber(options.scanLimit == null ? 10 : Number(options.scanLimit), 'scanLimit');
+      const promotionRecommendation = options.promotionRecommendation || 'promote';
+
+      return useStore((store) => {
+        let checkpointId = options.checkpointId || null;
+        let sourceMode = null;
+        if (checkpointId) {
+          sourceMode = 'checkpoint';
+        } else if (options.sessionId) {
+          const latestCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId });
+          checkpointId = latestCheckpoint?.id || null;
+          sourceMode = 'latest_checkpoint';
+        } else if (allowScopeFallback) {
+          sourceMode = 'scope_fallback';
+        } else {
+          return {
+            kind: 'memory_promotion_suggestions',
+            trigger,
+            source: {
+              sessionId: null,
+              checkpointId: null,
+              mode: 'none',
+              allowScopeFallback: false,
+            },
+            proposals: [],
+            skipped: [],
+            nextActions: [
+              'Provide sessionId or checkpointId to review current closeout candidates.',
+              'Use allowScopeFallback=true only with trigger=manual_closeout when intentionally reviewing the scope backlog.',
+              'Do not promote automatically.',
+            ],
+          };
+        }
+
+        if (options.sessionId && !checkpointId) {
+          return {
+            kind: 'memory_promotion_suggestions',
+            trigger,
+            source: {
+              sessionId: options.sessionId,
+              checkpointId: null,
+              mode: sourceMode,
+              allowScopeFallback,
+            },
+            proposals: [],
+            skipped: [],
+            nextActions: [
+              'No latest checkpoint was found for this session; distill a checkpoint before reviewing promotions.',
+              'Do not promote automatically.',
+            ],
+          };
+        }
+
+        const candidates = store.listMemoryCandidates({
+          ...scope,
+          sessionId: sourceMode === 'scope_fallback' ? null : options.sessionId || null,
+          checkpointId: sourceMode === 'scope_fallback' ? null : checkpointId,
+          status: 'pending',
+          promotionRecommendation,
+          sort: 'recommendation',
+          limit: scanLimit,
+        });
+        const assessed = candidates.map((candidate) => {
+          const warnings = promotionCandidateWarnings(store, scope, candidate);
+          const score = scorePromotionCandidate(candidate, warnings, trigger);
+          return { candidate, warnings, score };
+        });
+        const selected = assessed
+          .filter((item) => item.score > 0)
+          .sort((a, b) => b.score - a.score)
+          .slice(0, limit);
+
+        return {
+          kind: 'memory_promotion_suggestions',
+          trigger,
+          source: {
+            sessionId: options.sessionId || null,
+            checkpointId: checkpointId || null,
+            mode: sourceMode,
+            allowScopeFallback,
+          },
+          proposals: selected.map((item, index) => promotionProposal(item.candidate, item.warnings, index + 1)),
+          skipped: assessed
+            .filter((item) => item.score <= 0)
+            .map((item) => ({
+              candidateId: item.candidate.id,
+              reason: candidateWarningReason(item.warnings) || 'low_score',
+            })),
+          nextActions: [
+            'Ask the user to choose: promote, edit then promote, skip, or reject.',
+            'Do not promote automatically.',
+          ],
+        };
+      });
+    },
+
+    async reconcileMemory(options = {}) {
+      const scope = normalizeScopeOptions(options, config);
+      requireOption(options.query, 'query');
+      requireOption(options.correction, 'correction');
+      const mode = options.mode || 'propose';
+      if (!['propose', 'apply_safe'].includes(mode)) {
+        throw new Error('mode must be propose or apply_safe.');
+      }
+      const limit = positiveNumber(options.limit == null ? 8 : Number(options.limit), 'limit');
+      const candidateLimit = positiveNumber(
+        options.candidateLimit == null ? 5 : Number(options.candidateLimit),
+        'candidateLimit',
+      );
+      const includeShared = truthyOption(options.includeShared);
+      const reconciliationQuery = `${options.query}\n${options.correction}`;
+      const bootstrap = await this.bootstrapContext({
+        ...options,
+        query: reconciliationQuery,
+        includeShared,
+        limit,
+      });
+      const liveState = isLiveStateCorrection(`${options.query}\n${options.correction}`);
+      return useStore((store) => {
+        const basis = (bootstrap.results || []).slice(0, limit).map(summarizeBasisResult);
+        if (options.sessionId && !basis.some((item) => item.type === 'checkpoint')) {
+          const latestCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId });
+          if (latestCheckpoint) {
+            basis.push(checkpointBasisResult(latestCheckpoint));
+          }
+        }
+        if (options.sessionId && !basis.some((item) => item.type === 'memory_candidate')) {
+          const latestCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId });
+          if (latestCheckpoint) {
+            const latestCandidates = store.listMemoryCandidates({
+              ...scope,
+              checkpointId: latestCheckpoint.id,
+              status: 'pending',
+              sort: 'recommendation',
+              limit: candidateLimit,
+            });
+            basis.push(...latestCandidates.map(indexedCandidateBasisResult));
+          }
+        }
+        const durableBasis = basis.filter((item) => item.type === 'memory');
+        const checkpointBasis = basis.filter((item) => item.type === 'checkpoint');
+        const candidateBasis = basis.filter((item) => item.type === 'memory_candidate').slice(0, candidateLimit);
+        const conflicts = basis.map((item) => ({
+          type: item.type,
+          key: item.key,
+          conflict: 'possible_conflict',
+          reason:
+            item.type === 'checkpoint'
+              ? 'Checkpoint may explain prior belief, but it should not be edited directly.'
+              : 'User correction may conflict with this stored context; review before applying.',
+        }));
+        const proposedActions = [
+          ...durableBasis.map((item) => ({
+            action: liveState ? 'verify_live_state_before_memory_change' : 'correct_memory',
+            key: item.key,
+            content: options.correction,
+            reason: 'User correction conflicts with existing durable memory.',
+          })),
+          ...candidateBasis.map((item) => ({
+            action: 'reject_memory_candidate',
+            candidateId: item.candidateId,
+            reason: 'User correction indicates this candidate should not become durable truth.',
+          })),
+          ...checkpointBasis.map((item) => ({
+            action: 'propose_corrective_memory_note',
+            checkpointId: item.checkpointId,
+            content: options.correction,
+            reason: 'Checkpoints are immutable handoff evidence; add corrective durable context instead.',
+          })),
+        ];
+        const appliedActions = [];
+        const warnings = [];
+
+        if (liveState) {
+          warnings.push({
+            code: 'live_state_verification_required',
+            message: 'Correction appears to involve mutable live state; verify git/GitHub/CI/runtime/migrations first.',
+          });
+        }
+
+        if (mode === 'apply_safe') {
+          if (liveState) {
+            warnings.push({
+              code: 'apply_safe_skipped_live_state',
+              message: 'No memory changes were applied because live state verification is required.',
+            });
+          } else if (durableBasis.length === 1) {
+            const durable = durableBasis[0];
+            const previous = store.getMemory({ ...scope, key: durable.key });
+            const corrected = store.rememberMemory({
+              ...scope,
+              key: durable.key,
+              content: options.correction,
+              category: durable.category || 'note',
+              tags: [],
+              importance: undefined,
+              supersedesMemoryId: previous?.id || durable.memoryId || undefined,
+              eventType: 'correct',
+              eventMetadata: {
+                key: durable.key,
+                previousMemoryId: previous?.id || durable.memoryId || null,
+                previousContent: previous?.content || durable.content,
+                reason: 'Applied via reconcile_memory apply_safe.',
+              },
+            });
+            appliedActions.push({
+              action: 'correct_memory',
+              key: corrected.key,
+              memoryId: corrected.id,
+            });
+          } else if (durableBasis.length > 1) {
+            warnings.push({
+              code: 'ambiguous_durable_memory',
+              message: 'Multiple durable memories matched; no automatic correction was applied.',
+            });
+          }
+
+          if (!liveState) {
+            for (const item of candidateBasis) {
+              const candidate = store.getMemoryCandidate({
+                ...scope,
+                candidateId: item.candidateId,
+              });
+              if (candidate?.status === 'pending') {
+                const rejected = store.markMemoryCandidateReviewed({
+                  ...scope,
+                  candidateId: item.candidateId,
+                  status: 'rejected',
+                  reason: 'Rejected via reconcile_memory apply_safe after user correction.',
+                  metadata: {
+                    correction: options.correction,
+                    query: options.query,
+                  },
+                });
+                appliedActions.push({
+                  action: 'reject_memory_candidate',
+                  candidateId: rejected.id,
+                });
+              }
+            }
+          }
+        }
+
+        return {
+          kind: 'memory_reconciliation',
+          mode,
+          scope: bootstrap.scope,
+          storage: bootstrap.storage,
+          query: options.query,
+          correction: options.correction,
+          basis,
+          conflicts,
+          proposedActions,
+          appliedActions,
+          warnings,
+          trustPolicy: {
+            userCorrection: 'strong evidence, but not automatically treated as universal truth',
+            durableMemory: 'canonical until corrected or deactivated',
+            checkpoint: 'basis and immutable handoff evidence; do not edit directly',
+            memoryCandidate: 'review material that can be rejected when contradicted',
+            liveState: 'verify mutable git/GitHub/CI/runtime/migration claims before changing memory',
+          },
+          nextActions:
+            mode === 'apply_safe'
+              ? ['Review appliedActions and warnings.', 'Verify mutable live state before making further memory changes.']
+              : [
+                  'Ask the user whether to apply a correction, deactivate stale durable memory, reject candidates, or add a corrective note.',
+                  'Verify mutable live state before changing memory for git/GitHub/CI/runtime/migration claims.',
+                ],
+        };
+      });
     },
 
     promoteMemoryCandidate(options) {

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -26,7 +26,10 @@ const MCP_INSTRUCTIONS = [
   'Use ContextForge for scoped memory retrieval on demand.',
   'At the start of non-trivial project work, call bootstrap_context with repoPath, cwd, or an explicit scopeKey. It summarizes storage authority, vector readiness, repo semantic retrieval results, and trust hints in one response.',
   'If db_info shows remote storage, treat results as shared canonical ContextForge state for the configured scope. If it shows local or project-local storage, treat results as machine-local context unless the user confirms that store is authoritative.',
-  'Search result types have different trust levels: memory is reviewed durable fact or decision; checkpoint is recent session continuity, not canonical truth; memory_candidate is an unreviewed promotion candidate for review.',
+  'Search result types have different trust roles: memory is reviewed durable fact or decision; checkpoint is credible recent handoff state for continuity, planning, prior intent, recent decisions, and unfinished work, but mutable live-state claims must be verified with git/GitHub/CI/runtime/migrations before acting; memory_candidate is unreviewed promotion material and not durable truth.',
+  'For start/resume requests such as "지난 환경 작업과 동기화", "어제 하던 거 이어서", "previous work", or "continue", call sync_resume_context. Use checkpoints actively as handoff notes, then verify mutable state with git/GitHub/CI/runtime/migrations. Do not propose memory promotions during resume sync.',
+  'For closeout triggers only, call suggest_memory_promotions: after this agent merges a PR, after the user says they merged and the agent syncs main/cleans branches, or when the user explicitly says today\'s work is done. Suggest at most 1-3 durable memory promotions and never promote automatically.',
+  'For user corrections such as "너 잘못 알고 있잖아", "그거 아니야", "그건 X가 아니라 Y야", or "기억 수정해", call reconcile_memory. Show the basis for prior knowledge, assess conflicts, and only apply safe corrections when the user explicitly asks to fix memory.',
   'When resuming a known session, pass sessionId to bootstrap_context or call get_working_summary to load latest rolling handoff state separately from durable memory and checkpoint search results.',
   'If working on a repository while the MCP process cwd is elsewhere, pass repoPath or cwd so repo scope resolves to that checkout; repoPath takes precedence when both are provided.',
   'Treat scopeKey as the canonical repo memory key; pass an explicit normalized GitHub key when local paths differ across machines or the checkout cannot infer the right remote.',
@@ -85,6 +88,30 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
       },
     },
     async (args) => jsonResult(await app.bootstrapContext(args)),
+  );
+
+  server.registerTool(
+    'sync_resume_context',
+    {
+      title: 'Sync Resume Context',
+      description:
+        'Build a start/resume handoff package for continuing work across machines or agent environments. Use checkpoints as credible recent handoff notes, durable memories as canonical long-term context, and memory candidates only as review material. This tool must not propose or perform durable memory promotion.',
+      inputSchema: {
+        ...scopedSchema,
+        query: z.string(),
+        sessionId: z.string().optional(),
+        includeShared: z.boolean().optional(),
+        limit: z.number().int().positive().optional(),
+        rawTailLimit: z.number().int().positive().optional(),
+        sharedScopeKey: z.string().optional(),
+      },
+      annotations: {
+        title: 'Sync Resume Context',
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.syncResumeContext(args)),
   );
 
   server.registerTool(
@@ -355,6 +382,63 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
       },
     },
     async (args) => jsonResult(await app.listMemoryCandidates(args)),
+  );
+
+  server.registerTool(
+    'suggest_memory_promotions',
+    {
+      title: 'Suggest Memory Promotions',
+      description:
+        'Suggest at most 1-3 high-signal durable memory promotion candidates at closeout triggers only. Review only the current session or latest checkpoint candidate set by default. Never promote automatically.',
+      inputSchema: {
+        ...scopedSchema,
+        sessionId: z.string().optional(),
+        checkpointId: z.string().optional(),
+        trigger: z.enum([
+          'agent_merged_pr',
+          'user_merged_then_synced',
+          'user_declared_work_done',
+          'manual_closeout',
+        ]),
+        limit: z.number().int().positive().optional(),
+        scanLimit: z.number().int().positive().optional(),
+        promotionRecommendation: z.string().optional(),
+        includeWarnings: z.boolean().optional(),
+        allowScopeFallback: z.boolean().optional(),
+      },
+      annotations: {
+        title: 'Suggest Memory Promotions',
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.suggestMemoryPromotions(args)),
+  );
+
+  server.registerTool(
+    'reconcile_memory',
+    {
+      title: 'Reconcile Memory',
+      description:
+        'Search relevant durable memories, checkpoints, and memory candidates for a user correction; explain the basis for existing knowledge, assess conflicts, and optionally apply safe memory corrections only when explicitly requested.',
+      inputSchema: {
+        ...scopedSchema,
+        query: z.string(),
+        correction: z.string(),
+        mode: z.enum(['propose', 'apply_safe']).optional(),
+        sessionId: z.string().optional(),
+        includeShared: z.boolean().optional(),
+        limit: z.number().int().positive().optional(),
+        candidateLimit: z.number().int().positive().optional(),
+        sharedScopeKey: z.string().optional(),
+      },
+      annotations: {
+        title: 'Reconcile Memory',
+        readOnlyHint: false,
+        idempotentHint: false,
+      },
+    },
+    async (args) => jsonResult(await app.reconcileMemory(args)),
   );
 
   server.registerTool(

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -163,7 +163,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Search Memory',
       description:
-        'Search scoped ContextForge retrieval results. Results may include type=memory reviewed durable facts, type=checkpoint recent continuity, and type=memory_candidate unreviewed promotion candidates. Pass repoPath or cwd to retrieve repo results for a checkout outside the MCP process cwd; repoPath takes precedence. Pass scopeKey to pin the canonical repo memory key.',
+        'Search scoped ContextForge retrieval results. Results may include type=memory reviewed durable facts, type=checkpoint credible recent handoff state, and type=memory_candidate unreviewed promotion candidates. Pass repoPath or cwd to retrieve repo results for a checkout outside the MCP process cwd; repoPath takes precedence. Pass scopeKey to pin the canonical repo memory key.',
       inputSchema: {
         ...scopedSchema,
         query: z.string(),
@@ -420,7 +420,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Reconcile Memory',
       description:
-        'Search relevant durable memories, checkpoints, and memory candidates for a user correction; explain the basis for existing knowledge, assess conflicts, and optionally apply safe memory corrections only when explicitly requested.',
+        'Search relevant durable memories, checkpoints, and memory candidates for a user correction; explain the basis for existing knowledge, assess conflicts, and optionally apply safe memory corrections only when explicitly requested. Default mode=propose is read-only; mode=apply_safe may correct durable memory or reject candidates when the correction is unambiguous.',
       inputSchema: {
         ...scopedSchema,
         query: z.string(),

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -3,6 +3,7 @@ import { normalizeScopeOptions } from '../scopes/index.js';
 const REMOTE_METHODS = [
   'dbInfo',
   'bootstrapContext',
+  'syncResumeContext',
   'checkCodexExec',
   'beginSession',
   'sessionStatus',
@@ -14,6 +15,8 @@ const REMOTE_METHODS = [
   'deactivateMemory',
   'listMemoryEvents',
   'listMemoryCandidates',
+  'suggestMemoryPromotions',
+  'reconcileMemory',
   'getMemory',
   'search',
   'rebuildEmbeddings',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -4158,7 +4158,7 @@ test('suggestMemoryPromotions honors scanLimit and reports capped proposal limit
   });
 
   assert.equal(result.proposals.length, 2);
-  assert.ok(result.warnings.some((warning) => warning.code === 'limit_capped'));
+  assert.ok(result.requestWarnings.some((warning) => warning.code === 'limit_capped'));
 });
 
 test('suggestMemoryPromotions uses only latest checkpoint for a session and skips risky candidates', async () => {
@@ -4353,7 +4353,7 @@ test('reconcileMemory proposes by default and apply_safe only changes unambiguou
   assert.equal(live.appliedActions.length, 0);
 });
 
-test('reconcileMemory apply_safe does not mutate when no durable memory matches', async () => {
+test('reconcileMemory apply_safe rejects matching candidates when no durable memory matches', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({
     env: {
@@ -4403,11 +4403,14 @@ test('reconcileMemory apply_safe does not mutate when no durable memory matches'
     correction: 'Candidate-only claim is wrong.',
     mode: 'apply_safe',
   });
-  assert.deepEqual(result.appliedActions, []);
+  assert.deepEqual(
+    result.appliedActions.map((action) => action.action),
+    ['reject_memory_candidate'],
+  );
   const candidates = app.listMemoryCandidates({
     scope: 'repo',
     scopeKey: 'candidate-only-repo',
-    status: 'pending',
+    status: 'rejected',
   });
   assert.equal(candidates.length, 1);
 });

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -16,6 +16,7 @@ import { createInterruptibleSleep, shouldSkipRecentFailedAutoDistill } from '../
 import { watchClaudeCodeSessions } from '../src/ingest/claude_code.js';
 import { ingestCodexRolloutFile, watchCodexSessions } from '../src/ingest/codex.js';
 import { searchMemories } from '../src/retrieval/search.js';
+import { REMOTE_METHODS } from '../src/remote/client.js';
 import { startContextForgeServer } from '../src/server.js';
 import { ContextForgeStore, SCHEMA_VERSION } from '../src/storage/sqlite.js';
 
@@ -3947,6 +3948,341 @@ test('bootstrapContext reuses one query embedding across repo and shared retriev
   assert.ok(result.results.some((item) => item.group === 'shared'));
 });
 
+test('syncResumeContext returns handoff context without promotion proposals', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'resume_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      resume_provider: async () => ({
+        summaryShort: 'Resume handoff for usage observability.',
+        summaryText:
+          'Usage observability work left unfinished migration checks and PR verification for the next agent.',
+        decisions: ['Use checkpoint handoff for prior intent.'],
+        todos: ['Verify CI before acting.'],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'resume-candidate-runbook',
+            content: 'Review usage observability closeout candidates only at closeout.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.9,
+            stability: 0.9,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'resume-repo',
+    key: 'resume-durable-rule',
+    content: 'Usage observability resume must verify CI live.',
+    category: 'runbook',
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'resume-repo',
+    sessionId: 'resume-session',
+    role: 'assistant',
+    content: 'Usage observability checkpoint should preserve unfinished work.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'resume-repo',
+    sessionId: 'resume-session',
+  });
+
+  const result = await app.syncResumeContext({
+    scope: 'repo',
+    scopeKey: 'resume-repo',
+    sessionId: 'resume-session',
+    query: 'usage observability resume unfinished work closeout candidates',
+  });
+
+  assert.equal(result.kind, 'resume_context');
+  assert.equal(result.handoff.recentCheckpoints[0].trust, 'credible_recent_handoff');
+  assert.match(result.handoff.recentCheckpoints[0].useHint, /Use actively/);
+  assert.equal(result.handoff.memoryCandidates.count, 1);
+  assert.equal(result.handoff.memoryCandidates.items[0].trust, 'review_material');
+  assert.equal(Object.hasOwn(result, 'proposals'), false);
+  assert.ok(result.nextActions.includes('Do not propose memory promotions during resume sync.'));
+});
+
+test('suggestMemoryPromotions avoids scope fallback unless explicitly allowed', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'suggest_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      suggest_provider: async () => ({
+        summaryShort: 'Promotion suggestion checkpoint.',
+        summaryText: 'Closeout produced a stable runbook candidate.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'closeout-runbook',
+            content: 'Closeout should verify branch parity before frontend follow-up.',
+            reason: 'PR #595 merge and main parity were verified.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.91,
+            stability: 0.92,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'suggest-repo',
+    sessionId: 'suggest-session',
+    role: 'assistant',
+    content: 'Closeout candidate: branch parity runbook.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'suggest-repo',
+    sessionId: 'suggest-session',
+  });
+
+  const noFallback = app.suggestMemoryPromotions({
+    scope: 'repo',
+    scopeKey: 'suggest-repo',
+    trigger: 'manual_closeout',
+  });
+  assert.deepEqual(noFallback.proposals, []);
+  assert.equal(noFallback.source.mode, 'none');
+
+  assert.throws(
+    () =>
+      app.suggestMemoryPromotions({
+        scope: 'repo',
+        scopeKey: 'suggest-repo',
+        trigger: 'agent_merged_pr',
+        allowScopeFallback: true,
+      }),
+    /allowScopeFallback/,
+  );
+
+  const fallback = app.suggestMemoryPromotions({
+    scope: 'repo',
+    scopeKey: 'suggest-repo',
+    trigger: 'manual_closeout',
+    allowScopeFallback: true,
+  });
+  assert.equal(fallback.source.mode, 'scope_fallback');
+  assert.equal(fallback.proposals.length, 1);
+  assert.equal(fallback.proposals[0].key, 'closeout-runbook');
+});
+
+test('suggestMemoryPromotions uses only latest checkpoint for a session and skips risky candidates', async () => {
+  const dataDir = await makeTempDir();
+  let callCount = 0;
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'latest_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      latest_provider: async () => {
+        callCount += 1;
+        return {
+          summaryShort: `Checkpoint ${callCount}.`,
+          summaryText: `Checkpoint ${callCount} contains candidates.`,
+          decisions: [],
+          todos: [],
+          openQuestions: [],
+          memoryCandidates:
+            callCount === 1
+              ? [
+                  {
+                    key: 'old-runbook',
+                    content: 'Old checkpoint candidate should not be suggested from latest session closeout.',
+                    category: 'runbook',
+                    confidence: 0.95,
+                    stability: 0.95,
+                    sensitivity: 'low',
+                    promotionRecommendation: 'promote',
+                  },
+                ]
+              : [
+                  {
+                    key: 'latest-runbook',
+                    content: 'Latest checkpoint candidate should be suggested.',
+                    category: 'runbook',
+                    candidateType: 'runbook',
+                    confidence: 0.95,
+                    stability: 0.95,
+                    sensitivity: 'low',
+                    promotionRecommendation: 'promote',
+                  },
+                  {
+                    key: 'latest-secret',
+                    content: 'Risky candidate should not be suggested.',
+                    category: 'runbook',
+                    candidateType: 'runbook',
+                    confidence: 0.95,
+                    stability: 0.95,
+                    sensitivity: 'high',
+                    promotionRecommendation: 'promote',
+                  },
+                ],
+        };
+      },
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'latest-repo',
+    sessionId: 'latest-session',
+    role: 'assistant',
+    content: 'First checkpoint raw.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'latest-repo',
+    sessionId: 'latest-session',
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'latest-repo',
+    sessionId: 'latest-session',
+    role: 'assistant',
+    content: 'Second checkpoint raw.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'latest-repo',
+    sessionId: 'latest-session',
+  });
+
+  const result = app.suggestMemoryPromotions({
+    scope: 'repo',
+    scopeKey: 'latest-repo',
+    sessionId: 'latest-session',
+    trigger: 'user_declared_work_done',
+  });
+
+  assert.deepEqual(
+    result.proposals.map((proposal) => proposal.key),
+    ['latest-runbook'],
+  );
+  assert.ok(result.skipped.some((item) => item.reason.includes('high_sensitivity')));
+});
+
+test('reconcileMemory proposes by default and apply_safe only changes unambiguous non-live memory', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'reconcile_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      reconcile_provider: async () => ({
+        summaryShort: 'Reconcile checkpoint.',
+        summaryText: 'Prior note incorrectly said the API uses REST only.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'api-rest-only-candidate',
+            content: 'The API uses REST only.',
+            category: 'api-contract',
+            confidence: 0.8,
+            stability: 0.8,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'reconcile-repo',
+    key: 'api-transport',
+    content: 'The API uses REST only.',
+    category: 'api-contract',
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'reconcile-repo',
+    sessionId: 'reconcile-session',
+    role: 'assistant',
+    content: 'The API uses REST only.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'reconcile-repo',
+    sessionId: 'reconcile-session',
+  });
+
+  const proposed = await app.reconcileMemory({
+    scope: 'repo',
+    scopeKey: 'reconcile-repo',
+    sessionId: 'reconcile-session',
+    query: 'API REST only transport',
+    correction: 'The API supports REST and GraphQL.',
+  });
+  assert.equal(proposed.mode, 'propose');
+  assert.ok(proposed.basis.some((item) => item.type === 'memory'));
+  assert.ok(proposed.basis.some((item) => item.type === 'checkpoint'));
+  assert.ok(proposed.basis.some((item) => item.type === 'memory_candidate'));
+  assert.ok(proposed.proposedActions.some((item) => item.action === 'correct_memory'));
+  assert.ok(proposed.proposedActions.some((item) => item.action === 'reject_memory_candidate'));
+  assert.equal(app.getMemory({ scope: 'repo', scopeKey: 'reconcile-repo', key: 'api-transport' }).content, 'The API uses REST only.');
+
+  const applied = await app.reconcileMemory({
+    scope: 'repo',
+    scopeKey: 'reconcile-repo',
+    sessionId: 'reconcile-session',
+    query: 'API REST only transport',
+    correction: 'The API supports REST and GraphQL.',
+    mode: 'apply_safe',
+  });
+  assert.ok(applied.appliedActions.some((item) => item.action === 'correct_memory'));
+  assert.ok(applied.appliedActions.some((item) => item.action === 'reject_memory_candidate'));
+  assert.equal(
+    app.getMemory({ scope: 'repo', scopeKey: 'reconcile-repo', key: 'api-transport' }).content,
+    'The API supports REST and GraphQL.',
+  );
+
+  const live = await app.reconcileMemory({
+    scope: 'repo',
+    scopeKey: 'reconcile-repo',
+    sessionId: 'reconcile-session',
+    query: 'PR status on main',
+    correction: 'PR #12 is not merged.',
+    mode: 'apply_safe',
+  });
+  assert.ok(live.warnings.some((warning) => warning.code === 'live_state_verification_required'));
+  assert.equal(live.appliedActions.length, 0);
+});
+
+test('REMOTE_METHODS exposes resume, suggestion, and reconciliation wrappers', () => {
+  assert.ok(REMOTE_METHODS.includes('syncResumeContext'));
+  assert.ok(REMOTE_METHODS.includes('suggestMemoryPromotions'));
+  assert.ok(REMOTE_METHODS.includes('reconcileMemory'));
+});
+
 test('CLI supports the v0 workflow with synthetic data', async () => {
   const dataDir = await makeTempDir();
   const env = { ...process.env, CONTEXTFORGE_DATA_DIR: dataDir };
@@ -4109,10 +4445,13 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'promote_memory_candidate',
       'prune_raw_events',
       'rebuild_embeddings',
+      'reconcile_memory',
       'reject_memory_candidate',
       'remember',
       'search',
       'session_status',
+      'suggest_memory_promotions',
+      'sync_resume_context',
     ]);
     const rememberTool = toolList.tools.find((tool) => tool.name === 'remember');
     assert.ok(rememberTool.inputSchema.properties.repoPath);
@@ -4128,6 +4467,14 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     const bootstrapTool = toolList.tools.find((tool) => tool.name === 'bootstrap_context');
     assert.ok(bootstrapTool.inputSchema.properties.sessionId);
     assert.ok(bootstrapTool.inputSchema.properties.rawTailLimit);
+    const syncResumeTool = toolList.tools.find((tool) => tool.name === 'sync_resume_context');
+    assert.ok(syncResumeTool.inputSchema.properties.sessionId);
+    const suggestTool = toolList.tools.find((tool) => tool.name === 'suggest_memory_promotions');
+    assert.ok(suggestTool.inputSchema.properties.allowScopeFallback);
+    assert.ok(suggestTool.inputSchema.properties.trigger);
+    const reconcileTool = toolList.tools.find((tool) => tool.name === 'reconcile_memory');
+    assert.ok(reconcileTool.inputSchema.properties.correction);
+    assert.ok(reconcileTool.inputSchema.properties.mode);
     const appendRawTool = toolList.tools.find((tool) => tool.name === 'append_raw');
     assert.deepEqual(appendRawTool.inputSchema.properties.role.enum, ['user', 'assistant']);
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -4016,6 +4016,23 @@ test('syncResumeContext returns handoff context without promotion proposals', as
   assert.ok(result.nextActions.includes('Do not propose memory promotions during resume sync.'));
 });
 
+test('syncResumeContext handles empty bootstrap results without proposals', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  const result = await app.syncResumeContext({
+    scope: 'repo',
+    scopeKey: 'empty-resume-repo',
+    query: 'no matching resume context',
+  });
+
+  assert.equal(result.kind, 'resume_context');
+  assert.deepEqual(result.handoff.durableMemories, []);
+  assert.deepEqual(result.handoff.recentCheckpoints, []);
+  assert.equal(result.handoff.memoryCandidates.count, 0);
+  assert.equal(Object.hasOwn(result, 'proposals'), false);
+});
+
 test('suggestMemoryPromotions avoids scope fallback unless explicitly allowed', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({
@@ -4060,7 +4077,7 @@ test('suggestMemoryPromotions avoids scope fallback unless explicitly allowed', 
     sessionId: 'suggest-session',
   });
 
-  const noFallback = app.suggestMemoryPromotions({
+  const noFallback = await app.suggestMemoryPromotions({
     scope: 'repo',
     scopeKey: 'suggest-repo',
     trigger: 'manual_closeout',
@@ -4068,7 +4085,7 @@ test('suggestMemoryPromotions avoids scope fallback unless explicitly allowed', 
   assert.deepEqual(noFallback.proposals, []);
   assert.equal(noFallback.source.mode, 'none');
 
-  assert.throws(
+  await assert.rejects(
     () =>
       app.suggestMemoryPromotions({
         scope: 'repo',
@@ -4079,7 +4096,7 @@ test('suggestMemoryPromotions avoids scope fallback unless explicitly allowed', 
     /allowScopeFallback/,
   );
 
-  const fallback = app.suggestMemoryPromotions({
+  const fallback = await app.suggestMemoryPromotions({
     scope: 'repo',
     scopeKey: 'suggest-repo',
     trigger: 'manual_closeout',
@@ -4088,6 +4105,60 @@ test('suggestMemoryPromotions avoids scope fallback unless explicitly allowed', 
   assert.equal(fallback.source.mode, 'scope_fallback');
   assert.equal(fallback.proposals.length, 1);
   assert.equal(fallback.proposals[0].key, 'closeout-runbook');
+});
+
+test('suggestMemoryPromotions honors scanLimit and reports capped proposal limits', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'scan_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      scan_provider: async () => ({
+        summaryShort: 'Many candidates.',
+        summaryText: 'Closeout produced many promotion candidates.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: Array.from({ length: 5 }, (_, index) => ({
+          key: `scan-runbook-${index + 1}`,
+          content: `Runbook candidate ${index + 1}.`,
+          category: 'runbook',
+          candidateType: 'runbook',
+          confidence: 0.9,
+          stability: 0.9,
+          sensitivity: 'low',
+          promotionRecommendation: 'promote',
+        })),
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'scan-repo',
+    sessionId: 'scan-session',
+    role: 'assistant',
+    content: 'Many closeout candidates.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'scan-repo',
+    sessionId: 'scan-session',
+  });
+
+  const result = await app.suggestMemoryPromotions({
+    scope: 'repo',
+    scopeKey: 'scan-repo',
+    sessionId: 'scan-session',
+    trigger: 'manual_closeout',
+    scanLimit: 2,
+    limit: 5,
+  });
+
+  assert.equal(result.proposals.length, 2);
+  assert.ok(result.warnings.some((warning) => warning.code === 'limit_capped'));
 });
 
 test('suggestMemoryPromotions uses only latest checkpoint for a session and skips risky candidates', async () => {
@@ -4172,7 +4243,7 @@ test('suggestMemoryPromotions uses only latest checkpoint for a session and skip
     sessionId: 'latest-session',
   });
 
-  const result = app.suggestMemoryPromotions({
+  const result = await app.suggestMemoryPromotions({
     scope: 'repo',
     scopeKey: 'latest-repo',
     sessionId: 'latest-session',
@@ -4221,6 +4292,8 @@ test('reconcileMemory proposes by default and apply_safe only changes unambiguou
     key: 'api-transport',
     content: 'The API uses REST only.',
     category: 'api-contract',
+    tags: ['api', 'transport'],
+    importance: 6,
   });
   app.appendRaw({
     scope: 'repo',
@@ -4264,6 +4337,9 @@ test('reconcileMemory proposes by default and apply_safe only changes unambiguou
     app.getMemory({ scope: 'repo', scopeKey: 'reconcile-repo', key: 'api-transport' }).content,
     'The API supports REST and GraphQL.',
   );
+  const corrected = app.getMemory({ scope: 'repo', scopeKey: 'reconcile-repo', key: 'api-transport' });
+  assert.deepEqual(corrected.tags, ['api', 'transport']);
+  assert.equal(corrected.importance, 6);
 
   const live = await app.reconcileMemory({
     scope: 'repo',
@@ -4275,6 +4351,65 @@ test('reconcileMemory proposes by default and apply_safe only changes unambiguou
   });
   assert.ok(live.warnings.some((warning) => warning.code === 'live_state_verification_required'));
   assert.equal(live.appliedActions.length, 0);
+});
+
+test('reconcileMemory apply_safe does not mutate when no durable memory matches', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'candidate_only_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      candidate_only_provider: async () => ({
+        summaryShort: 'Candidate only checkpoint.',
+        summaryText: 'Only a candidate exists for this correction.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'candidate-only',
+            content: 'Candidate-only stale claim.',
+            category: 'runbook',
+            confidence: 0.8,
+            stability: 0.8,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'candidate-only-repo',
+    sessionId: 'candidate-only-session',
+    role: 'assistant',
+    content: 'Candidate-only stale claim.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'candidate-only-repo',
+    sessionId: 'candidate-only-session',
+  });
+
+  const result = await app.reconcileMemory({
+    scope: 'repo',
+    scopeKey: 'candidate-only-repo',
+    sessionId: 'candidate-only-session',
+    query: 'candidate-only stale claim',
+    correction: 'Candidate-only claim is wrong.',
+    mode: 'apply_safe',
+  });
+  assert.deepEqual(result.appliedActions, []);
+  const candidates = app.listMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'candidate-only-repo',
+    status: 'pending',
+  });
+  assert.equal(candidates.length, 1);
 });
 
 test('REMOTE_METHODS exposes resume, suggestion, and reconciliation wrappers', () => {


### PR DESCRIPTION
## Summary

- add `sync_resume_context` for start/resume handoff packages that treat checkpoints as credible recent handoff state without proposing promotions
- add `suggest_memory_promotions` as a closeout-only, suggestion-only selector with guarded scope fallback behavior
- add `reconcile_memory` for user correction flows across durable memory, checkpoints, and memory candidates
- expose the new wrappers through MCP and remote storage mode, and update agent instructions

## Compatibility Notes

- `suggest_memory_promotions` returns request-level warnings as `requestWarnings`; candidate-level warnings remain on each proposal.

## Validation

- `npm test`
- `node src/cli.js dbInfo`
- `git diff --check`

## Follow-up Issues

- #84 dry-run auto-promote tool
- #83 guarded real auto-promotion behind env flags
- #82 async embedding job queue
- #81 memory update candidates
- #80 preference occurrence and merge model
- #79 structured session working context
- #78 checkpoint levels
- #77 Korean-friendly fallback retrieval