### PR TITLE
[codex] Add guarded auto memory promotion

### DIFF
--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -381,6 +381,16 @@ only one to three items for promotion. It is normal for many `memory_candidate`
 records to accumulate; treat them as a review queue, not as a backlog that must
 be emptied.
 
+When the user wants automatic promotion, use `auto_promote_memory_candidates`
+only at closeout triggers and only with `sessionId` or `checkpointId`. The tool
+defaults to `dryRun=true`. Real promotion with `dryRun=false` requires
+`CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true` and still applies strict policy:
+pending candidates only, `promotionRecommendation=promote`, high confidence and
+stability, no high/restricted sensitivity, no duplicates, no scope-wide backlog
+fallback, and category limited to `runbook`, `failure-mode`, `api-contract`,
+`environment`, or `decision`. Do not auto-promote `preference` candidates until
+occurrence/merge tracking exists.
+
 Candidate records may include review signals such as `candidateType`,
 `confidence`, `stability`, `sensitivity`, `promotionRecommendation`, and
 `sourceEventIds`. Use those fields to prioritize review. Treat `ignore`,
@@ -476,6 +486,9 @@ Prefer distilling at meaningful boundaries:
   candidates.
 - `suggest_memory_promotions`: closeout-only selector that proposes at most one
   to three durable memory promotions and never promotes automatically.
+- `auto_promote_memory_candidates`: closeout-only strict automatic promotion
+  selector. Defaults to dry-run; real promotion requires
+  `CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true` plus `dryRun=false`.
 - `reconcile_memory`: reconcile user corrections against durable memories,
   checkpoints, and memory candidates.
 - `promote_memory_candidate`: promote a reviewed candidate by candidate id.

