### PR TITLE
[codex] Add session working context handoff

### DIFF
--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -192,8 +192,9 @@ trust levels.
 5. If resuming a known session, call `session_status` for that `sessionId` to
    inspect recent checkpoint state.
 6. If the task needs live handoff state, pass `sessionId` to
-   `bootstrap_context` or call `get_working_summary`. Treat the returned
-   working summary as current session state, not durable truth.
+   `bootstrap_context` or call `get_working_summary` and
+   `get_session_working_context`. Treat returned working state as current
+   session state, not durable truth.
 7. If the task depends on recent handoff state, call `sync_resume_context` when
    available. Treat checkpoints as credible recent handoff state and memory
    candidates as review material only. Do not propose promotions during resume
@@ -471,7 +472,8 @@ Prefer distilling at meaningful boundaries:
   repo memory/checkpoints/candidates semantically, optionally includes up to
   three shared-scope results, and annotates trust plus verification hints.
 - `sync_resume_context`: build a start/resume handoff package. Checkpoints are
-  credible recent handoff state; candidates are review material only.
+  credible recent handoff state; structured working context is mutable session
+  state; candidates are review material only.
 - `search`: retrieve scoped results. Results can include reviewed durable
   `memory`, recent-continuity `checkpoint`, and unreviewed
   `memory_candidate` records.
@@ -484,6 +486,11 @@ Prefer distilling at meaningful boundaries:
   distillation and debugging. Tool output is evidence, not conversation memory;
   keep tool-call/tool-result payloads in the native agent transcript or an
   explicit artifact, and distill the assistant-interpreted verification facts.
+- `get_working_summary`: fetch the rolling summary for one session.
+- `get_session_working_context`: fetch structured mutable task state for one
+  session.
+- `upsert_session_working_context`: create or update structured mutable task
+  state for a session. This is not durable memory.
 - `session_status`: inspect raw/checkpoint thresholds before distilling.
 - `distill_checkpoint`: create a recent-continuity checkpoint.
 - `distill_usage`: summarize distillation run counts, selected input size,

--- a/src/cli.js
+++ b/src/cli.js
@@ -129,6 +129,26 @@ function toCoreOptions(options) {
     iterations: options.iterations == null ? undefined : Number(options.iterations),
     charsPerToken: options.charsPerToken == null ? undefined : Number(options.charsPerToken),
     rawTailLimit: options.rawTailLimit == null ? undefined : Number(options.rawTailLimit),
+    mode: options.mode,
+    currentTask: options.currentTask,
+    currentUserIntent: options.currentUserIntent,
+    targetSubject: options.targetSubject,
+    sourceSubject: options.sourceSubject,
+    lastUserCorrection: options.lastUserCorrection,
+    openQuestion: options.openQuestion,
+    nonGoals: options.nonGoals
+      ? String(options.nonGoals)
+          .split(',')
+          .map((item) => item.trim())
+          .filter(Boolean)
+      : undefined,
+    avoidMisreadings: options.avoidMisreadings
+      ? String(options.avoidMisreadings)
+          .split(',')
+          .map((item) => item.trim())
+          .filter(Boolean)
+      : undefined,
+    confidence: options.confidence == null ? undefined : Number(options.confidence),
     batchSize: options.batchSize == null ? undefined : Number(options.batchSize),
     force: options.force === true || options.force === 'true',
   };
@@ -161,6 +181,8 @@ async function main() {
     appendRaw: (app, coreOptions) => app.appendRaw(coreOptions),
     listRawEvents: (app, coreOptions) => app.listRawEvents(coreOptions),
     getWorkingSummary: (app, coreOptions) => app.getWorkingSummary(coreOptions),
+    getSessionWorkingContext: (app, coreOptions) => app.getSessionWorkingContext(coreOptions),
+    upsertSessionWorkingContext: (app, coreOptions) => app.upsertSessionWorkingContext(coreOptions),
     pruneRawEvents: (app, coreOptions) => app.pruneRawEvents(coreOptions),
     distillCheckpoint: (app, coreOptions) => app.distillCheckpoint(coreOptions),
     listDistillRuns: (app, coreOptions) => app.listDistillRuns(coreOptions),

--- a/src/core.js
+++ b/src/core.js
@@ -300,6 +300,35 @@ function bootstrapWorkingSummary(summary) {
   };
 }
 
