### PR TITLE
[codex] Add store transaction helper

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -705,7 +705,7 @@ function autoPromotionWouldPromote(indexedCandidate, warnings, rank) {
 
 function autoPromoteIndexedCandidate(store, scope, indexedCandidate, warnings, reason) {
   const candidate = indexedCandidate.candidate || {};
-  return store.transaction(() => {
+  return store.withTransaction(() => {
     const memory = store.rememberMemory({
       ...scope,
       key: candidate.key,

--- a/src/core.js
+++ b/src/core.js
@@ -705,7 +705,7 @@ function autoPromotionWouldPromote(indexedCandidate, warnings, rank) {
 
 function autoPromoteIndexedCandidate(store, scope, indexedCandidate, warnings, reason) {
   const candidate = indexedCandidate.candidate || {};
-  return store.db.transaction(() => {
+  return store.transaction(() => {
     const memory = store.rememberMemory({
       ...scope,
       key: candidate.key,
@@ -739,7 +739,7 @@ function autoPromoteIndexedCandidate(store, scope, indexedCandidate, warnings, r
       },
     });
     return memory;
-  })();
+  });
 }
 
 function summarizeBasisResult(result) {

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -242,7 +242,8 @@ export class ContextForgeStore {
     this.db.close();
   }
 
-  transaction(fn) {
+  // Runs fn inside an implicit transaction; rolls back on throw; returns fn's return value.
+  withTransaction(fn) {
     return this.db.transaction(fn)();
   }
 

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -242,6 +242,10 @@ export class ContextForgeStore {
     this.db.close();
   }
 
+  transaction(fn) {
+    return this.db.transaction(fn)();
+  }
+
   ensureColumn(table, column, definition) {
     const columns = this.db.prepare(`PRAGMA table_info(${table})`).all();
     if (!columns.some((item) => item.name === column)) {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -195,6 +195,44 @@ test('dbInfo initializes a fresh SQLite store', async () => {
   assert.match(info.dbPath, /contextforge\.db$/);
 });
 
+test('ContextForgeStore.withTransaction returns results and rolls back on throw', async () => {
+  const dataDir = await makeTempDir();
+  const store = new ContextForgeStore({ dataDir });
+  try {
+    const memory = store.withTransaction(() =>
+      store.rememberMemory({
+        scopeType: 'repo',
+        scopeKey: 'tx-repo',
+        key: 'tx-memory',
+        content: 'Transaction return value survives.',
+      }),
+    );
+
+    assert.equal(memory.key, 'tx-memory');
+    assert.equal(
+      store.getMemory({ scopeType: 'repo', scopeKey: 'tx-repo', key: 'tx-memory' }).content,
+      'Transaction return value survives.',
+    );
+
+    assert.throws(
+      () =>
+        store.withTransaction(() => {
+          store.rememberMemory({
+            scopeType: 'repo',
+            scopeKey: 'tx-repo',
+            key: 'rolled-back-memory',
+            content: 'This should roll back.',
+          });
+          throw new Error('rollback please');
+        }),
+      /rollback please/,
+    );
+    assert.equal(store.getMemory({ scopeType: 'repo', scopeKey: 'tx-repo', key: 'rolled-back-memory' }), null);
+  } finally {
+    store.close();
+  }
+});
+
 test('repo scope key defaults to normalized GitHub origin remote', async () => {
   const cwd = await makeGitRepo();
   const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: path.join(cwd, 'data') }, cwd });


### PR DESCRIPTION
## Summary

- add `ContextForgeStore.withTransaction(fn)` as the public store-level transaction helper
- update auto-promotion to call `store.withTransaction(...)` instead of reaching into `store.db.transaction(...)`
- document and directly test pass-through return values plus rollback-on-throw behavior

## Validation

- `npm test` — 93 pass / 0 fail
- `git diff --check`

Closes #87.