--- a/src/cli.js
+++ b/src/cli.js
@@ -91,6 +91,16 @@ function toCoreOptions(options) {
     status: options.status,
     candidateType: options.candidateType,
     promotionRecommendation: options.promotionRecommendation,
+    trigger: options.trigger,
+    dryRun: options.dryRun == null ? undefined : options.dryRun === true || options.dryRun === 'true',
+    minConfidence: options.minConfidence == null ? undefined : Number(options.minConfidence),
+    minStability: options.minStability == null ? undefined : Number(options.minStability),
+    allowedCategories: options.allowedCategories
+      ? String(options.allowedCategories)
+          .split(',')
+          .map((item) => item.trim())
+          .filter(Boolean)
+      : undefined,
     sort: options.sort,
     allowWarnings: options.allowWarnings === true || options.allowWarnings === 'true',
     allowStatusOverride: options.allowStatusOverride === true || options.allowStatusOverride === 'true',
@@ -144,6 +154,7 @@ async function main() {
     deactivateMemory: (app, coreOptions) => app.deactivateMemory(coreOptions),
     listMemoryEvents: (app, coreOptions) => app.listMemoryEvents(coreOptions),
     listMemoryCandidates: (app, coreOptions) => app.listMemoryCandidates(coreOptions),
+    autoPromoteMemoryCandidates: (app, coreOptions) => app.autoPromoteMemoryCandidates(coreOptions),
     search: (app, coreOptions) => app.search(coreOptions),
     rebuildEmbeddings: (app, coreOptions) => app.rebuildEmbeddings(coreOptions),
     getMemory: (app, coreOptions) => app.getMemory(coreOptions),

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -31,6 +31,10 @@ function parseOptionalPositiveInteger(value, name) {
   return parsed;
 }
 
+function parseBoolean(value) {
+  return value === true || value === 'true' || value === '1' || value === 1;
+}
+
 function findGitRoot(cwd) {
   let current = path.resolve(cwd);
   while (true) {
@@ -216,6 +220,9 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
         'CONTEXTFORGE_REMOTE_TIMEOUT_MS',
         30000,
       ),
+    },
+    autoPromote: {
+      enabled: parseBoolean(env.CONTEXTFORGE_AUTO_PROMOTE_ENABLED),
     },
     codexExec: {
       command: env.CONTEXTFORGE_CODEX_EXEC_COMMAND || 'codex',

--- a/src/core.js
+++ b/src/core.js
@@ -456,6 +456,10 @@ const AUTO_SKIP_WARNING_CODES = new Set([
   'recommendation_not_promote',
   'low_confidence',
   'low_stability',
+  'auto_low_confidence',
+  'auto_low_stability',
+  'auto_disallowed_category',
+  'preference_auto_excluded',
   'temporary_candidate',
 ]);
 
@@ -467,6 +471,8 @@ const DURABLE_PROPOSAL_CATEGORIES = new Set([
   'preference',
   'environment',
 ]);
+
+const SAFE_AUTO_PROMOTE_CATEGORIES = new Set(['runbook', 'failure-mode', 'api-contract', 'environment', 'decision']);
 
 function compactBootstrapCandidate(result) {
   return {
@@ -634,6 +640,97 @@ function promotionProposal(indexedCandidate, warnings, rank) {
     warnings,
     recommendedAction: 'ask_user',
   };
+}
+
+function normalizeAllowedCategories(value, defaultCategories = SAFE_AUTO_PROMOTE_CATEGORIES) {
+  const raw = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value
+          .split(',')
+          .map((item) => item.trim())
+          .filter(Boolean)
+      : Array.from(defaultCategories);
+  return new Set(raw.filter((category) => category !== 'preference'));
+}
+
+function autoPromotionWarnings(store, scope, indexedCandidate, policy) {
+  const candidate = indexedCandidate.candidate || {};
+  const warnings = promotionCandidateWarnings(store, scope, indexedCandidate);
+  if (Number(candidate.confidence || 0) < policy.minConfidence) {
+    warnings.push({
+      code: 'auto_low_confidence',
+      message: `Candidate confidence must be at least ${policy.minConfidence}.`,
+      confidence: candidate.confidence ?? null,
+      minConfidence: policy.minConfidence,
+    });
+  }
+  if (Number(candidate.stability || 0) < policy.minStability) {
+    warnings.push({
+      code: 'auto_low_stability',
+      message: `Candidate stability must be at least ${policy.minStability}.`,
+      stability: candidate.stability ?? null,
+      minStability: policy.minStability,
+    });
+  }
+  if (!policy.allowedCategories.has(candidate.category)) {
+    warnings.push({
+      code: candidate.category === 'preference' ? 'preference_auto_excluded' : 'auto_disallowed_category',
+      message:
+        candidate.category === 'preference'
+          ? 'Preference candidates are excluded from auto-promotion until occurrence/merge tracking exists.'
+          : `Candidate category "${candidate.category}" is not allowed for auto-promotion.`,
+      category: candidate.category || null,
+    });
+  }
+  return warnings;
+}
+
+function autoPromotionWouldPromote(indexedCandidate, warnings, rank) {
+  const proposal = promotionProposal(indexedCandidate, warnings, rank);
+  return {
+    ...proposal,
+    recommendedAction: 'dry_run_only',
+    auditReason:
+      'Would auto-promote in a future enabled mode because this closeout-scoped pending candidate passed strict dry-run safety policy.',
+  };
+}
+
+function autoPromoteIndexedCandidate(store, scope, indexedCandidate, reason) {
+  const candidate = indexedCandidate.candidate || {};
+  const memory = store.rememberMemory({
+    ...scope,
+    key: candidate.key,
+    content: candidate.content,
+    category: candidate.category || 'note',
+    tags: candidate.tags || [],
+    importance: candidate.importance || 0,
+    eventType: 'promote',
+    eventMetadata: {
+      sourceCheckpointId: indexedCandidate.checkpointId,
+      sourceSessionId: indexedCandidate.sessionId,
+      sourceCandidateIndex: indexedCandidate.index,
+      sourceCandidateId: indexedCandidate.id,
+      candidateSourceEventIds: candidate.sourceEventIds || [],
+      promotionWarnings: [],
+      reason,
+      autoPromoted: true,
+    },
+  });
+  store.markMemoryCandidateReviewed({
+    ...scope,
+    candidateId: indexedCandidate.id,
+    status: 'promoted',
+    reason,
+    promotedMemoryId: memory.id,
+    metadata: {
+      memoryKey: memory.key,
+      memoryId: memory.id,
+      promotionWarnings: [],
+      autoPromoted: true,
+    },
+  });
+  return memory;
 }
 
 function summarizeBasisResult(result) {
@@ -1411,6 +1508,176 @@ export function createContextForge(options = {}) {
           nextActions: [
             'Ask the user to choose: promote, edit then promote, skip, or reject.',
             'Do not promote automatically.',
+          ],
+        };
+      });
+    },
+
+    async autoPromoteMemoryCandidates(options = {}) {
+      const scope = normalizeScopeOptions(options, config);
+      const trigger = options.trigger;
+      if (!CLOSEOUT_TRIGGERS.has(trigger)) {
+        throw new Error('trigger must be a closeout trigger.');
+      }
+      const dryRun = options.dryRun == null ? true : truthyOption(options.dryRun);
+      if (!dryRun && !config.autoPromote.enabled) {
+        throw new Error('Set CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true to use dryRun=false.');
+      }
+      const requestedLimit = positiveNumber(options.limit == null ? 2 : Number(options.limit), 'limit');
+      const limit = Math.min(2, requestedLimit);
+      const requestWarnings =
+        requestedLimit > 2
+          ? [
+              {
+                code: 'limit_capped',
+                message: 'auto_promote_memory_candidates handles at most 2 candidates per call.',
+                requestedLimit,
+                effectiveLimit: limit,
+              },
+            ]
+          : [];
+      const minConfidence = Number(options.minConfidence ?? 0.85);
+      const minStability = Number(options.minStability ?? 0.85);
+      if (!Number.isFinite(minConfidence) || minConfidence < 0 || minConfidence > 1) {
+        throw new Error('minConfidence must be between 0 and 1.');
+      }
+      if (!Number.isFinite(minStability) || minStability < 0 || minStability > 1) {
+        throw new Error('minStability must be between 0 and 1.');
+      }
+      const allowedCategories = normalizeAllowedCategories(options.allowedCategories);
+      const scanLimit = positiveNumber(options.scanLimit == null ? 10 : Number(options.scanLimit), 'scanLimit');
+      if (!options.sessionId && !options.checkpointId) {
+        return {
+          kind: 'auto_memory_promotion_dry_run',
+          trigger,
+          dryRun,
+          source: {
+            sessionId: null,
+            checkpointId: null,
+            mode: 'none',
+          },
+          policy: {
+            minConfidence,
+            minStability,
+            allowedCategories: Array.from(allowedCategories),
+            scopeFallback: false,
+            realPromotionEnabled: config.autoPromote.enabled,
+          },
+          wouldPromote: dryRun ? [] : undefined,
+          promoted: dryRun ? undefined : [],
+          skipped: [],
+          requestWarnings,
+          nextActions: [
+            'Provide sessionId or checkpointId; auto-promotion dry-run never scans the scope backlog.',
+            'No memory candidates were promoted.',
+          ],
+        };
+      }
+
+      return useStore((store) => {
+        let checkpointId = options.checkpointId || null;
+        let sourceMode = null;
+        if (checkpointId) {
+          sourceMode = 'checkpoint';
+        } else {
+          const latestCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId });
+          checkpointId = latestCheckpoint?.id || null;
+          sourceMode = 'latest_checkpoint';
+        }
+        if (options.sessionId && !checkpointId) {
+          return {
+            kind: 'auto_memory_promotion_dry_run',
+            trigger,
+            dryRun,
+            source: {
+              sessionId: options.sessionId,
+              checkpointId: null,
+              mode: sourceMode,
+            },
+            policy: {
+              minConfidence,
+              minStability,
+              allowedCategories: Array.from(allowedCategories),
+              scopeFallback: false,
+              realPromotionEnabled: config.autoPromote.enabled,
+            },
+            wouldPromote: dryRun ? [] : undefined,
+            promoted: dryRun ? undefined : [],
+            skipped: [],
+            requestWarnings,
+            nextActions: [
+              'No latest checkpoint was found for this session; distill a checkpoint before auto-promotion dry-run.',
+              'No memory candidates were promoted.',
+            ],
+          };
+        }
+
+        const policy = { minConfidence, minStability, allowedCategories };
+        const candidates = store.listMemoryCandidates({
+          ...scope,
+          sessionId: options.sessionId || null,
+          checkpointId,
+          status: 'pending',
+          promotionRecommendation: 'promote',
+          sort: 'recommendation',
+          limit: scanLimit,
+        });
+        const assessed = candidates.map((candidate) => {
+          const warnings = autoPromotionWarnings(store, scope, candidate, policy);
+          const score = scorePromotionCandidate(candidate, warnings);
+          return { candidate, warnings, score };
+        });
+        const selected = assessed
+          .filter((item) => item.score > 0)
+          .sort((a, b) => b.score - a.score)
+          .slice(0, limit);
+
+        return {
+          kind: 'auto_memory_promotion_dry_run',
+          trigger,
+          dryRun,
+          source: {
+            sessionId: options.sessionId || null,
+            checkpointId,
+            mode: sourceMode,
+          },
+          policy: {
+            minConfidence,
+            minStability,
+            allowedCategories: Array.from(allowedCategories),
+            scopeFallback: false,
+            realPromotionEnabled: config.autoPromote.enabled,
+          },
+          wouldPromote: dryRun
+            ? selected.map((item, index) => autoPromotionWouldPromote(item.candidate, item.warnings, index + 1))
+            : undefined,
+          promoted: dryRun
+            ? undefined
+            : selected.map((item, index) => {
+                const reason =
+                  'Auto-promoted by auto_promote_memory_candidates after strict closeout-scoped safety checks.';
+                const memory = autoPromoteIndexedCandidate(store, scope, item.candidate, reason);
+                return {
+                  rank: index + 1,
+                  candidateId: item.candidate.id,
+                  memoryId: memory.id,
+                  key: memory.key,
+                  category: memory.category,
+                  auditReason: reason,
+                };
+              }),
+          skipped: assessed
+            .filter((item) => item.score <= 0)
+            .map((item) => ({
+              candidateId: item.candidate.id,
+              reason: candidateWarningReason(item.warnings) || 'low_score',
+            })),
+          requestWarnings,
+          nextActions: [
+            dryRun
+              ? 'Inspect wouldPromote quality or set dryRun=false with CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true to promote.'
+              : 'Review promoted entries and audit metadata.',
+            dryRun ? 'No memory candidates were promoted.' : 'Do not auto-promote preference candidates until occurrence/merge tracking exists.',
           ],
         };
       });

--- a/src/core.js
+++ b/src/core.js
@@ -456,11 +456,15 @@ const AUTO_SKIP_WARNING_CODES = new Set([
   'recommendation_not_promote',
   'low_confidence',
   'low_stability',
+  'temporary_candidate',
+]);
+
+const AUTO_PROMOTE_SKIP_WARNING_CODES = new Set([
+  ...AUTO_SKIP_WARNING_CODES,
   'auto_low_confidence',
   'auto_low_stability',
   'auto_disallowed_category',
   'preference_auto_excluded',
-  'temporary_candidate',
 ]);
 
 const DURABLE_PROPOSAL_CATEGORIES = new Set([
@@ -604,8 +608,8 @@ function candidateWarningReason(warnings) {
   return warnings.map((warning) => warning.code).join(', ');
 }
 
-function scorePromotionCandidate(indexedCandidate, warnings) {
-  if (warnings.some((warning) => AUTO_SKIP_WARNING_CODES.has(warning.code))) {
+function scorePromotionCandidate(indexedCandidate, warnings, skipWarningCodes = AUTO_SKIP_WARNING_CODES) {
+  if (warnings.some((warning) => skipWarningCodes.has(warning.code))) {
     return 0;
   }
   const candidate = indexedCandidate.candidate || {};
@@ -651,12 +655,15 @@ function normalizeAllowedCategories(value, defaultCategories = SAFE_AUTO_PROMOTE
           .map((item) => item.trim())
           .filter(Boolean)
       : Array.from(defaultCategories);
-  return new Set(raw.filter((category) => category !== 'preference'));
+  return {
+    allowedCategories: new Set(raw.filter((category) => category !== 'preference')),
+    strippedPreference: raw.includes('preference'),
+  };
 }
 
 function autoPromotionWarnings(store, scope, indexedCandidate, policy) {
   const candidate = indexedCandidate.candidate || {};
-  const warnings = promotionCandidateWarnings(store, scope, indexedCandidate);
+  const warnings = [...promotionCandidateWarnings(store, scope, indexedCandidate)];
   if (Number(candidate.confidence || 0) < policy.minConfidence) {
     warnings.push({
       code: 'auto_low_confidence',
@@ -696,41 +703,43 @@ function autoPromotionWouldPromote(indexedCandidate, warnings, rank) {
   };
 }
 
-function autoPromoteIndexedCandidate(store, scope, indexedCandidate, reason) {
+function autoPromoteIndexedCandidate(store, scope, indexedCandidate, warnings, reason) {
   const candidate = indexedCandidate.candidate || {};
-  const memory = store.rememberMemory({
-    ...scope,
-    key: candidate.key,
-    content: candidate.content,
-    category: candidate.category || 'note',
-    tags: candidate.tags || [],
-    importance: candidate.importance || 0,
-    eventType: 'promote',
-    eventMetadata: {
-      sourceCheckpointId: indexedCandidate.checkpointId,
-      sourceSessionId: indexedCandidate.sessionId,
-      sourceCandidateIndex: indexedCandidate.index,
-      sourceCandidateId: indexedCandidate.id,
-      candidateSourceEventIds: candidate.sourceEventIds || [],
-      promotionWarnings: [],
+  return store.db.transaction(() => {
+    const memory = store.rememberMemory({
+      ...scope,
+      key: candidate.key,
+      content: candidate.content,
+      category: candidate.category || 'note',
+      tags: candidate.tags || [],
+      importance: candidate.importance ?? 0,
+      eventType: 'promote',
+      eventMetadata: {
+        sourceCheckpointId: indexedCandidate.checkpointId,
+        sourceSessionId: indexedCandidate.sessionId,
+        sourceCandidateIndex: indexedCandidate.index,
+        sourceCandidateId: indexedCandidate.id,
+        candidateSourceEventIds: candidate.sourceEventIds || [],
+        promotionWarnings: warnings,
+        reason,
+        autoPromoted: true,
+      },
+    });
+    store.markMemoryCandidateReviewed({
+      ...scope,
+      candidateId: indexedCandidate.id,
+      status: 'promoted',
       reason,
-      autoPromoted: true,
-    },
-  });
-  store.markMemoryCandidateReviewed({
-    ...scope,
-    candidateId: indexedCandidate.id,
-    status: 'promoted',
-    reason,
-    promotedMemoryId: memory.id,
-    metadata: {
-      memoryKey: memory.key,
-      memoryId: memory.id,
-      promotionWarnings: [],
-      autoPromoted: true,
-    },
-  });
-  return memory;
+      promotedMemoryId: memory.id,
+      metadata: {
+        memoryKey: memory.key,
+        memoryId: memory.id,
+        promotionWarnings: warnings,
+        autoPromoted: true,
+      },
+    });
+    return memory;
+  })();
 }
 
 function summarizeBasisResult(result) {
@@ -1544,7 +1553,14 @@ export function createContextForge(options = {}) {
       if (!Number.isFinite(minStability) || minStability < 0 || minStability > 1) {
         throw new Error('minStability must be between 0 and 1.');
       }
-      const allowedCategories = normalizeAllowedCategories(options.allowedCategories);
+      const categoryPolicy = normalizeAllowedCategories(options.allowedCategories);
+      const allowedCategories = categoryPolicy.allowedCategories;
+      if (categoryPolicy.strippedPreference) {
+        requestWarnings.push({
+          code: 'preference_input_stripped',
+          message: 'Preference candidates cannot be auto-promoted until occurrence/merge tracking exists.',
+        });
+      }
       const scanLimit = positiveNumber(options.scanLimit == null ? 10 : Number(options.scanLimit), 'scanLimit');
       if (!options.sessionId && !options.checkpointId) {
         return {
@@ -1563,8 +1579,8 @@ export function createContextForge(options = {}) {
             scopeFallback: false,
             realPromotionEnabled: config.autoPromote.enabled,
           },
-          wouldPromote: dryRun ? [] : undefined,
-          promoted: dryRun ? undefined : [],
+          wouldPromote: [],
+          promoted: [],
           skipped: [],
           requestWarnings,
           nextActions: [
@@ -1601,8 +1617,8 @@ export function createContextForge(options = {}) {
               scopeFallback: false,
               realPromotionEnabled: config.autoPromote.enabled,
             },
-            wouldPromote: dryRun ? [] : undefined,
-            promoted: dryRun ? undefined : [],
+            wouldPromote: [],
+            promoted: [],
             skipped: [],
             requestWarnings,
             nextActions: [
@@ -1624,7 +1640,7 @@ export function createContextForge(options = {}) {
         });
         const assessed = candidates.map((candidate) => {
           const warnings = autoPromotionWarnings(store, scope, candidate, policy);
-          const score = scorePromotionCandidate(candidate, warnings);
+          const score = scorePromotionCandidate(candidate, warnings, AUTO_PROMOTE_SKIP_WARNING_CODES);
           return { candidate, warnings, score };
         });
         const selected = assessed
@@ -1650,19 +1666,21 @@ export function createContextForge(options = {}) {
           },
           wouldPromote: dryRun
             ? selected.map((item, index) => autoPromotionWouldPromote(item.candidate, item.warnings, index + 1))
-            : undefined,
+            : [],
           promoted: dryRun
-            ? undefined
+            ? []
             : selected.map((item, index) => {
                 const reason =
                   'Auto-promoted by auto_promote_memory_candidates after strict closeout-scoped safety checks.';
-                const memory = autoPromoteIndexedCandidate(store, scope, item.candidate, reason);
+                const memory = autoPromoteIndexedCandidate(store, scope, item.candidate, item.warnings, reason);
                 return {
-                  rank: index + 1,
-                  candidateId: item.candidate.id,
+                  ...promotionProposal(item.candidate, item.warnings, index + 1),
                   memoryId: memory.id,
-                  key: memory.key,
-                  category: memory.category,
+                  promotionResult: {
+                    memoryId: memory.id,
+                    memoryKey: memory.key,
+                    status: 'promoted',
+                  },
                   auditReason: reason,
                 };
               }),

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -29,6 +29,7 @@ const MCP_INSTRUCTIONS = [
   'Search result types have different trust roles: memory is reviewed durable fact or decision; checkpoint is credible recent handoff state for continuity, planning, prior intent, recent decisions, and unfinished work, but mutable live-state claims must be verified with git/GitHub/CI/runtime/migrations before acting; memory_candidate is unreviewed promotion material and not durable truth.',
   'For start/resume requests such as "지난 환경 작업과 동기화", "어제 하던 거 이어서", "previous work", or "continue", call sync_resume_context. Use checkpoints actively as handoff notes, then verify mutable state with git/GitHub/CI/runtime/migrations. Do not propose memory promotions during resume sync.',
   'For closeout triggers only, call suggest_memory_promotions: after this agent merges a PR, after the user says they merged and the agent syncs main/cleans branches, or when the user explicitly says today\'s work is done. Suggest at most 1-3 durable memory promotions and never promote automatically.',
+  'For strict closeout-scoped safe automatic promotion, call auto_promote_memory_candidates only when the user wants automatic promotion. By default use dryRun=true. Use dryRun=false only when CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true is intentionally configured; never use scope-wide backlog fallback and never auto-promote preference candidates.',
   'For user corrections such as "너 잘못 알고 있잖아", "그거 아니야", "그건 X가 아니라 Y야", or "기억 수정해", call reconcile_memory. Show the basis for prior knowledge, assess conflicts, and only apply safe corrections when the user explicitly asks to fix memory.',
   'When resuming a known session, pass sessionId to bootstrap_context or call get_working_summary to load latest rolling handoff state separately from durable memory and checkpoint search results.',
   'If working on a repository while the MCP process cwd is elsewhere, pass repoPath or cwd so repo scope resolves to that checkout; repoPath takes precedence when both are provided.',
@@ -413,6 +414,38 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
       },
     },
     async (args) => jsonResult(await app.suggestMemoryPromotions(args)),
+  );
+
+  server.registerTool(
+    'auto_promote_memory_candidates',
+    {
+      title: 'Auto Promote Memory Candidates',
+      description:
+        'Dry-run or, when CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true and dryRun=false, automatically promote only strict closeout-scoped safe memory candidates. Requires sessionId or checkpointId and never scans the scope backlog.',
+      inputSchema: {
+        ...scopedSchema,
+        sessionId: z.string().optional(),
+        checkpointId: z.string().optional(),
+        trigger: z.enum([
+          'agent_merged_pr',
+          'user_merged_then_synced',
+          'user_declared_work_done',
+          'manual_closeout',
+        ]),
+        dryRun: z.boolean().optional(),
+        limit: z.number().int().positive().optional(),
+        scanLimit: z.number().int().positive().optional(),
+        minConfidence: z.number().optional(),
+        minStability: z.number().optional(),
+        allowedCategories: z.array(z.string()).optional(),
+      },
+      annotations: {
+        title: 'Auto Promote Memory Candidates',
+        readOnlyHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.autoPromoteMemoryCandidates(args)),
   );
 
   server.registerTool(

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -16,6 +16,7 @@ const REMOTE_METHODS = [
   'listMemoryEvents',
   'listMemoryCandidates',
   'suggestMemoryPromotions',
+  'autoPromoteMemoryCandidates',
   'reconcileMemory',
   'getMemory',
   'search',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -4294,7 +4294,7 @@ test('autoPromoteMemoryCandidates requires closeout scope and defaults to dry-ru
     role: 'assistant',
     content: 'Strict auto promotion candidate.',
   });
-  await app.distillCheckpoint({
+  const checkpoint = await app.distillCheckpoint({
     scope: 'repo',
     scopeKey: 'auto-repo',
     sessionId: 'auto-session',
@@ -4317,9 +4317,43 @@ test('autoPromoteMemoryCandidates requires closeout scope and defaults to dry-ru
   });
   assert.equal(dryRun.dryRun, true);
   assert.equal(dryRun.wouldPromote.length, 1);
+  assert.deepEqual(dryRun.promoted, []);
   assert.equal(dryRun.wouldPromote[0].key, 'auto-runbook');
   assert.ok(dryRun.requestWarnings.some((warning) => warning.code === 'limit_capped'));
   assert.equal(app.listMemoryCandidates({ scope: 'repo', scopeKey: 'auto-repo', status: 'promoted' }).length, 0);
+
+  const checkpointOnly = await app.autoPromoteMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'auto-repo',
+    checkpointId: checkpoint.id,
+    trigger: 'manual_closeout',
+  });
+  assert.equal(checkpointOnly.source.mode, 'checkpoint');
+  assert.equal(checkpointOnly.wouldPromote.length, 1);
+
+  await assert.rejects(
+    () =>
+      app.autoPromoteMemoryCandidates({
+        scope: 'repo',
+        scopeKey: 'auto-repo',
+        sessionId: 'auto-session',
+        trigger: 'manual_closeout',
+        minConfidence: 1.5,
+      }),
+    /minConfidence/,
+  );
+
+  await assert.rejects(
+    () =>
+      app.autoPromoteMemoryCandidates({
+        scope: 'repo',
+        scopeKey: 'auto-repo',
+        sessionId: 'auto-session',
+        trigger: 'manual_closeout',
+        minStability: -1,
+      }),
+    /minStability/,
+  );
 
   await assert.rejects(
     () =>
@@ -4332,6 +4366,52 @@ test('autoPromoteMemoryCandidates requires closeout scope and defaults to dry-ru
       }),
     /CONTEXTFORGE_AUTO_PROMOTE_ENABLED/,
   );
+});
+
+test('autoPromoteMemoryCandidates returns stable empty arrays and preference input warnings', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'auto_empty_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      auto_empty_provider: async () => ({
+        summaryShort: 'No candidates.',
+        summaryText: 'Closeout produced no memory candidates.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'auto-empty-repo',
+    sessionId: 'auto-empty-session',
+    role: 'assistant',
+    content: 'No candidates here.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'auto-empty-repo',
+    sessionId: 'auto-empty-session',
+  });
+
+  const result = await app.autoPromoteMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'auto-empty-repo',
+    sessionId: 'auto-empty-session',
+    trigger: 'manual_closeout',
+    allowedCategories: ['preference'],
+  });
+
+  assert.deepEqual(result.wouldPromote, []);
+  assert.deepEqual(result.promoted, []);
+  assert.deepEqual(result.policy.allowedCategories, []);
+  assert.ok(result.requestWarnings.some((warning) => warning.code === 'preference_input_stripped'));
 });
 
 test('autoPromoteMemoryCandidates promotes only strict safe candidates when enabled', async () => {
@@ -4407,10 +4487,13 @@ test('autoPromoteMemoryCandidates promotes only strict safe candidates when enab
   });
 
   assert.equal(result.dryRun, false);
+  assert.deepEqual(result.wouldPromote, []);
   assert.deepEqual(
     result.promoted.map((item) => item.key),
     ['safe-api-contract'],
   );
+  assert.ok(result.promoted[0].evidence);
+  assert.equal(result.promoted[0].promotionResult.status, 'promoted');
   assert.ok(result.skipped.some((item) => item.reason.includes('preference_auto_excluded')));
   assert.ok(result.skipped.some((item) => item.reason.includes('auto_low_confidence')));
   assert.equal(app.getMemory({ scope: 'repo', scopeKey: 'auto-enabled-repo', key: 'safe-api-contract' }).status, 'active');

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -4257,6 +4257,167 @@ test('suggestMemoryPromotions uses only latest checkpoint for a session and skip
   assert.ok(result.skipped.some((item) => item.reason.includes('high_sensitivity')));
 });
 
+test('autoPromoteMemoryCandidates requires closeout scope and defaults to dry-run', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'auto_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      auto_provider: async () => ({
+        summaryShort: 'Auto promote checkpoint.',
+        summaryText: 'Closeout produced strict automatic promotion candidates.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'auto-runbook',
+            content: 'Closeout automation can promote strict runbook candidates.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.95,
+            stability: 0.95,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'auto-repo',
+    sessionId: 'auto-session',
+    role: 'assistant',
+    content: 'Strict auto promotion candidate.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'auto-repo',
+    sessionId: 'auto-session',
+  });
+
+  const noSource = await app.autoPromoteMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'auto-repo',
+    trigger: 'manual_closeout',
+  });
+  assert.deepEqual(noSource.wouldPromote, []);
+  assert.equal(noSource.source.mode, 'none');
+
+  const dryRun = await app.autoPromoteMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'auto-repo',
+    sessionId: 'auto-session',
+    trigger: 'user_declared_work_done',
+    limit: 5,
+  });
+  assert.equal(dryRun.dryRun, true);
+  assert.equal(dryRun.wouldPromote.length, 1);
+  assert.equal(dryRun.wouldPromote[0].key, 'auto-runbook');
+  assert.ok(dryRun.requestWarnings.some((warning) => warning.code === 'limit_capped'));
+  assert.equal(app.listMemoryCandidates({ scope: 'repo', scopeKey: 'auto-repo', status: 'promoted' }).length, 0);
+
+  await assert.rejects(
+    () =>
+      app.autoPromoteMemoryCandidates({
+        scope: 'repo',
+        scopeKey: 'auto-repo',
+        sessionId: 'auto-session',
+        trigger: 'manual_closeout',
+        dryRun: false,
+      }),
+    /CONTEXTFORGE_AUTO_PROMOTE_ENABLED/,
+  );
+});
+
+test('autoPromoteMemoryCandidates promotes only strict safe candidates when enabled', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'auto_enabled_provider',
+      CONTEXTFORGE_AUTO_PROMOTE_ENABLED: 'true',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      auto_enabled_provider: async () => ({
+        summaryShort: 'Auto enabled checkpoint.',
+        summaryText: 'Closeout produced mixed automatic promotion candidates.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'safe-api-contract',
+            content: 'The API contract requires idempotent delete retries.',
+            category: 'api-contract',
+            candidateType: 'api-contract',
+            confidence: 0.96,
+            stability: 0.96,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+          {
+            key: 'user-pref',
+            content: 'The user prefers a particular closing phrase.',
+            category: 'preference',
+            candidateType: 'preference',
+            confidence: 0.99,
+            stability: 0.99,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+          {
+            key: 'low-confidence-runbook',
+            content: 'This runbook is not stable enough.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.7,
+            stability: 0.96,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'auto-enabled-repo',
+    sessionId: 'auto-enabled-session',
+    role: 'assistant',
+    content: 'Mixed auto promotion candidates.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'auto-enabled-repo',
+    sessionId: 'auto-enabled-session',
+  });
+
+  const result = await app.autoPromoteMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'auto-enabled-repo',
+    sessionId: 'auto-enabled-session',
+    trigger: 'agent_merged_pr',
+    dryRun: false,
+  });
+
+  assert.equal(result.dryRun, false);
+  assert.deepEqual(
+    result.promoted.map((item) => item.key),
+    ['safe-api-contract'],
+  );
+  assert.ok(result.skipped.some((item) => item.reason.includes('preference_auto_excluded')));
+  assert.ok(result.skipped.some((item) => item.reason.includes('auto_low_confidence')));
+  assert.equal(app.getMemory({ scope: 'repo', scopeKey: 'auto-enabled-repo', key: 'safe-api-contract' }).status, 'active');
+  assert.equal(app.getMemory({ scope: 'repo', scopeKey: 'auto-enabled-repo', key: 'user-pref' }), null);
+  assert.equal(app.listMemoryCandidates({ scope: 'repo', scopeKey: 'auto-enabled-repo', status: 'promoted' }).length, 1);
+});
+
 test('reconcileMemory proposes by default and apply_safe only changes unambiguous non-live memory', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({
@@ -4415,9 +4576,10 @@ test('reconcileMemory apply_safe rejects matching candidates when no durable mem
   assert.equal(candidates.length, 1);
 });
 
-test('REMOTE_METHODS exposes resume, suggestion, and reconciliation wrappers', () => {
+test('REMOTE_METHODS exposes resume, suggestion, auto-promotion, and reconciliation wrappers', () => {
   assert.ok(REMOTE_METHODS.includes('syncResumeContext'));
   assert.ok(REMOTE_METHODS.includes('suggestMemoryPromotions'));
+  assert.ok(REMOTE_METHODS.includes('autoPromoteMemoryCandidates'));
   assert.ok(REMOTE_METHODS.includes('reconcileMemory'));
 });
 
@@ -4568,6 +4730,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     const toolNames = toolList.tools.map((tool) => tool.name).sort();
     assert.deepEqual(toolNames, [
       'append_raw',
+      'auto_promote_memory_candidates',
       'begin_session',
       'bootstrap_context',
       'correct_memory',
@@ -4610,6 +4773,10 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     const suggestTool = toolList.tools.find((tool) => tool.name === 'suggest_memory_promotions');
     assert.ok(suggestTool.inputSchema.properties.allowScopeFallback);
     assert.ok(suggestTool.inputSchema.properties.trigger);
+    const autoPromoteTool = toolList.tools.find((tool) => tool.name === 'auto_promote_memory_candidates');
+    assert.ok(autoPromoteTool.inputSchema.properties.dryRun);
+    assert.ok(autoPromoteTool.inputSchema.properties.minConfidence);
+    assert.ok(autoPromoteTool.inputSchema.properties.allowedCategories);
     const reconcileTool = toolList.tools.find((tool) => tool.name === 'reconcile_memory');
     assert.ok(reconcileTool.inputSchema.properties.correction);
     assert.ok(reconcileTool.inputSchema.properties.mode);


### PR DESCRIPTION
## Summary

- add `auto_promote_memory_candidates` / `autoPromoteMemoryCandidates` for closeout-scoped candidate auto-promotion
- keep default behavior as `dryRun=true`, but allow real promotion with `dryRun=false` only when `CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true`
- enforce strict gates: session/checkpoint required, no scope fallback, pending promote candidates only, high confidence/stability, allowed categories only, no preference auto-promotion, no duplicate/risky candidates
- expose the tool through MCP, CLI, and remote storage mode, and document the policy

## Validation

- `npm test` — 92 pass / 0 fail
- `git diff --check`
- `node src/cli.js dbInfo`

Closes #84.
Closes #83.