+function bootstrapSessionWorkingContext(context) {
+  if (!context) {
+    return null;
+  }
+  return {
+    type: 'session_working_context',
+    id: context.id,
+    sessionId: context.sessionId,
+    conversationId: context.conversationId,
+    mode: context.mode,
+    currentTask: context.currentTask,
+    currentUserIntent: context.currentUserIntent,
+    targetSubject: context.targetSubject,
+    sourceSubject: context.sourceSubject,
+    lastUserCorrection: context.lastUserCorrection,
+    openQuestion: context.openQuestion,
+    nonGoals: context.nonGoals,
+    avoidMisreadings: context.avoidMisreadings,
+    confidence: context.confidence,
+    sourceCheckpointId: context.sourceCheckpointId,
+    distillRunId: context.distillRunId,
+    updatedAt: context.updatedAt,
+    trust: 'mutable_session_state',
+    verificationRequired: true,
+    whyUse:
+      'Structured live session state for resume handoff; useful for current task framing, but not reviewed durable memory.',
+  };
+}
+
 function bootstrapRawTailEvent(event) {
   return {
     id: event.id,
@@ -1170,6 +1199,9 @@ export function createContextForge(options = {}) {
         const workingSummary = sessionId
           ? bootstrapWorkingSummary(store.getWorkingSummary({ ...scope, sessionId }))
           : null;
+        const structuredWorkingContext = sessionId
+          ? bootstrapSessionWorkingContext(store.getSessionWorkingContext({ ...scope, sessionId }))
+          : null;
         const rawTail = sessionId
           ? store
               .listRecentRawEvents({ ...scope, sessionId, limit: rawTailLimit })
@@ -1181,7 +1213,7 @@ export function createContextForge(options = {}) {
           query: options.query,
           includeShared,
           sharedLimit: includeShared ? sharedLimit : null,
-          ...(sessionId ? { sessionId, workingSummary, rawTail, rawTailLimit } : {}),
+          ...(sessionId ? { sessionId, workingSummary, structuredWorkingContext, rawTail, rawTailLimit } : {}),
           ...(sharedSkippedReason ? { sharedSkippedReason } : {}),
           summary: bootstrapSummary(results),
           results,
@@ -1240,6 +1272,7 @@ export function createContextForge(options = {}) {
         ...(bootstrap.sessionId ? { sessionId: bootstrap.sessionId } : {}),
         handoff: {
           workingSummary: bootstrap.workingSummary || null,
+          structuredWorkingContext: bootstrap.structuredWorkingContext || null,
           rawTail: bootstrap.rawTail || [],
           durableMemories,
           recentCheckpoints,
@@ -2142,6 +2175,42 @@ export function createContextForge(options = {}) {
       return useStore((store) => store.getWorkingSummary({ ...scope, sessionId: options.sessionId }));
     },
 
+    getSessionWorkingContext(options) {
+      const scope = normalizeScopeOptions(options, config);
+      requireOption(options.sessionId, 'sessionId');
+      return useStore((store) => store.getSessionWorkingContext({ ...scope, sessionId: options.sessionId }));
+    },
+
+    upsertSessionWorkingContext(options) {
+      const scope = normalizeScopeOptions(options, config);
+      requireOption(options.sessionId, 'sessionId');
+      return useStore((store) =>
+        store.upsertSessionWorkingContext({
+          ...scope,
+          sessionId: options.sessionId,
+          conversationId: options.conversationId || null,
+          mode: options.mode || 'task_execution',
+          currentTask: options.currentTask || options.current_task || '',
+          currentUserIntent: options.currentUserIntent || options.current_user_intent || '',
+          targetSubject: options.targetSubject ?? options.target_subject ?? null,
+          sourceSubject: options.sourceSubject ?? options.source_subject ?? null,
+          lastUserCorrection: options.lastUserCorrection ?? options.last_user_correction ?? null,
+          openQuestion: options.openQuestion ?? options.open_question ?? null,
+          nonGoals: options.nonGoals || options.non_goals || options.nonGoalsJson || options.non_goals_json || [],
+          avoidMisreadings:
+            options.avoidMisreadings ||
+            options.avoid_misreadings ||
+            options.avoidMisreadingsJson ||
+            options.avoid_misreadings_json ||
+            [],
+          confidence: options.confidence ?? 0,
+          sourceCheckpointId: options.sourceCheckpointId || options.source_checkpoint_id || null,
+          distillRunId: options.distillRunId || options.distill_run_id || null,
+          metadata: options.metadata || {},
+        }),
+      );
+    },
+
     async distillCheckpoint(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.sessionId, 'sessionId');
@@ -2154,6 +2223,7 @@ export function createContextForge(options = {}) {
         const rawEvents = store.listRawEvents({ ...scope, sessionId: options.sessionId });
         const previousCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId });
         const previousWorkingSummary = store.getWorkingSummary({ ...scope, sessionId: options.sessionId });
+        const previousSessionWorkingContext = store.getSessionWorkingContext({ ...scope, sessionId: options.sessionId });
         const policy = {
           maxEvents: positiveNumber(
             options.maxEvents == null ? config.distillPolicy.maxEvents : Number(options.maxEvents),
@@ -2176,6 +2246,7 @@ export function createContextForge(options = {}) {
           todos: 'string[]',
           openQuestions: 'string[]',
           workingSummary: 'string',
+          sessionWorkingContext: 'object?',
           memoryCandidates: 'object[]',
           sourceEventCount: 'number',
           provider: 'string',
@@ -2191,6 +2262,7 @@ export function createContextForge(options = {}) {
             rawEventIds: selectedRawEvents.map((event) => event.id),
             previousCheckpointId: previousCheckpoint?.id || null,
             previousWorkingSummaryId: previousWorkingSummary?.id || null,
+            previousSessionWorkingContextId: previousSessionWorkingContext?.id || null,
             requestedOutputSchema,
             providerMetadata,
             sourceProvenance,
@@ -2209,6 +2281,7 @@ export function createContextForge(options = {}) {
             rawEvents: selectedRawEvents,
             previousCheckpoint,
             previousWorkingSummary,
+            previousSessionWorkingContext,
             requestedOutputSchema,
           });
         } catch (error) {
@@ -2293,6 +2366,41 @@ export function createContextForge(options = {}) {
           workingSummaryError = error;
         }
 
+        let sessionWorkingContext = null;
+        let sessionWorkingContextError = null;
+        if (output.sessionWorkingContext) {
+          try {
+            const context = output.sessionWorkingContext;
+            sessionWorkingContext = store.upsertSessionWorkingContext({
+              ...scope,
+              sessionId: options.sessionId,
+              conversationId,
+              mode: context.mode || 'task_execution',
+              currentTask: context.currentTask || context.current_task || '',
+              currentUserIntent: context.currentUserIntent || context.current_user_intent || '',
+              targetSubject: context.targetSubject ?? context.target_subject ?? null,
+              sourceSubject: context.sourceSubject ?? context.source_subject ?? null,
+              lastUserCorrection: context.lastUserCorrection ?? context.last_user_correction ?? null,
+              openQuestion: context.openQuestion ?? context.open_question ?? null,
+              nonGoals: context.nonGoals || context.non_goals || [],
+              avoidMisreadings: context.avoidMisreadings || context.avoid_misreadings || [],
+              confidence: context.confidence ?? 0,
+              sourceCheckpointId: checkpoint?.id || null,
+              distillRunId: distillRun.id,
+              metadata: {
+                providerMetadata: output.metadata,
+                sourceProvenance,
+                sourceRawEventIds: selectedRawEvents.map((event) => event.id),
+                sourceEventWindow: distillWindow.metadata,
+                checkpointId: checkpoint?.id || null,
+                checkpointInsertFailed: Boolean(checkpointError),
+              },
+            });
+          } catch (error) {
+            sessionWorkingContextError = error;
+          }
+        }
+
         if (checkpointError) {
           store.failDistillRun({
             id: distillRun.id,
@@ -2303,6 +2411,9 @@ export function createContextForge(options = {}) {
               workingSummaryUpdated: Boolean(workingSummary),
               workingSummaryId: workingSummary?.id || null,
               workingSummaryError: errorSummary(workingSummaryError),
+              sessionWorkingContextUpdated: Boolean(sessionWorkingContext),
+              sessionWorkingContextId: sessionWorkingContext?.id || null,
+              sessionWorkingContextError: errorSummary(sessionWorkingContextError),
               providerMetadata: output.metadata,
             },
           });
@@ -2318,6 +2429,9 @@ export function createContextForge(options = {}) {
             workingSummaryUpdated: Boolean(workingSummary),
             workingSummaryId: workingSummary?.id || null,
             workingSummaryError: errorSummary(workingSummaryError),
+            sessionWorkingContextUpdated: Boolean(sessionWorkingContext),
+            sessionWorkingContextId: sessionWorkingContext?.id || null,
+            sessionWorkingContextError: errorSummary(sessionWorkingContextError),
             providerMetadata: output.metadata,
           },
         });
@@ -2355,6 +2469,11 @@ export function createContextForge(options = {}) {
             updated: Boolean(workingSummary),
             id: workingSummary?.id || null,
             error: errorSummary(workingSummaryError),
+          },
+          sessionWorkingContext: {
+            updated: Boolean(sessionWorkingContext),
+            id: sessionWorkingContext?.id || null,
+            error: errorSummary(sessionWorkingContextError),
           },
           embedding,
         };

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -3,8 +3,8 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v5';
-export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v4';
+export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v6';
+export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v5';
 
 const OUTPUT_SCHEMA = {
   $id: CODEX_EXEC_OUTPUT_SCHEMA_VERSION,
@@ -26,6 +26,22 @@ const OUTPUT_SCHEMA = {
     summaryShort: { type: 'string', minLength: 1 },
     summaryText: { type: 'string', minLength: 1 },
     workingSummary: { type: 'string', minLength: 1 },
+    sessionWorkingContext: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        mode: { type: 'string' },
+        currentTask: { type: 'string' },
+        currentUserIntent: { type: 'string' },
+        targetSubject: { type: ['string', 'null'] },
+        sourceSubject: { type: ['string', 'null'] },
+        lastUserCorrection: { type: ['string', 'null'] },
+        openQuestion: { type: ['string', 'null'] },
+        nonGoals: { type: 'array', items: { type: 'string' } },
+        avoidMisreadings: { type: 'array', items: { type: 'string' } },
+        confidence: { type: 'number', minimum: 0, maximum: 1 },
+      },
+    },
     decisions: { type: 'array', items: { type: 'string' } },
     todos: { type: 'array', items: { type: 'string' } },
     openQuestions: { type: 'array', items: { type: 'string' } },
@@ -133,6 +149,25 @@ function compactWorkingSummary(summary) {
   };
 }
 
+function compactSessionWorkingContext(context) {
+  if (!context) return null;
+  return {
+    id: context.id,
+    mode: context.mode,
+    currentTask: context.currentTask,
+    currentUserIntent: context.currentUserIntent,
+    targetSubject: context.targetSubject,
+    sourceSubject: context.sourceSubject,
+    lastUserCorrection: context.lastUserCorrection,
+    openQuestion: context.openQuestion,
+    nonGoals: context.nonGoals,
+    avoidMisreadings: context.avoidMisreadings,
+    confidence: context.confidence,
+    sourceCheckpointId: context.sourceCheckpointId,
+    updatedAt: context.updatedAt,
+  };
+}
+
 function buildRawEventPayload(rawEvents, maxInputChars) {
   const events = [];
   let remaining = maxInputChars;
@@ -177,7 +212,9 @@ export function buildCodexExecPrompt(input, options = {}) {
       'Write the checkpoint as recent continuity for handoff and search, not as canonical durable truth.',
       'Write workingSummary as the latest rolling session state for immediate continuation: current goal, completed work, active blockers, and next actions.',
       'If previousWorkingSummary is supplied, update it with the new raw events instead of replacing it with a delta-only summary.',
+      'If useful, write sessionWorkingContext as structured mutable resume state: currentTask, currentUserIntent, targetSubject, sourceSubject, lastUserCorrection, openQuestion, nonGoals, avoidMisreadings, and confidence.',
       'Do not make workingSummary a durable fact; it is live handoff state and may be overwritten by later distills.',
+      'Do not make sessionWorkingContext a durable fact; it is mutable task framing for resume handoff.',
       'Optimize the checkpoint for future retrieval, not for a generic meeting-summary style. Preserve concrete hooks a future agent might search for.',
       'Preserve proper nouns, API names, command names, file paths, issue or PR numbers, model names, error strings, numeric thresholds, time intervals, and cadence details when they matter.',
       'Distinguish decision, rationale, risks, conditions, and next action. Do not say only that a topic was discussed.',
@@ -199,6 +236,7 @@ export function buildCodexExecPrompt(input, options = {}) {
     requestedOutputSchema: input.requestedOutputSchema,
     previousCheckpoint: compactCheckpoint(input.previousCheckpoint),
     previousWorkingSummary: compactWorkingSummary(input.previousWorkingSummary),
+    previousSessionWorkingContext: compactSessionWorkingContext(input.previousSessionWorkingContext),
     rawEvents: rawPayload.events,
   };
 

--- a/src/distill/validate.js
+++ b/src/distill/validate.js
@@ -53,6 +53,17 @@ export function validateDistillOutput(output) {
     );
   }
 
+  if (
+    output.sessionWorkingContext != null &&
+    (typeof output.sessionWorkingContext !== 'object' || Array.isArray(output.sessionWorkingContext))
+  ) {
+    throw new Error(
+      `Provider output field "sessionWorkingContext" must be an object when present; received ${receivedType(
+        output.sessionWorkingContext,
+      )}.`,
+    );
+  }
+
   return {
     summaryShort: output.summaryShort,
     summaryText: output.summaryText,
@@ -64,6 +75,7 @@ export function validateDistillOutput(output) {
         ? output.workingSummary
         : output.summaryText,
     memoryCandidates: output.memoryCandidates,
+    sessionWorkingContext: output.sessionWorkingContext || null,
     sourceEventCount: output.sourceEventCount,
     provider: output.provider,
     metadata: output.metadata || {},

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -31,7 +31,7 @@ const MCP_INSTRUCTIONS = [
   'For closeout triggers only, call suggest_memory_promotions: after this agent merges a PR, after the user says they merged and the agent syncs main/cleans branches, or when the user explicitly says today\'s work is done. Suggest at most 1-3 durable memory promotions and never promote automatically.',
   'For strict closeout-scoped safe automatic promotion, call auto_promote_memory_candidates only when the user wants automatic promotion. By default use dryRun=true. Use dryRun=false only when CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true is intentionally configured; never use scope-wide backlog fallback and never auto-promote preference candidates.',
   'For user corrections such as "너 잘못 알고 있잖아", "그거 아니야", "그건 X가 아니라 Y야", or "기억 수정해", call reconcile_memory. Show the basis for prior knowledge, assess conflicts, and only apply safe corrections when the user explicitly asks to fix memory.',
-  'When resuming a known session, pass sessionId to bootstrap_context or call get_working_summary to load latest rolling handoff state separately from durable memory and checkpoint search results.',
+  'When resuming a known session, pass sessionId to bootstrap_context or call get_working_summary and get_session_working_context to load latest rolling handoff state separately from durable memory and checkpoint search results.',
   'If working on a repository while the MCP process cwd is elsewhere, pass repoPath or cwd so repo scope resolves to that checkout; repoPath takes precedence when both are provided.',
   'Treat scopeKey as the canonical repo memory key; pass an explicit normalized GitHub key when local paths differ across machines or the checkout cannot infer the right remote.',
   'Use remember for reviewed durable facts the user or assistant intentionally wants saved.',
@@ -299,6 +299,56 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
       },
     },
     async (args) => jsonResult(await app.getWorkingSummary(args)),
+  );
+
+  server.registerTool(
+    'get_session_working_context',
+    {
+      title: 'Get Session Working Context',
+      description:
+        'Fetch structured mutable working context for one scoped session. This is live resume state, not durable canonical memory.',
+      inputSchema: {
+        ...scopedSchema,
+        sessionId: z.string(),
+      },
+      annotations: {
+        title: 'Get Session Working Context',
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.getSessionWorkingContext(args)),
+  );
+
+  server.registerTool(
+    'upsert_session_working_context',
+    {
+      title: 'Upsert Session Working Context',
+      description:
+        'Create or update structured mutable working context for the current scoped session. Use for live task state only, not durable memory.',
+      inputSchema: {
+        ...scopedSchema,
+        sessionId: z.string(),
+        conversationId: z.string().optional(),
+        mode: z.string().optional(),
+        currentTask: z.string().optional(),
+        currentUserIntent: z.string().optional(),
+        targetSubject: z.string().optional(),
+        sourceSubject: z.string().optional(),
+        lastUserCorrection: z.string().optional(),
+        openQuestion: z.string().optional(),
+        nonGoals: z.array(z.string()).optional(),
+        avoidMisreadings: z.array(z.string()).optional(),
+        confidence: z.number().optional(),
+        metadata: metadataSchema.optional(),
+      },
+      annotations: {
+        title: 'Upsert Session Working Context',
+        readOnlyHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.upsertSessionWorkingContext(args)),
   );
 
   server.registerTool(

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -24,6 +24,8 @@ const REMOTE_METHODS = [
   'appendRaw',
   'listRawEvents',
   'getWorkingSummary',
+  'getSessionWorkingContext',
+  'upsertSessionWorkingContext',
   'pruneRawEvents',
   'distillCheckpoint',
   'listDistillRuns',

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -4,7 +4,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import Database from 'better-sqlite3';
 import * as sqliteVec from 'sqlite-vec';
 
-export const SCHEMA_VERSION = 9;
+export const SCHEMA_VERSION = 10;
 
 function nowIso() {
   return new Date().toISOString();
@@ -120,6 +120,32 @@ function hydrateWorkingSummary(row) {
   };
 }
 
+function hydrateSessionWorkingContext(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    scopeType: row.scope_type,
+    scopeKey: row.scope_key,
+    sessionId: row.session_id,
+    conversationId: row.conversation_id,
+    mode: row.mode,
+    currentTask: row.current_task,
+    currentUserIntent: row.current_user_intent,
+    targetSubject: row.target_subject,
+    sourceSubject: row.source_subject,
+    lastUserCorrection: row.last_user_correction,
+    openQuestion: row.open_question,
+    nonGoals: parseJson(row.non_goals_json, []),
+    avoidMisreadings: parseJson(row.avoid_misreadings_json, []),
+    confidence: row.confidence,
+    sourceCheckpointId: row.source_checkpoint_id,
+    distillRunId: row.distill_run_id,
+    metadata: parseJson(row.metadata_json, {}),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
 function hydrateMemoryEvent(row) {
   if (!row) return null;
   return {
@@ -208,6 +234,16 @@ function normalizeCandidate(candidate) {
     promotionRecommendation: value.promotionRecommendation ? String(value.promotionRecommendation) : null,
     sourceEventIds: Array.isArray(value.sourceEventIds) ? value.sourceEventIds.map((item) => String(item)) : [],
   };
+}
+
+function normalizeStringList(value) {
+  return Array.isArray(value) ? value.map((item) => String(item)).filter(Boolean) : [];
+}
+
+function normalizeConfidence(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.max(0, Math.min(1, parsed));
 }
 
 export class ContextForgeStore {
@@ -344,6 +380,32 @@ export class ContextForgeStore {
         FOREIGN KEY (distill_run_id) REFERENCES distill_runs(id) ON DELETE SET NULL
       );
 
+      CREATE TABLE IF NOT EXISTS session_working_context (
+        id TEXT PRIMARY KEY,
+        scope_type TEXT NOT NULL CHECK (scope_type IN ('shared', 'repo', 'local')),
+        scope_key TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        conversation_id TEXT,
+        mode TEXT NOT NULL DEFAULT 'task_execution',
+        current_task TEXT NOT NULL DEFAULT '',
+        current_user_intent TEXT NOT NULL DEFAULT '',
+        target_subject TEXT,
+        source_subject TEXT,
+        last_user_correction TEXT,
+        open_question TEXT,
+        non_goals_json TEXT NOT NULL DEFAULT '[]',
+        avoid_misreadings_json TEXT NOT NULL DEFAULT '[]',
+        confidence REAL NOT NULL DEFAULT 0,
+        source_checkpoint_id TEXT,
+        distill_run_id TEXT,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE (scope_type, scope_key, session_id),
+        FOREIGN KEY (source_checkpoint_id) REFERENCES checkpoints(id) ON DELETE SET NULL,
+        FOREIGN KEY (distill_run_id) REFERENCES distill_runs(id) ON DELETE SET NULL
+      );
+
       CREATE TABLE IF NOT EXISTS memory_events (
         id TEXT PRIMARY KEY,
         memory_id TEXT NOT NULL,
@@ -404,6 +466,8 @@ export class ContextForgeStore {
         ON distill_runs(scope_type, scope_key, session_id, created_at);
       CREATE INDEX IF NOT EXISTS idx_working_summaries_scope
         ON working_summaries(scope_type, scope_key, updated_at);
+      CREATE INDEX IF NOT EXISTS idx_session_working_context_scope
+        ON session_working_context(scope_type, scope_key, updated_at);
       CREATE INDEX IF NOT EXISTS idx_memory_candidate_scope_status
         ON memory_candidate_index(scope_type, scope_key, status, created_at);
       CREATE INDEX IF NOT EXISTS idx_memory_candidate_checkpoint
@@ -455,6 +519,7 @@ export class ContextForgeStore {
         checkpoints: count('checkpoints'),
         distillRuns: count('distill_runs'),
         workingSummaries: count('working_summaries'),
+        sessionWorkingContexts: count('session_working_context'),
         memoryEvents: count('memory_events'),
         memoryCandidates: count('memory_candidate_index'),
         embeddings: embeddingIndexExists ? count('embedding_index') : 0,
@@ -1333,6 +1398,90 @@ export class ContextForgeStore {
         timestamp,
       );
     return hydrateWorkingSummary(row);
+  }
+
+  getSessionWorkingContext({ scopeType, scopeKey, sessionId }) {
+    const row = this.db
+      .prepare(`
+        SELECT * FROM session_working_context
+        WHERE scope_type = ? AND scope_key = ? AND session_id = ?
+      `)
+      .get(scopeType, scopeKey, sessionId);
+    return hydrateSessionWorkingContext(row);
+  }
+
+  upsertSessionWorkingContext({
+    scopeType,
+    scopeKey,
+    sessionId,
+    conversationId = null,
+    mode = 'task_execution',
+    currentTask = '',
+    currentUserIntent = '',
+    targetSubject = null,
+    sourceSubject = null,
+    lastUserCorrection = null,
+    openQuestion = null,
+    nonGoals = [],
+    avoidMisreadings = [],
+    confidence = 0,
+    sourceCheckpointId = null,
+    distillRunId = null,
+    metadata = {},
+  }) {
+    if (!sessionId) throw new Error('sessionId is required.');
+
+    const timestamp = nowIso();
+    const row = this.db
+      .prepare(`
+        INSERT INTO session_working_context (
+          id, scope_type, scope_key, session_id, conversation_id, mode,
+          current_task, current_user_intent, target_subject, source_subject,
+          last_user_correction, open_question, non_goals_json, avoid_misreadings_json,
+          confidence, source_checkpoint_id, distill_run_id, metadata_json, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(scope_type, scope_key, session_id) DO UPDATE SET
+          conversation_id = excluded.conversation_id,
+          mode = excluded.mode,
+          current_task = excluded.current_task,
+          current_user_intent = excluded.current_user_intent,
+          target_subject = excluded.target_subject,
+          source_subject = excluded.source_subject,
+          last_user_correction = excluded.last_user_correction,
+          open_question = excluded.open_question,
+          non_goals_json = excluded.non_goals_json,
+          avoid_misreadings_json = excluded.avoid_misreadings_json,
+          confidence = excluded.confidence,
+          source_checkpoint_id = excluded.source_checkpoint_id,
+          distill_run_id = excluded.distill_run_id,
+          metadata_json = excluded.metadata_json,
+          updated_at = excluded.updated_at
+        RETURNING *
+      `)
+      .get(
+        randomUUID(),
+        scopeType,
+        scopeKey,
+        sessionId,
+        conversationId,
+        String(mode || 'task_execution'),
+        String(currentTask || ''),
+        String(currentUserIntent || ''),
+        targetSubject == null ? null : String(targetSubject),
+        sourceSubject == null ? null : String(sourceSubject),
+        lastUserCorrection == null ? null : String(lastUserCorrection),
+        openQuestion == null ? null : String(openQuestion),
+        json(normalizeStringList(nonGoals), []),
+        json(normalizeStringList(avoidMisreadings), []),
+        normalizeConfidence(confidence),
+        sourceCheckpointId,
+        distillRunId,
+        json(metadata, {}),
+        timestamp,
+        timestamp,
+      );
+    return hydrateSessionWorkingContext(row);
   }
 
   listMemoryCandidates({

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -233,6 +233,55 @@ test('ContextForgeStore.withTransaction returns results and rolls back on throw'
   }
 });
 
+test('session working context is mutable scoped session state', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  const context = app.upsertSessionWorkingContext({
+    scope: 'repo',
+    scopeKey: 'working-context-repo',
+    sessionId: 'working-context-session',
+    currentTask: 'Implement structured resume handoff.',
+    currentUserIntent: 'Continue design follow-up work.',
+    targetSubject: 'session_working_context',
+    nonGoals: ['durable memory promotion'],
+    avoidMisreadings: ['structured context is canonical memory'],
+    confidence: 0.8,
+  });
+
+  assert.equal(context.scopeType, 'repo');
+  assert.equal(context.scopeKey, 'working-context-repo');
+  assert.equal(context.mode, 'task_execution');
+  assert.equal(context.currentTask, 'Implement structured resume handoff.');
+  assert.deepEqual(context.nonGoals, ['durable memory promotion']);
+  assert.deepEqual(context.avoidMisreadings, ['structured context is canonical memory']);
+  assert.equal(context.confidence, 0.8);
+
+  app.upsertSessionWorkingContext({
+    scope: 'repo',
+    scopeKey: 'working-context-repo',
+    sessionId: 'working-context-session',
+    currentTask: 'Update structured resume handoff tests.',
+    confidence: 2,
+  });
+
+  const updated = app.getSessionWorkingContext({
+    scope: 'repo',
+    scopeKey: 'working-context-repo',
+    sessionId: 'working-context-session',
+  });
+  assert.equal(updated.id, context.id);
+  assert.equal(updated.currentTask, 'Update structured resume handoff tests.');
+  assert.equal(updated.confidence, 1);
+
+  const otherSession = app.getSessionWorkingContext({
+    scope: 'repo',
+    scopeKey: 'working-context-repo',
+    sessionId: 'other-session',
+  });
+  assert.equal(otherSession, null);
+});
+
 test('repo scope key defaults to normalized GitHub origin remote', async () => {
   const cwd = await makeGitRepo();
   const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: path.join(cwd, 'data') }, cwd });
@@ -3647,8 +3696,8 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.model, 'gpt-test');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.reasoningEffort, 'low');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.timeoutMs, 1234);
-  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v5');
-  assert.equal(checkpoint.metadata.providerMetadata.codexExec.outputSchemaVersion, 'contextforge.checkpoint.v4');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v6');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.outputSchemaVersion, 'contextforge.checkpoint.v5');
   assert.match(invocation.prompt, /Return exactly one JSON object/);
   assert.deepEqual(invocation.args.slice(0, 2), ['exec', '--skip-git-repo-check']);
   assert.ok(invocation.args.includes('--output-schema'));
@@ -3658,6 +3707,7 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.equal(invocation.timeoutMs, 1234);
   const candidateSchema = schema.properties.memoryCandidates.items;
   assert.deepEqual(candidateSchema.required, Object.keys(candidateSchema.properties));
+  assert.ok(schema.properties.sessionWorkingContext);
   assert.deepEqual(schema.properties.metadata.required, ['providerNotes', 'retrievalHooks']);
 
   const runs = app.listDistillRuns({
@@ -3666,9 +3716,9 @@ test('codex_exec provider distills synthetic raw events through a runner', async
     sessionId: 'codex-session',
   });
   assert.equal(runs[0].status, 'succeeded');
-  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v5');
-  assert.equal(runs[0].inputMetadata.providerMetadata.outputSchemaVersion, 'contextforge.checkpoint.v4');
-  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v5');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v6');
+  assert.equal(runs[0].inputMetadata.providerMetadata.outputSchemaVersion, 'contextforge.checkpoint.v5');
+  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v6');
 });
 
 test('codex_exec records JSON brace fallback recovery metadata', async () => {
@@ -3872,8 +3922,8 @@ test('codex_exec parse failures preserve raw evidence', async () => {
   });
   assert.equal(runs[0].status, 'failed');
   assert.equal(runs[0].outputMetadata.providerFailed, true);
-  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v5');
-  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v5');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v6');
+  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v6');
 });
 
 test('bootstrapContext returns semantic retrieval with trust and verification hints', async () => {
@@ -4002,6 +4052,15 @@ test('syncResumeContext returns handoff context without promotion proposals', as
         decisions: ['Use checkpoint handoff for prior intent.'],
         todos: ['Verify CI before acting.'],
         openQuestions: [],
+        sessionWorkingContext: {
+          currentTask: 'Continue usage observability closeout verification.',
+          currentUserIntent: 'Resume unfinished PR verification without proposing memory promotions.',
+          targetSubject: 'usage observability',
+          openQuestion: 'Has CI passed on the latest PR commit?',
+          nonGoals: ['memory promotion review during resume'],
+          avoidMisreadings: ['checkpoint is weak memory'],
+          confidence: 0.82,
+        },
         memoryCandidates: [
           {
             key: 'resume-candidate-runbook',
@@ -4046,6 +4105,10 @@ test('syncResumeContext returns handoff context without promotion proposals', as
   });
 
   assert.equal(result.kind, 'resume_context');
+  assert.equal(result.handoff.structuredWorkingContext.type, 'session_working_context');
+  assert.equal(result.handoff.structuredWorkingContext.trust, 'mutable_session_state');
+  assert.match(result.handoff.structuredWorkingContext.currentTask, /usage observability/);
+  assert.deepEqual(result.handoff.structuredWorkingContext.nonGoals, ['memory promotion review during resume']);
   assert.equal(result.handoff.recentCheckpoints[0].trust, 'credible_recent_handoff');
   assert.match(result.handoff.recentCheckpoints[0].useHint, /Use actively/);
   assert.equal(result.handoff.memoryCandidates.count, 1);
@@ -4716,6 +4779,8 @@ test('REMOTE_METHODS exposes resume, suggestion, auto-promotion, and reconciliat
   assert.ok(REMOTE_METHODS.includes('suggestMemoryPromotions'));
   assert.ok(REMOTE_METHODS.includes('autoPromoteMemoryCandidates'));
   assert.ok(REMOTE_METHODS.includes('reconcileMemory'));
+  assert.ok(REMOTE_METHODS.includes('getSessionWorkingContext'));
+  assert.ok(REMOTE_METHODS.includes('upsertSessionWorkingContext'));
 });
 
 test('CLI supports the v0 workflow with synthetic data', async () => {
@@ -4874,6 +4939,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'distill_checkpoint',
       'distill_usage',
       'get_memory',
+      'get_session_working_context',
       'get_working_summary',
       'list_memory_candidates',
       'list_memory_events',
@@ -4888,6 +4954,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'session_status',
       'suggest_memory_promotions',
       'sync_resume_context',
+      'upsert_session_working_context',
     ]);
     const rememberTool = toolList.tools.find((tool) => tool.name === 'remember');
     assert.ok(rememberTool.inputSchema.properties.repoPath);
@@ -4905,6 +4972,9 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     assert.ok(bootstrapTool.inputSchema.properties.rawTailLimit);
     const syncResumeTool = toolList.tools.find((tool) => tool.name === 'sync_resume_context');
     assert.ok(syncResumeTool.inputSchema.properties.sessionId);
+    const sessionWorkingContextTool = toolList.tools.find((tool) => tool.name === 'upsert_session_working_context');
+    assert.ok(sessionWorkingContextTool.inputSchema.properties.currentTask);
+    assert.ok(sessionWorkingContextTool.inputSchema.properties.avoidMisreadings);
     const suggestTool = toolList.tools.find((tool) => tool.name === 'suggest_memory_promotions');
     assert.ok(suggestTool.inputSchema.properties.allowScopeFallback);
     assert.ok(suggestTool.inputSchema.properties.trigger);


### PR DESCRIPTION
## Summary

- add `session_working_context` as mutable scoped session state for structured resume handoff
- expose get/upsert APIs through core, CLI, remote, and MCP
- include structured working context in `bootstrapContext`/`syncResumeContext` when `sessionId` is supplied
- allow distillation providers, including `codex_exec`, to emit optional `sessionWorkingContext`

## Validation

- `npm test` — 94 pass / 0 fail
- `git diff --check`
- `node src/cli.js dbInfo` — schemaVersion 10 with `sessionWorkingContexts` table count

Closes #79.