### PR TITLE
Add preference occurrence tracking

### DIFF
--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -393,8 +393,10 @@ defaults to `dryRun=true`. Real promotion with `dryRun=false` requires
 pending candidates only, `promotionRecommendation=promote`, high confidence and
 stability, no high/restricted sensitivity, no duplicates, no scope-wide backlog
 fallback, and category limited to `runbook`, `failure-mode`, `api-contract`,
-`environment`, or `decision`. Do not auto-promote `preference` candidates until
-occurrence/merge tracking exists.
+`environment`, or `decision`. Do not auto-promote `preference` candidates from
+the normal auto-promotion path. Preference candidates are tracked separately as
+occurrences so repeated evidence, corrections, and future merge policy can be
+reviewed before any durable preference is created.
 
 `auto_promote_memory_candidates` returns
 `kind: "auto_memory_promotion_result"` for both dry-run and real-promotion
@@ -407,6 +409,12 @@ Candidate records may include review signals such as `candidateType`,
 `sourceEventIds`. Use those fields to prioritize review. Treat `ignore`,
 `reject`, low-confidence, low-stability, and high-sensitivity candidates as
 reasons to skip or reject unless the user explicitly asks to keep them.
+
+For preference-like candidates, use `list_preference_occurrences` to inspect
+merged occurrence evidence across sessions and checkpoints. Repeated preference
+evidence is not durable memory by itself. Corrections handled through
+`reconcile_memory` can weaken preference occurrences when contradicted
+candidates are rejected.
 
 If a candidate key looks wrong, too broad, or belongs to the wrong repo, do not
 promote it as-is. Use `remember` with a corrected key/content or leave it as a
@@ -503,6 +511,8 @@ Prefer distilling at meaningful boundaries:
   estimated input tokens, elapsed time, and actual provider usage when recorded.
 - `list_memory_candidates`: inspect checkpoint-generated durable-memory
   candidates.
+- `list_preference_occurrences`: inspect merged preference evidence recorded
+  from preference-like candidates.
 - `suggest_memory_promotions`: closeout-only selector that proposes at most one
   to three durable memory promotions and never promotes automatically.
 - `auto_promote_memory_candidates`: closeout-only strict automatic promotion

--- a/src/cli.js
+++ b/src/cli.js
@@ -179,6 +179,7 @@ async function main() {
     deactivateMemory: (app, coreOptions) => app.deactivateMemory(coreOptions),
     listMemoryEvents: (app, coreOptions) => app.listMemoryEvents(coreOptions),
     listMemoryCandidates: (app, coreOptions) => app.listMemoryCandidates(coreOptions),
+    listPreferenceOccurrences: (app, coreOptions) => app.listPreferenceOccurrences(coreOptions),
     autoPromoteMemoryCandidates: (app, coreOptions) => app.autoPromoteMemoryCandidates(coreOptions),
     search: (app, coreOptions) => app.search(coreOptions),
     rebuildEmbeddings: (app, coreOptions) => app.rebuildEmbeddings(coreOptions),

--- a/src/core.js
+++ b/src/core.js
@@ -1510,6 +1510,17 @@ export function createContextForge(options = {}) {
       );
     },
 
+    listPreferenceOccurrences(options) {
+      const scope = normalizeScopeOptions(options, config);
+      return useStore((store) =>
+        store.listPreferenceOccurrences({
+          ...scope,
+          status: options.status || null,
+          limit: options.limit == null ? null : Number(options.limit),
+        }),
+      );
+    },
+
     async suggestMemoryPromotions(options = {}) {
       const scope = normalizeScopeOptions(options, config);
       const trigger = options.trigger;
@@ -1871,7 +1882,7 @@ export function createContextForge(options = {}) {
             reason: 'User correction conflicts with existing durable memory.',
           })),
           ...candidateBasis.map((item) => ({
-            action: 'reject_memory_candidate',
+            action: item.category === 'preference' ? 'reject_memory_candidate_and_weaken_preference_occurrence' : 'reject_memory_candidate',
             candidateId: item.candidateId,
             reason: 'User correction indicates this candidate should not become durable truth.',
           })),
