### PR TITLE
[codex] Rename auto-promotion response kind

### DIFF
--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -391,6 +391,12 @@ fallback, and category limited to `runbook`, `failure-mode`, `api-contract`,
 `environment`, or `decision`. Do not auto-promote `preference` candidates until
 occurrence/merge tracking exists.
 
+`auto_promote_memory_candidates` returns
+`kind: "auto_memory_promotion_result"` for both dry-run and real-promotion
+modes. Older experimental builds returned
+`kind: "auto_memory_promotion_dry_run"`; callers should use the `dryRun`
+boolean to distinguish behavior.
+
 Candidate records may include review signals such as `candidateType`,
 `confidence`, `stability`, `sensitivity`, `promotionRecommendation`, and
 `sourceEventIds`. Use those fields to prioritize review. Treat `ignore`,

--- a/src/core.js
+++ b/src/core.js
@@ -1564,7 +1564,7 @@ export function createContextForge(options = {}) {
       const scanLimit = positiveNumber(options.scanLimit == null ? 10 : Number(options.scanLimit), 'scanLimit');
       if (!options.sessionId && !options.checkpointId) {
         return {
-          kind: 'auto_memory_promotion_dry_run',
+          kind: 'auto_memory_promotion_result',
           trigger,
           dryRun,
           source: {
@@ -1602,7 +1602,7 @@ export function createContextForge(options = {}) {
         }
         if (options.sessionId && !checkpointId) {
           return {
-            kind: 'auto_memory_promotion_dry_run',
+            kind: 'auto_memory_promotion_result',
             trigger,
             dryRun,
             source: {
@@ -1649,7 +1649,7 @@ export function createContextForge(options = {}) {
           .slice(0, limit);
 
         return {
-          kind: 'auto_memory_promotion_dry_run',
+          kind: 'auto_memory_promotion_result',
           trigger,
           dryRun,
           source: {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -4343,6 +4343,7 @@ test('autoPromoteMemoryCandidates requires closeout scope and defaults to dry-ru
     scopeKey: 'auto-repo',
     trigger: 'manual_closeout',
   });
+  assert.equal(noSource.kind, 'auto_memory_promotion_result');
   assert.deepEqual(noSource.wouldPromote, []);
   assert.equal(noSource.source.mode, 'none');
 
@@ -4353,6 +4354,7 @@ test('autoPromoteMemoryCandidates requires closeout scope and defaults to dry-ru
     trigger: 'user_declared_work_done',
     limit: 5,
   });
+  assert.equal(dryRun.kind, 'auto_memory_promotion_result');
   assert.equal(dryRun.dryRun, true);
   assert.equal(dryRun.wouldPromote.length, 1);
   assert.deepEqual(dryRun.promoted, []);
@@ -4445,6 +4447,7 @@ test('autoPromoteMemoryCandidates returns stable empty arrays and preference inp
     trigger: 'manual_closeout',
     allowedCategories: ['preference'],
   });
+  assert.equal(result.kind, 'auto_memory_promotion_result');
 
   assert.deepEqual(result.wouldPromote, []);
   assert.deepEqual(result.promoted, []);
@@ -4524,6 +4527,7 @@ test('autoPromoteMemoryCandidates promotes only strict safe candidates when enab
     dryRun: false,
   });
 
+  assert.equal(result.kind, 'auto_memory_promotion_result');
   assert.equal(result.dryRun, false);
   assert.deepEqual(result.wouldPromote, []);
   assert.deepEqual(


### PR DESCRIPTION
## Summary

- rename `autoPromoteMemoryCandidates` response `kind` to mode-neutral `auto_memory_promotion_result`
- keep behavior distinction on the existing `dryRun` boolean
- document the experimental old `auto_memory_promotion_dry_run` kind for compatibility context

## Validation

- `npm test` — 93 pass / 0 fail
- `git diff --check`

Closes #88.