### PR TITLE
[codex] Improve Korean lexical retrieval fallback

### DIFF
--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -292,6 +292,15 @@ token only; embedding provider credentials belong to the remote server process.
 Vector-backed checkpoint and candidate hits are useful for "what happened last
 time?" queries. They are intentionally not a replacement for durable memory.
 
+Embeddings are required for normal high-quality ContextForge retrieval. Lexical
+fallback is Unicode-aware for Korean and mixed Korean/English/dev strings, and
+can scan durable memories, checkpoints, and memory candidates using Hangul
+bigram/trigram-style tokens plus existing English/code tokens. Treat this as a
+degraded-mode safety net and supplemental ranking signal, not as an acceptable
+replacement for embeddings on canonical remote storage. It avoids extra storage
+tables for now, trading lower storage cost for broader scope scans if embeddings
+are unavailable during diagnostics or local fallback.
+
 Vector matches are context candidates, not live truth. Always verify
 time-sensitive or externally mutable state against the current source of truth:
 

--- a/src/retrieval/search.js
+++ b/src/retrieval/search.js
@@ -1,8 +1,25 @@
 function tokenize(text) {
-  return String(text || '')
+  const parts = String(text || '')
     .toLowerCase()
-    .split(/[^a-z0-9_./:-]+/)
-    .filter((token) => token.length > 1);
+    .match(/[a-z0-9_./:-]+|[\p{Script=Hangul}]+/gu);
+  if (!parts) return [];
+
+  return parts.flatMap((part) => {
+    if (!/\p{Script=Hangul}/u.test(part)) {
+      return part.split(/[^a-z0-9_./:-]+/).filter((token) => token.length > 1);
+    }
+    if (part.length <= 2) {
+      return [part];
+    }
+    const grams = [part];
+    for (let index = 0; index <= part.length - 2; index += 1) {
+      grams.push(part.slice(index, index + 2));
+    }
+    for (let index = 0; index <= part.length - 3; index += 1) {
+      grams.push(part.slice(index, index + 3));
+    }
+    return grams;
+  });
 }
 
 function unique(values) {
@@ -29,14 +46,7 @@ function vectorScore(distance) {
   return Math.round(1000 / (1 + Math.max(0, parsed)));
 }
 
-function scoreMemory(memory, queryTokens) {
-  const fields = {
-    key: memory.key,
-    category: memory.category,
-    content: memory.content,
-    tags: memory.tags.join(' '),
-  };
-
+function scoreFields(fields, queryTokens) {
   let score = 0;
   const matched = [];
   for (const token of queryTokens) {
@@ -74,6 +84,47 @@ function scoreMemory(memory, queryTokens) {
     score,
     matched,
   };
+}
+
+function scoreMemory(memory, queryTokens) {
+  return scoreFields(
+    {
+      key: memory.key,
+      category: memory.category,
+      content: memory.content,
+      tags: memory.tags.join(' '),
+    },
+    queryTokens,
+  );
+}
+
+function scoreCheckpoint(checkpoint, queryTokens) {
+  return scoreFields(
+    {
+      summary: checkpoint.summaryShort,
+      content: checkpoint.summaryText,
+      decisions: (checkpoint.decisions || []).join(' '),
+      todos: (checkpoint.todos || []).join(' '),
+      openQuestions: (checkpoint.openQuestions || []).join(' '),
+      hooks: Array.isArray(checkpoint.metadata?.providerMetadata?.retrievalHooks)
+        ? checkpoint.metadata.providerMetadata.retrievalHooks.join(' ')
+        : '',
+    },
+    queryTokens,
+  );
+}
+
+function scoreCandidate(candidate, queryTokens) {
+  return scoreFields(
+    {
+      key: candidate.candidate.key,
+      category: candidate.candidate.category,
+      content: candidate.candidate.content,
+      reason: candidate.candidate.reason,
+      tags: (candidate.candidate.tags || []).join(' '),
+    },
+    queryTokens,
+  );
 }
 
 function normalizeSearchScopes({ scopeType, scopeKey, searchScopes, sharedScopeKey }) {
@@ -127,6 +178,16 @@ function vectorRetrieval(match) {
   };
 }
 
+function lexicalVectorRetrieval({ lexical, vectorMatch }) {
+  return {
+    method: lexical && vectorMatch ? 'hybrid:vector+lexical' : vectorMatch ? 'vector' : 'lexical',
+    ftsRank: null,
+    vectorDistance: vectorMatch?.distance ?? null,
+    vectorModel: vectorMatch?.model ?? null,
+    vectorDimensions: vectorMatch?.dimensions ?? null,
+  };
+}
+
 export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, searchScopes, sharedScopeKey, queryEmbedding }) {
   const queryTokens = unique(tokenize(query));
   if (queryTokens.length === 0 && !queryEmbedding) {
@@ -172,11 +233,27 @@ export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, 
         : [];
       const ftsById = new Map(ftsMatches.map((match) => [match.memory.id, match]));
       const vectorById = new Map(vectorMatches.map((match) => [match.memory.id, match]));
+      const checkpointVectorById = new Map(checkpointVectorMatches.map((match) => [match.checkpoint.id, match]));
+      const candidateVectorById = new Map(candidateVectorMatches.map((match) => [match.candidate.id, match]));
       const ftsIds = new Set(ftsById.keys());
       const vectorIds = new Set(vectorById.keys());
       const lexicalCandidates =
         queryTokens.length > 0 && store.listMemories
           ? store.listMemories(source)
+          : [];
+      const lexicalCheckpoints =
+        queryTokens.length > 0 && store.listCheckpoints
+          ? store.listCheckpoints({
+              scopeType: source.scopeType,
+              scopeKey: source.scopeKey,
+            })
+          : [];
+      const lexicalMemoryCandidates =
+        queryTokens.length > 0 && store.listMemoryCandidates
+          ? store.listMemoryCandidates({
+              scopeType: source.scopeType,
+              scopeKey: source.scopeKey,
+            })
           : [];
       const candidateMemories = [
         ...ftsMatches.map((match) => match.memory),
@@ -184,6 +261,14 @@ export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, 
         ...lexicalCandidates,
       ];
       const memoriesById = new Map(candidateMemories.map((memory) => [memory.id, memory]));
+      const checkpointsById = new Map([
+        ...checkpointVectorMatches.map((match) => [match.checkpoint.id, match.checkpoint]),
+        ...lexicalCheckpoints.map((checkpoint) => [checkpoint.id, checkpoint]),
+      ]);
+      const candidatesById = new Map([
+        ...candidateVectorMatches.map((match) => [match.candidate.id, match.candidate]),
+        ...lexicalMemoryCandidates.map((candidate) => [candidate.id, candidate]),
+      ]);
 
       const memoryResults = [...memoriesById.values()].map((memory) => {
         const match = scoreMemory(memory, queryTokens);
@@ -216,30 +301,38 @@ export function searchMemories(store, { scopeType, scopeKey, query, limit = 10, 
           memory,
         };
       });
-      const checkpointResults = checkpointVectorMatches.map((match) => ({
-        type: 'checkpoint',
-        score: vectorScore(match.distance),
-        why: [],
-        retrieval: vectorRetrieval(match),
-        source: {
-          scopeType: source.scopeType,
-          scopeKey: source.scopeKey,
-          role: source.role,
-        },
-        checkpoint: match.checkpoint,
-      }));
-      const candidateResults = candidateVectorMatches.map((match) => ({
-        type: 'memory_candidate',
-        score: vectorScore(match.distance),
-        why: [],
-        retrieval: vectorRetrieval(match),
-        source: {
-          scopeType: source.scopeType,
-          scopeKey: source.scopeKey,
-          role: source.role,
-        },
-        candidate: match.candidate,
-      }));
+      const checkpointResults = [...checkpointsById.values()].map((checkpoint) => {
+        const match = scoreCheckpoint(checkpoint, queryTokens);
+        const vectorMatch = checkpointVectorById.get(checkpoint.id);
+        return {
+          type: 'checkpoint',
+          score: match.score * 100 + vectorScore(vectorMatch?.distance),
+          why: match.matched,
+          retrieval: lexicalVectorRetrieval({ lexical: match.score > 0, vectorMatch }),
+          source: {
+            scopeType: source.scopeType,
+            scopeKey: source.scopeKey,
+            role: source.role,
+          },
+          checkpoint,
+        };
+      });
+      const candidateResults = [...candidatesById.values()].map((candidate) => {
+        const match = scoreCandidate(candidate, queryTokens);
+        const vectorMatch = candidateVectorById.get(candidate.id);
+        return {
+          type: 'memory_candidate',
+          score: match.score * 100 + vectorScore(vectorMatch?.distance),
+          why: match.matched,
+          retrieval: lexicalVectorRetrieval({ lexical: match.score > 0, vectorMatch }),
+          source: {
+            scopeType: source.scopeType,
+            scopeKey: source.scopeKey,
+            role: source.role,
+          },
+          candidate,
+        };
+      });
 
       return [...memoryResults, ...checkpointResults, ...candidateResults];
     })

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -705,8 +705,7 @@ test('memory candidates require explicit promotion and can be corrected or deact
     scopeKey: 'repo-promote',
     query: 'human agent review',
   });
-  assert.equal(searchBeforeDeactivate.length, 1);
-  assert.equal(searchBeforeDeactivate[0].memory.key, 'candidate-rule');
+  assert.equal(searchBeforeDeactivate.find((result) => result.memory?.key === 'candidate-rule').type, 'memory');
 
   const inactive = app.deactivateMemory({
     scope: 'repo',
@@ -730,7 +729,7 @@ test('memory candidates require explicit promotion and can be corrected or deact
     scopeKey: 'repo-promote',
     query: 'agent review',
   });
-  assert.deepEqual(searchAfterDeactivate, []);
+  assert.equal(searchAfterDeactivate.some((result) => result.memory?.key === 'candidate-rule'), false);
 });
 
 test('CLI supports promoteMemory', async () => {
@@ -2412,7 +2411,7 @@ test('embedding rebuild populates sqlite-vec index for hybrid retrieval', async 
   assert.equal(info.vector.dimensions, 3);
 });
 
-test('vector search still runs for Korean queries that have no lexical tokens', () => {
+test('vector search still runs for Korean queries with lexical tokens', () => {
   const memory = {
     id: 'memory-korean',
     key: 'korean-memory',
@@ -2426,9 +2425,7 @@ test('vector search still runs for Korean queries that have no lexical tokens', 
   const results = searchMemories(
     {
       searchMemoryVectorIndex: () => [{ memory, distance: 0, model: 'test-embedding', dimensions: 3 }],
-      listMemories: () => {
-        throw new Error('listMemories should not be called when the query has no lexical tokens.');
-      },
+      listMemories: () => [],
     },
     {
       scopeType: 'repo',
@@ -2441,6 +2438,65 @@ test('vector search still runs for Korean queries that have no lexical tokens', 
   assert.equal(results.length, 1);
   assert.equal(results[0].memory.key, 'korean-memory');
   assert.equal(results[0].retrieval.method, 'vector');
+});
+
+test('Korean lexical safety net retrieves checkpoints and candidates in degraded no-embedding mode', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'korean_fallback_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      korean_fallback_provider: async () => ({
+        summaryShort: '지난 환경 동기화 작업',
+        summaryText: '사용자는 지난 환경 작업과 동기화한 뒤 체크포인트 인수인계를 이어가기로 했다.',
+        decisions: ['한국어 재개 쿼리는 임베딩이 없어도 최근 체크포인트를 찾아야 한다.'],
+        todos: ['다음 작업에서 런타임 상태를 확인한다.'],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'korean-resume-runbook',
+            content: '한국어 재개 요청은 체크포인트와 후보를 fallback 검색으로도 찾을 수 있어야 한다.',
+            reason: '지난 환경 작업과 동기화 요청에서 필요했다.',
+            category: 'runbook',
+            tags: ['한국어', '재개', '동기화'],
+            importance: 0,
+            candidateType: 'runbook',
+            confidence: 0.9,
+            stability: 0.9,
+            sensitivity: 'low',
+            promotionRecommendation: 'review',
+            sourceEventIds: [],
+          },
+        ],
+      }),
+    },
+  });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'korean-fallback-repo',
+    sessionId: 'korean-fallback-session',
+    role: 'assistant',
+    content: '지난 환경 작업과 동기화 후 재개한다.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'korean-fallback-repo',
+    sessionId: 'korean-fallback-session',
+  });
+
+  const results = app.search({
+    scope: 'repo',
+    scopeKey: 'korean-fallback-repo',
+    query: '지난 환경 작업 동기화 재개',
+    limit: 5,
+  });
+
+  assert.ok(results.some((result) => result.type === 'checkpoint' && result.retrieval.method === 'lexical'));
+  assert.ok(results.some((result) => result.type === 'memory_candidate' && result.retrieval.method === 'lexical'));
 });
 
 test('hybrid ranking keeps strong lexical matches ahead of weak vector-only matches', () => {
@@ -2557,7 +2613,7 @@ test('distillCheckpoint embeds the new checkpoint and candidates when embeddings
   });
   assert.equal(checkpointResults[0].type, 'checkpoint');
   assert.equal(checkpointResults[0].checkpoint.id, checkpoint.id);
-  assert.equal(checkpointResults[0].retrieval.method, 'vector');
+  assert.equal(checkpointResults[0].retrieval.method, 'hybrid:vector+lexical');
 
   const candidateResults = await app.search({
     scope: 'repo',


### PR DESCRIPTION
## Summary

- add Hangul-aware tokenization for Korean and mixed Korean/English/dev retrieval queries
- add lexical checkpoint and memory-candidate scanning as a degraded safety net and supplemental ranking signal
- keep embeddings as the normal required high-quality retrieval path; document lexical fallback as degraded-mode only

## Validation

- `npm test` — 95 pass / 0 fail
- `git diff --check`

Closes #77.