@@ -1957,6 +1968,23 @@ export function createContextForge(options = {}) {
                   action: 'reject_memory_candidate',
                   candidateId: rejected.id,
                 });
+                if (candidate.candidate?.category === 'preference' || candidate.candidate?.candidateType === 'preference') {
+                  const weakened = store.weakenPreferenceOccurrenceForCandidate({
+                    ...scope,
+                    candidateId: item.candidateId,
+                    correction: options.correction,
+                    reason: 'Weakened via reconcile_memory apply_safe after user correction.',
+                  });
+                  if (weakened) {
+                    appliedActions.push({
+                      action: 'weaken_preference_occurrence',
+                      occurrenceId: weakened.id,
+                      mergeKey: weakened.mergeKey,
+                      negativeCount: weakened.negativeCount,
+                      status: weakened.status,
+                    });
+                  }
+                }
               }
             }
           }

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -30,6 +30,7 @@ const MCP_INSTRUCTIONS = [
   'For start/resume requests such as "지난 환경 작업과 동기화", "어제 하던 거 이어서", "previous work", or "continue", call sync_resume_context. Use checkpoints actively as handoff notes, then verify mutable state with git/GitHub/CI/runtime/migrations. Do not propose memory promotions during resume sync.',
   'For closeout triggers only, call suggest_memory_promotions: after this agent merges a PR, after the user says they merged and the agent syncs main/cleans branches, or when the user explicitly says today\'s work is done. Suggest at most 1-3 durable memory promotions and never promote automatically.',
   'For strict closeout-scoped safe automatic promotion, call auto_promote_memory_candidates only when the user wants automatic promotion. By default use dryRun=true. Use dryRun=false only when CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true is intentionally configured; never use scope-wide backlog fallback and never auto-promote preference candidates.',
+  'Preference-like candidates are tracked as merged occurrences; use list_preference_occurrences to review repeated evidence and weakened corrections, but do not treat occurrence evidence alone as durable preference truth.',
   'For user corrections such as "너 잘못 알고 있잖아", "그거 아니야", "그건 X가 아니라 Y야", or "기억 수정해", call reconcile_memory. Show the basis for prior knowledge, assess conflicts, and only apply safe corrections when the user explicitly asks to fix memory.',
   'When resuming a known session, pass sessionId to bootstrap_context or call get_working_summary and get_session_working_context to load latest rolling handoff state separately from durable memory and checkpoint search results.',
   'If working on a repository while the MCP process cwd is elsewhere, pass repoPath or cwd so repo scope resolves to that checkout; repoPath takes precedence when both are provided.',
@@ -459,6 +460,26 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
       },
     },
     async (args) => jsonResult(await app.listMemoryCandidates(args)),
+  );
+
+  server.registerTool(
+    'list_preference_occurrences',
+    {
+      title: 'List Preference Occurrences',
+      description:
+        'List merged preference occurrence evidence tracked from preference-like memory candidates. Use for review; do not auto-promote preferences solely from this output.',
+      inputSchema: {
+        ...scopedSchema,
+        status: z.enum(['active', 'weakened', 'superseded', 'rejected']).optional(),
+        limit: z.number().int().positive().optional(),
+      },
+      annotations: {
+        title: 'List Preference Occurrences',
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.listPreferenceOccurrences(args)),
   );
 
   server.registerTool(

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -15,6 +15,7 @@ const REMOTE_METHODS = [
   'deactivateMemory',
   'listMemoryEvents',
   'listMemoryCandidates',
+  'listPreferenceOccurrences',
   'suggestMemoryPromotions',
   'autoPromoteMemoryCandidates',
   'reconcileMemory',

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -4,7 +4,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import Database from 'better-sqlite3';
 import * as sqliteVec from 'sqlite-vec';
 
-export const SCHEMA_VERSION = 11;
+export const SCHEMA_VERSION = 12;
 
 function nowIso() {
   return new Date().toISOString();
@@ -203,6 +203,33 @@ function hydrateMemoryCandidate(row) {
   };
 }
 
+function hydratePreferenceOccurrence(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    scopeType: row.scope_type,
+    scopeKey: row.scope_key,
+    mergeKey: row.merge_key,
+    preferenceKey: row.preference_key,
+    content: row.content,
+    category: row.category,
+    occurrenceCount: row.occurrence_count,
+    negativeCount: row.negative_count,
+    confidence: row.confidence,
+    stability: row.stability,
+    status: row.status,
+    candidateIds: parseJson(row.candidate_ids_json, []),
+    sessionIds: parseJson(row.session_ids_json, []),
+    checkpointIds: parseJson(row.checkpoint_ids_json, []),
+    sourceEventIds: parseJson(row.source_event_ids_json, []),
+    lastCorrection: row.last_correction,
+    reviewReason: row.review_reason,
+    metadata: parseJson(row.metadata_json, {}),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
 function ftsValue(value) {
   return String(value || '').replace(/\0/g, ' ');
 }
@@ -213,6 +240,27 @@ function normalizeTags(tags) {
 
 function contentHash(value) {
   return createHash('sha256').update(String(value || '')).digest('hex');
+}
+
+function normalizePreferenceText(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function preferenceMergeKey(candidate) {
+  const key = normalizePreferenceText(candidate.key);
+  if (key) {
+    return `key:${key}`;
+  }
+  return `content:${contentHash(normalizePreferenceText(candidate.content))}`;
+}
+
+function isPreferenceCandidate(candidate) {
+  return [candidate.category, candidate.candidateType].some(
+    (value) => normalizePreferenceText(value) === 'preference',
+  );
 }
 
 function validateDimensions(dimensions) {
@@ -243,6 +291,10 @@ function normalizeCandidate(candidate) {
 
 function normalizeStringList(value) {
   return Array.isArray(value) ? value.map((item) => String(item)).filter(Boolean) : [];
+}
+
+function appendUniqueStrings(existing, additions) {
+  return Array.from(new Set([...normalizeStringList(existing), ...normalizeStringList(additions)]));
 }
 
 function normalizeConfidence(value) {
@@ -456,6 +508,31 @@ export class ContextForgeStore {
         FOREIGN KEY (promoted_memory_id) REFERENCES memories(id) ON DELETE SET NULL
       );
 
+      CREATE TABLE IF NOT EXISTS preference_occurrences (
+        id TEXT PRIMARY KEY,
+        scope_type TEXT NOT NULL CHECK (scope_type IN ('shared', 'repo', 'local')),
+        scope_key TEXT NOT NULL,
+        merge_key TEXT NOT NULL,
+        preference_key TEXT NOT NULL DEFAULT '',
+        content TEXT NOT NULL,
+        category TEXT NOT NULL DEFAULT 'preference',
+        occurrence_count INTEGER NOT NULL DEFAULT 0,
+        negative_count INTEGER NOT NULL DEFAULT 0,
+        confidence REAL,
+        stability REAL,
+        status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'weakened', 'superseded', 'rejected')),
+        candidate_ids_json TEXT NOT NULL DEFAULT '[]',
+        session_ids_json TEXT NOT NULL DEFAULT '[]',
+        checkpoint_ids_json TEXT NOT NULL DEFAULT '[]',
+        source_event_ids_json TEXT NOT NULL DEFAULT '[]',
+        last_correction TEXT,
+        review_reason TEXT,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE (scope_type, scope_key, merge_key)
+      );
+
       CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
         memory_id UNINDEXED,
         scope_type UNINDEXED,
@@ -482,6 +559,8 @@ export class ContextForgeStore {
         ON memory_candidate_index(scope_type, scope_key, status, created_at);
       CREATE INDEX IF NOT EXISTS idx_memory_candidate_checkpoint
         ON memory_candidate_index(checkpoint_id, candidate_index);
+      CREATE INDEX IF NOT EXISTS idx_preference_occurrences_scope
+        ON preference_occurrences(scope_type, scope_key, status, updated_at);
     `);
 
     this.ensureColumn('checkpoints', 'distill_run_id', 'TEXT');
@@ -502,7 +581,12 @@ export class ContextForgeStore {
     this.ensureColumn('memory_candidate_index', 'sensitivity', 'TEXT');
     this.ensureColumn('memory_candidate_index', 'promotion_recommendation', 'TEXT');
     this.ensureColumn('memory_candidate_index', 'source_event_ids_json', "TEXT NOT NULL DEFAULT '[]'");
+    this.ensureColumn('preference_occurrences', 'negative_count', 'INTEGER NOT NULL DEFAULT 0');
+    this.ensureColumn('preference_occurrences', 'last_correction', 'TEXT');
+    this.ensureColumn('preference_occurrences', 'review_reason', 'TEXT');
+    this.ensureColumn('preference_occurrences', 'metadata_json', "TEXT NOT NULL DEFAULT '{}'");
     this.backfillMemoryCandidateIndexOnce();
+    this.backfillPreferenceOccurrencesOnce();
     this.ensureMemoryFts();
 
     this.db
@@ -537,6 +621,7 @@ export class ContextForgeStore {
         sessionWorkingContexts: count('session_working_context'),
         memoryEvents: count('memory_events'),
         memoryCandidates: count('memory_candidate_index'),
+        preferenceOccurrences: count('preference_occurrences'),
         embeddings: embeddingIndexExists ? count('embedding_index') : 0,
       },
       vector: {
@@ -957,6 +1042,52 @@ export class ContextForgeStore {
       .run(nowIso());
   }
 
+  backfillPreferenceOccurrencesOnce() {
+    const completed = this.db
+      .prepare("SELECT value FROM schema_meta WHERE key = 'preference_occurrences_backfill_completed_at'")
+      .get();
+    if (completed?.value) {
+      return;
+    }
+    const rows = this.db
+      .prepare(`
+        SELECT
+          memory_candidate_index.*,
+          checkpoints.created_at AS checkpoint_created_at
+        FROM memory_candidate_index
+        JOIN checkpoints ON checkpoints.id = memory_candidate_index.checkpoint_id
+        WHERE memory_candidate_index.category = 'preference'
+           OR memory_candidate_index.candidate_type = 'preference'
+        ORDER BY memory_candidate_index.created_at ASC, memory_candidate_index.id ASC
+      `)
+      .all();
+    for (const row of rows) {
+      const indexedCandidate = hydrateMemoryCandidate(row);
+      if (!indexedCandidate || !isPreferenceCandidate(indexedCandidate.candidate)) {
+        continue;
+      }
+      this.upsertPreferenceOccurrenceForCandidate({
+        checkpoint: {
+          id: indexedCandidate.checkpointId,
+          scopeType: indexedCandidate.scopeType,
+          scopeKey: indexedCandidate.scopeKey,
+          sessionId: indexedCandidate.sessionId,
+          conversationId: indexedCandidate.conversationId,
+          createdAt: indexedCandidate.source.checkpointCreatedAt,
+        },
+        candidate: indexedCandidate.candidate,
+        candidateId: indexedCandidate.id,
+      });
+    }
+    this.db
+      .prepare(`
+        INSERT INTO schema_meta (key, value)
+        VALUES ('preference_occurrences_backfill_completed_at', ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+      `)
+      .run(nowIso());
+  }
+
   indexMemoryCandidatesForCheckpoint(checkpoint) {
     const candidates = Array.isArray(checkpoint?.metadata?.memoryCandidates)
       ? checkpoint.metadata.memoryCandidates
@@ -978,8 +1109,9 @@ export class ContextForgeStore {
 
     for (const [index, rawCandidate] of candidates.entries()) {
       const candidate = normalizeCandidate(rawCandidate);
-      insert.run(
-        randomUUID(),
+      const candidateId = randomUUID();
+      const inserted = insert.run(
+        candidateId,
         checkpoint.id,
         checkpoint.sessionId,
         checkpoint.conversationId,
@@ -1000,12 +1132,114 @@ export class ContextForgeStore {
         json(candidate.sourceEventIds, []),
         checkpoint.createdAt,
       );
+      if (inserted.changes > 0 && isPreferenceCandidate(candidate)) {
+        this.upsertPreferenceOccurrenceForCandidate({
+          checkpoint,
+          candidate,
+          candidateId,
+        });
+      }
     }
     return this.listMemoryCandidates({
       scopeType: checkpoint.scopeType,
       scopeKey: checkpoint.scopeKey,
       checkpointId: checkpoint.id,
     });
+  }
+
+  upsertPreferenceOccurrenceForCandidate({ checkpoint, candidate, candidateId }) {
+    const timestamp = nowIso();
+    const mergeKey = preferenceMergeKey(candidate);
+    const existing = this.db
+      .prepare(
+        `SELECT * FROM preference_occurrences
+         WHERE scope_type = ? AND scope_key = ? AND merge_key = ?`,
+      )
+      .get(checkpoint.scopeType, checkpoint.scopeKey, mergeKey);
+    if (!existing) {
+      this.db
+        .prepare(`
+          INSERT INTO preference_occurrences (
+            id, scope_type, scope_key, merge_key, preference_key, content, category,
+            occurrence_count, negative_count, confidence, stability, status,
+            candidate_ids_json, session_ids_json, checkpoint_ids_json, source_event_ids_json,
+            metadata_json, created_at, updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?, 'active', ?, ?, ?, ?, ?, ?, ?)
+        `)
+        .run(
+          randomUUID(),
+          checkpoint.scopeType,
+          checkpoint.scopeKey,
+          mergeKey,
+          candidate.key,
+          candidate.content,
+          candidate.category || 'preference',
+          candidate.confidence,
+          candidate.stability,
+          json([candidateId], []),
+          json([checkpoint.sessionId], []),
+          json([checkpoint.id], []),
+          json(candidate.sourceEventIds, []),
+          json(
+            {
+              latestReason: candidate.reason || null,
+              latestCandidateType: candidate.candidateType || null,
+              latestPromotionRecommendation: candidate.promotionRecommendation || null,
+            },
+            {},
+          ),
+          timestamp,
+          timestamp,
+        );
+      return this.getPreferenceOccurrence({ scopeType: checkpoint.scopeType, scopeKey: checkpoint.scopeKey, mergeKey });
+    }
+
+    const occurrenceCount = appendUniqueStrings(parseJson(existing.candidate_ids_json, []), [candidateId]).length;
+    const status = existing.status === 'rejected' ? 'weakened' : existing.status;
+    this.db
+      .prepare(`
+        UPDATE preference_occurrences
+        SET preference_key = COALESCE(NULLIF(?, ''), preference_key),
+            content = ?,
+            category = ?,
+            occurrence_count = ?,
+            confidence = MAX(COALESCE(confidence, 0), COALESCE(?, 0)),
+            stability = MAX(COALESCE(stability, 0), COALESCE(?, 0)),
+            status = ?,
+            candidate_ids_json = ?,
+            session_ids_json = ?,
+            checkpoint_ids_json = ?,
+            source_event_ids_json = ?,
+            metadata_json = ?,
+            updated_at = ?
+        WHERE id = ?
+      `)
+      .run(
+        candidate.key,
+        candidate.content,
+        candidate.category || existing.category || 'preference',
+        occurrenceCount,
+        candidate.confidence,
+        candidate.stability,
+        status,
+        json(appendUniqueStrings(parseJson(existing.candidate_ids_json, []), [candidateId]), []),
+        json(appendUniqueStrings(parseJson(existing.session_ids_json, []), [checkpoint.sessionId]), []),
+        json(appendUniqueStrings(parseJson(existing.checkpoint_ids_json, []), [checkpoint.id]), []),
+        json(appendUniqueStrings(parseJson(existing.source_event_ids_json, []), candidate.sourceEventIds), []),
+        json(
+          {
+            ...parseJson(existing.metadata_json, {}),
+            latestReason: candidate.reason || null,
+            latestCandidateType: candidate.candidateType || null,
+            latestPromotionRecommendation: candidate.promotionRecommendation || null,
+          },
+          {},
+        ),
+        timestamp,
+        existing.id,
+      );
+    return this.getPreferenceOccurrence({ scopeType: checkpoint.scopeType, scopeKey: checkpoint.scopeKey, mergeKey });
   }
 
   pruneRawEventsOlderThan(cutoffIso) {
@@ -1577,6 +1811,78 @@ export class ContextForgeStore {
       `)
       .all(...values)
       .map(hydrateMemoryCandidate);
+  }
+
+  getPreferenceOccurrence({ scopeType, scopeKey, mergeKey = null, candidateId = null }) {
+    if (candidateId) {
+      const row = this.db
+        .prepare(`
+          SELECT * FROM preference_occurrences
+          WHERE scope_type = ?
+            AND scope_key = ?
+            AND EXISTS (
+              SELECT 1 FROM json_each(preference_occurrences.candidate_ids_json)
+              WHERE json_each.value = ?
+            )
+          ORDER BY updated_at DESC
+          LIMIT 1
+        `)
+        .get(scopeType, scopeKey, candidateId);
+      return hydratePreferenceOccurrence(row);
+    }
+    if (!mergeKey) {
+      throw new Error('mergeKey or candidateId is required.');
+    }
+    const row = this.db
+      .prepare(`
+        SELECT * FROM preference_occurrences
+        WHERE scope_type = ? AND scope_key = ? AND merge_key = ?
+      `)
+      .get(scopeType, scopeKey, mergeKey);
+    return hydratePreferenceOccurrence(row);
+  }
+
+  listPreferenceOccurrences({ scopeType, scopeKey, status = null, limit = null }) {
+    const conditions = ['scope_type = ?', 'scope_key = ?'];
+    const values = [scopeType, scopeKey];
+    if (status) {
+      conditions.push('status = ?');
+      values.push(status);
+    }
+    const parsedLimit = limit == null ? null : Number(limit);
+    const limitClause = Number.isInteger(parsedLimit) && parsedLimit > 0 ? 'LIMIT ?' : '';
+    if (limitClause) {
+      values.push(parsedLimit);
+    }
+    return this.db
+      .prepare(`
+        SELECT * FROM preference_occurrences
+        WHERE ${conditions.join(' AND ')}
+        ORDER BY occurrence_count DESC, updated_at DESC, id DESC
+        ${limitClause}
+      `)
+      .all(...values)
+      .map(hydratePreferenceOccurrence);
+  }
+
+  weakenPreferenceOccurrenceForCandidate({ scopeType, scopeKey, candidateId, correction = null, reason = null }) {
+    const existing = this.getPreferenceOccurrence({ scopeType, scopeKey, candidateId });
+    if (!existing) {
+      return null;
+    }
+    const updatedAt = nowIso();
+    this.db
+      .prepare(`
+        UPDATE preference_occurrences
+        SET negative_count = negative_count + 1,
+            status = CASE status WHEN 'rejected' THEN 'rejected' ELSE 'weakened' END,
+            last_correction = ?,
+            review_reason = ?,
+            updated_at = ?
+        WHERE id = ?
+      `)
+      .run(correction, reason, updatedAt, existing.id);
+    return this.getPreferenceOccurrence({ scopeType, scopeKey, mergeKey: existing.mergeKey });
   }
 
   getMemoryCandidate({ scopeType, scopeKey, candidateId }) {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -4693,6 +4693,207 @@ test('autoPromoteMemoryCandidates promotes only strict safe candidates when enab
   assert.equal(autoEvents[0].metadata.autoPromoted, true);
 });
 
+test('preference candidates record merged occurrences across checkpoints', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'preference_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      preference_provider: async () => ({
+        summaryShort: 'Preference checkpoint.',
+        summaryText: 'A repeated user preference was observed.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'closing-style',
+            content: 'The user prefers concise Korean closeout summaries with command evidence.',
+            category: 'preference',
+            candidateType: 'preference',
+            confidence: 0.9,
+            stability: 0.86,
+            sensitivity: 'low',
+            promotionRecommendation: 'review',
+            sourceEventIds: ['event-a'],
+          },
+        ],
+      }),
+    },
+  });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'preference-repo',
+    sessionId: 'preference-session-a',
+    role: 'user',
+    content: 'Keep closeout summaries concise and in Korean.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'preference-repo',
+    sessionId: 'preference-session-a',
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'preference-repo',
+    sessionId: 'preference-session-b',
+    role: 'user',
+    content: 'Again, keep closeout summaries concise and in Korean.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'preference-repo',
+    sessionId: 'preference-session-b',
+  });
+
+  const occurrences = app.listPreferenceOccurrences({
+    scope: 'repo',
+    scopeKey: 'preference-repo',
+  });
+  assert.equal(occurrences.length, 1);
+  assert.equal(occurrences[0].mergeKey, 'key:closing-style');
+  assert.equal(occurrences[0].occurrenceCount, 2);
+  assert.deepEqual(occurrences[0].sessionIds.sort(), ['preference-session-a', 'preference-session-b']);
+  assert.equal(occurrences[0].checkpointIds.length, 2);
+  assert.equal(occurrences[0].confidence, 0.9);
+  assert.equal(occurrences[0].stability, 0.86);
+});
+
+test('preference occurrence backfill covers existing preference candidates', async () => {
+  const dataDir = await makeTempDir();
+  const env = {
+    CONTEXTFORGE_DATA_DIR: dataDir,
+    CONTEXTFORGE_DISTILL_PROVIDER: 'preference_backfill_provider',
+  };
+  const distillProviders = {
+    preference_backfill_provider: async () => ({
+      summaryShort: 'Preference backfill checkpoint.',
+      summaryText: 'A preference candidate existed before occurrence tracking.',
+      decisions: [],
+      todos: [],
+      openQuestions: [],
+      memoryCandidates: [
+        {
+          key: 'review-style',
+          content: 'The user prefers review comments grouped by severity.',
+          category: 'preference',
+          candidateType: 'preference',
+          confidence: 0.88,
+          stability: 0.82,
+          sensitivity: 'low',
+          promotionRecommendation: 'review',
+        },
+      ],
+    }),
+  };
+  const app = createContextForge({ env, cwd: process.cwd(), distillProviders });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'preference-backfill-repo',
+    sessionId: 'preference-backfill-session',
+    role: 'assistant',
+    content: 'Preference candidate exists before backfill.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'preference-backfill-repo',
+    sessionId: 'preference-backfill-session',
+  });
+
+  const db = new Database(path.join(dataDir, 'contextforge.db'));
+  try {
+    db.prepare('DELETE FROM preference_occurrences').run();
+    db.prepare("DELETE FROM schema_meta WHERE key = 'preference_occurrences_backfill_completed_at'").run();
+  } finally {
+    db.close();
+  }
+
+  const reopened = createContextForge({ env, cwd: process.cwd(), distillProviders });
+  const occurrences = reopened.listPreferenceOccurrences({
+    scope: 'repo',
+    scopeKey: 'preference-backfill-repo',
+  });
+  assert.equal(occurrences.length, 1);
+  assert.equal(occurrences[0].mergeKey, 'key:review-style');
+  assert.equal(occurrences[0].occurrenceCount, 1);
+});
+
+test('reconcileMemory apply_safe weakens preference occurrences when rejecting contradicted candidates', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'preference_reconcile_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      preference_reconcile_provider: async () => ({
+        summaryShort: 'Preference correction checkpoint.',
+        summaryText: 'A preference candidate should be rejected after correction.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'summary-style',
+            content: 'The user always wants long exhaustive closeout summaries.',
+            category: 'preference',
+            candidateType: 'preference',
+            confidence: 0.95,
+            stability: 0.95,
+            sensitivity: 'low',
+            promotionRecommendation: 'review',
+          },
+        ],
+      }),
+    },
+  });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'preference-correction-repo',
+    sessionId: 'preference-correction-session',
+    role: 'assistant',
+    content: 'Preference candidate: long exhaustive summaries.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'preference-correction-repo',
+    sessionId: 'preference-correction-session',
+  });
+
+  const before = app.listPreferenceOccurrences({
+    scope: 'repo',
+    scopeKey: 'preference-correction-repo',
+  });
+  assert.equal(before[0].status, 'active');
+  assert.equal(before[0].negativeCount, 0);
+
+  const result = await app.reconcileMemory({
+    scope: 'repo',
+    scopeKey: 'preference-correction-repo',
+    sessionId: 'preference-correction-session',
+    query: 'summary style preference',
+    correction: 'That is wrong; prefer concise summaries unless I ask for exhaustive detail.',
+    mode: 'apply_safe',
+  });
+
+  assert.ok(result.appliedActions.some((action) => action.action === 'reject_memory_candidate'));
+  assert.ok(result.appliedActions.some((action) => action.action === 'weaken_preference_occurrence'));
+  const after = app.listPreferenceOccurrences({
+    scope: 'repo',
+    scopeKey: 'preference-correction-repo',
+  });
+  assert.equal(after[0].status, 'weakened');
+  assert.equal(after[0].negativeCount, 1);
+  assert.match(after[0].lastCorrection, /prefer concise/);
+});
+
 test('reconcileMemory proposes by default and apply_safe only changes unambiguous non-live memory', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({
@@ -4856,6 +5057,7 @@ test('REMOTE_METHODS exposes resume, suggestion, auto-promotion, and reconciliat
   assert.ok(REMOTE_METHODS.includes('suggestMemoryPromotions'));
   assert.ok(REMOTE_METHODS.includes('autoPromoteMemoryCandidates'));
   assert.ok(REMOTE_METHODS.includes('reconcileMemory'));
+  assert.ok(REMOTE_METHODS.includes('listPreferenceOccurrences'));
   assert.ok(REMOTE_METHODS.includes('listCheckpoints'));
   assert.ok(REMOTE_METHODS.includes('getSessionWorkingContext'));
   assert.ok(REMOTE_METHODS.includes('upsertSessionWorkingContext'));
@@ -5022,6 +5224,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'list_checkpoints',
       'list_memory_candidates',
       'list_memory_events',
+      'list_preference_occurrences',
       'promote_memory',
       'promote_memory_candidate',
       'prune_raw_events',
@@ -5060,6 +5263,9 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     const suggestTool = toolList.tools.find((tool) => tool.name === 'suggest_memory_promotions');
     assert.ok(suggestTool.inputSchema.properties.allowScopeFallback);
     assert.ok(suggestTool.inputSchema.properties.trigger);
+    const preferenceOccurrencesTool = toolList.tools.find((tool) => tool.name === 'list_preference_occurrences');
+    assert.ok(preferenceOccurrencesTool.inputSchema.properties.status);
+    assert.ok(preferenceOccurrencesTool.inputSchema.properties.limit);
     const autoPromoteTool = toolList.tools.find((tool) => tool.name === 'auto_promote_memory_candidates');
     assert.ok(autoPromoteTool.inputSchema.properties.dryRun);
     assert.ok(autoPromoteTool.inputSchema.properties.minConfidence);


### PR DESCRIPTION
## Summary
- add a preference_occurrences table with occurrence counts, source sessions/checkpoints, confidence/stability, and correction weakening fields
- index preference-like memory candidates into merged occurrence evidence, including backfill for existing preference candidates
- expose listPreferenceOccurrences through core, CLI, remote, and MCP, and weaken occurrences from reconcile_memory apply_safe when contradicted candidates are rejected
- document that preference occurrences are review evidence, not durable truth or normal auto-promotion input

## Tests
- npm test
- git diff --check

Closes #80