### PR TITLE
Add embedding job queue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,8 @@ Private agent-memory systems may be useful reference material, but do not mutate
 - Keep prompt preload small. Retrieve details on demand.
 - Store runtime data locally by default and keep it out of git.
 - Support `shared`, `repo`, and `local` scopes explicitly.
-- Treat checkpoints as recent continuity, not canonical truth.
+- Treat checkpoints as credible recent handoff state for continuity and
+  planning; verify mutable live state before acting.
 - Treat distilled checkpoints as compressed retrieval indexes: preserve
   concrete names, numbers, intervals, APIs, paths, commands, error strings,
   decisions, rationale, risks, conditions, next actions, and retrieval hooks.
@@ -100,19 +101,32 @@ storage is canonical shared memory for the configured scope; local or
 project-local storage is machine/check-out local context unless the user says
 otherwise.
 
-Interpret search result types by trust level:
-- `memory`: reviewed durable fact or decision.
-- `checkpoint`: recent session continuity, not canonical truth.
-- `memory_candidate`: unreviewed promotion candidate and review material.
+Interpret search result types by trust role:
+- `memory`: reviewed durable fact, decision, preference, or runbook note.
+- `checkpoint`: credible recent handoff state for continuity, planning, prior
+  intent, recent decisions, and unfinished work. Verify mutable live state such
+  as git, GitHub, CI, runtime, and migrations before acting.
+- `memory_candidate`: unreviewed promotion material and review context, not
+  durable truth.
 
-Keep durable memory intentional. After distilling a checkpoint, review
-`list_memory_candidates` and promote only stable, reviewed facts.
+For start/resume wording such as "지난 환경 작업과 동기화", "어제 하던 거
+이어서", "previous work", or "continue", call `sync_resume_context` when
+available. Use checkpoints actively as handoff notes, then verify live state.
+Do not propose memory promotions during resume sync.
+
+Keep durable memory intentional. At closeout triggers only, call
+`suggest_memory_promotions` when available and propose at most one to three
+stable durable facts. Use `auto_promote_memory_candidates` only when the user
+explicitly wants strict closeout-scoped automatic promotion and the configured
+safety gates allow it.
 
 Use `remember` for new reviewed durable facts, decisions, preferences, or
 runbook notes. Use `promote_memory_candidate` only after reviewing a checkpoint
 candidate and confirming it is stable beyond the current task, scoped correctly,
-and free of secrets or private data. Use `correct_memory` for changed facts and
-`deactivate_memory` for stale facts.
+and free of secrets or private data. Use `reconcile_memory` for user
+corrections when available, `correct_memory` for changed durable facts,
+`deactivate_memory` for stale facts, and `reject_memory_candidate` for
+incorrect candidates.
 
 For full ContextForge MCP usage rules, follow
 `docs/agent-instructions.md`. That guide covers startup bootstrap, retrieval

--- a/README.md
+++ b/README.md
@@ -270,12 +270,15 @@ CONTEXTFORGE_OPENAI_API_KEY=sk-...
 CONTEXTFORGE_EMBEDDINGS_MODEL=text-embedding-3-small
 CONTEXTFORGE_EMBEDDINGS_DIMENSIONS=1536
 CONTEXTFORGE_EMBEDDINGS_TIMEOUT_MS=30000
+CONTEXTFORGE_EMBEDDINGS_STALE_AFTER_MS=600000
 ```
 
 The default and recommended embedding model is `text-embedding-3-small`.
 `CONTEXTFORGE_EMBEDDINGS_DIMENSIONS` is sent to OpenAI only for
 `text-embedding-3-*` models; legacy models such as `text-embedding-ada-002` do
 not support that request field and must return the configured dimension count.
+`CONTEXTFORGE_EMBEDDINGS_STALE_AFTER_MS` controls when a stuck `processing`
+embedding job is returned to `pending`; the default is 10 minutes.
 
 Use a long random token and store the same value on client machines as
 `CONTEXTFORGE_REMOTE_TOKEN`. Treat this token as an administrator credential:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ ContextForge is a sidecar memory runtime. It complements existing agent memory
 systems by providing canonical project/repo memory, evidence retention, and
 LLM-backed distillation.
 
+Current 0.3.x builds add remote-first MCP workflows, start/resume handoff
+tools, closeout memory promotion review, correction reconciliation, hybrid
+retrieval, and an embedding job queue so vector indexing can recover
+independently from memory or checkpoint writes.
+
 ## Goals
 
 - Keep durable memory in a canonical local store.
@@ -45,7 +50,7 @@ Codex / Claude Code / OpenClaw
 ## Storage Modes
 
 - `project-local`: repo-bound SQLite storage in a gitignored directory. This is
-  the default v0 mode.
+  the default zero-friction mode.
 - `local`: single-machine SQLite storage under the user's home directory.
 - `remote`: first-class VPS or server-backed canonical memory for multiple
   machines.
@@ -70,7 +75,7 @@ bring-your-own distillation providers, such as:
 - direct model APIs
 - local model runners
 
-The v0 implementation ships with a deterministic `mock` provider and a
+The current implementation ships with a deterministic `mock` provider and a
 `codex_exec` provider. The `codex_exec` provider shells out to `codex exec`,
 requests JSON-only output with a schema, validates the result, and records
 provider run metadata, including prompt and output schema versions.
@@ -200,7 +205,7 @@ reads and writes for `shared`, `repo`, and `local` scopes, and the client sends
 the requested scope explicitly with each operation. If a token is configured on
 the server, clients must send it with `CONTEXTFORGE_REMOTE_TOKEN`.
 
-Current v0 remote behavior is deliberately simple:
+Current remote behavior is deliberately simple:
 
 - `CONTEXTFORGE_STORAGE_MODE=remote` delegates core calls to
   `CONTEXTFORGE_REMOTE_URL`.
@@ -391,19 +396,34 @@ the ContextForge API, but it is not a replacement for TLS on untrusted networks
 or for operator-only handling of admin-capable credentials.
 
 When embeddings are enabled on the server, successful `distillCheckpoint` calls
-immediately embed the new checkpoint and any memory candidates from that
-checkpoint into the derived sqlite-vec index. The canonical tables remain
-SQLite memory/checkpoint tables; the vector index is rebuildable with:
+immediately queue embedding work for the new checkpoint and its memory
+candidates. Durable memory writes also queue their own embedding work. The
+actual sqlite-vec index write is processed by the embedding worker, so vector
+indexing can retry or recover independently from the canonical write path:
+
+```bash
+node src/cli.js processEmbeddingJobs --scope repo --scopeKey github.com/example/repo
+```
+
+Inspect queue state with `listEmbeddingJobs`, or with `dbInfo` for aggregate
+job counts and degraded retrieval signals. The canonical tables remain SQLite
+memory/checkpoint tables; the vector index is rebuildable with:
 
 ```bash
 node src/cli.js rebuildEmbeddings --scope repo --scopeKey github.com/example/repo
 ```
 
-If embedding fails after a successful distillation, the checkpoint remains
-stored and the result reports `embedding.reason = "embedding_failed"`. If some
-rows were already written before the failure, the response also includes
-`embedding.embedded`, `embedding.bySourceType`, and
-`embedding.partialFailure = true` so operators can see the partial DB state.
+If embedding fails after a successful write or distillation, the canonical
+memory/checkpoint data remains stored and the embedding job records `failed`
+with attempts and the last error. Retry failed jobs with:
+
+```bash
+node src/cli.js processEmbeddingJobs --retryFailed true
+```
+
+Stuck `processing` jobs are reset to `pending` after the configured stale
+timeout. Set `CONTEXTFORGE_EMBEDDINGS_STALE_AFTER_MS` on the worker/server, or
+pass `--staleAfterMs` for one run.
 
 If the configured embedding dimensions change, ContextForge refuses to silently
 drop the existing vector index. Run a forced rebuild only when you intentionally
@@ -1105,20 +1125,28 @@ The MCP server exposes a narrow tool surface over the same core API:
 
 - `begin_session`
 - `session_status`
+- `sync_resume_context`
 - `search`
 - `get_memory`
 - `remember`
 - `list_memory_events`
 - `list_memory_candidates`
+- `list_memory_update_candidates`
 - `append_raw`
 - `prune_raw_events`
 - `distill_checkpoint`
 - `distill_usage`
+- `suggest_memory_promotions`
+- `auto_promote_memory_candidates`
+- `reconcile_memory`
 - `promote_memory`
 - `promote_memory_candidate`
 - `reject_memory_candidate`
 - `correct_memory`
 - `deactivate_memory`
+- `process_embedding_jobs`
+- `list_embedding_jobs`
+- `rebuild_embeddings`
 
 Example MCP client configuration:
 
@@ -1252,9 +1280,11 @@ operators can tell which prompt contract produced the result.
 
 ## Status
 
-Early v0 core. The current implementation includes SQLite migrations, scoped
-durable memories, raw event capture, FTS-backed explainable search, mock
-checkpoint distillation, `codex_exec` checkpoint distillation, and a minimal
-remote HTTP mode for server-backed canonical memory. Search can combine repo and
-shared memory while keeping local memory opt-in. MCP stdio integration and an
-explicit promotion workflow are available. Additional providers are future work.
+0.3.x runtime. The current implementation includes SQLite migrations, scoped
+durable memories, raw event capture, rolling working summaries, checkpoint
+distillation with `mock` and `codex_exec` providers, remote HTTP mode for
+server-backed canonical memory, stdio and Streamable HTTP MCP, explainable
+hybrid retrieval, embedding job processing, closeout promotion review, strict
+safe auto-promotion controls, and memory reconciliation for user corrections.
+Additional distillation providers and large-store performance hardening remain
+future work.

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -553,6 +553,8 @@ Prefer distilling at meaningful boundaries:
   the derived sqlite-vec index.
 - `process_embedding_jobs`: process queued embedding jobs independently from
   checkpoint or memory writes. Use `retryFailed=true` when retrying failed
-  embedding provider or vector-index work.
+  embedding provider or vector-index work. A per-call `staleAfterMs` override
+  is available; otherwise ContextForge uses
+  `CONTEXTFORGE_EMBEDDINGS_STALE_AFTER_MS` with a 10 minute default.
 - `list_embedding_jobs`: inspect embedding job status, attempts, last error,
   source type/id, and completion time.

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -129,9 +129,10 @@ github.com/example/repo unless the user says otherwise. Include shared scope
 only for user-wide policy, deployment, credential-location, or cross-repo
 conventions.
 
-Interpret search result types by trust level:
+Interpret search result types by trust role:
 - memory: reviewed durable fact or decision.
-- checkpoint: recent session continuity; verify important claims before acting.
+- checkpoint: credible recent handoff state for continuity and planning; verify
+  mutable live state before acting.
 - memory_candidate: unreviewed promotion candidate and review material.
 
 For loose continuation prompts such as "yesterday", "continue", "previous
@@ -343,8 +344,9 @@ it.
 
 ## Checkpoints And Candidates
 
-Checkpoints are recent continuity. They are useful for handoff, but they are
-not canonical truth.
+Checkpoints are credible recent handoff state. Use them actively for
+continuity, planning, prior intent, recent decisions, and unfinished work, while
+verifying mutable live state separately.
 
 Good checkpoints are compressed retrieval indexes, not generic summaries. They
 should preserve the names, numbers, intervals, commands, paths, APIs, error

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -551,3 +551,8 @@ Prefer distilling at meaningful boundaries:
   durable memories, checkpoints, and memory candidates. If embedding dimensions
   changed, pass `force=true` only when the operator intentionally wants to reset
   the derived sqlite-vec index.
+- `process_embedding_jobs`: process queued embedding jobs independently from
+  checkpoint or memory writes. Use `retryFailed=true` when retrying failed
+  embedding provider or vector-index work.
+- `list_embedding_jobs`: inspect embedding job status, attempts, last error,
+  source type/id, and completion time.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,8 +53,8 @@ Single-machine home-directory mode.
 Repo-bound storage in a gitignored directory.
 
 - useful when memory should stay near one checkout
-- default v0 path: `.contextforge/`
-- default v0 storage mode
+- default path: `.contextforge/`
+- default storage mode
 - live DB files must not be committed
 
 ### Remote
@@ -77,7 +77,7 @@ can hold source, docs, migrations, example exports, and reviewed snapshots.
 
 ### Remote Client/Server Boundary
 
-The v0 remote boundary is intentionally narrow:
+The remote boundary is intentionally narrow:
 
 - the client keeps no canonical SQLite database when `storageMode=remote`
 - the client sends JSON requests to `/v0/<method>`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -103,7 +103,7 @@ Follow-on providers:
 
 Tracking issue: #4.
 
-Status: initial implementation in progress.
+Status: broad 0.3.x surface implemented.
 
 Goals:
 
@@ -112,29 +112,48 @@ Goals:
 - include examples for agent integration
 - document context budget guidance
 
-Initial tool surface:
+Tool surface:
 
 - `begin_session`
+- `session_status`
+- `sync_resume_context`
 - `search`
 - `get_memory`
 - `remember`
+- `list_memory_events`
+- `list_memory_candidates`
+- `list_memory_update_candidates`
 - `append_raw`
+- `prune_raw_events`
 - `distill_checkpoint`
+- `distill_usage`
+- `suggest_memory_promotions`
+- `auto_promote_memory_candidates`
+- `reconcile_memory`
 - `promote_memory`
+- `promote_memory_candidate`
+- `reject_memory_candidate`
+- `correct_memory`
+- `deactivate_memory`
+- `process_embedding_jobs`
+- `list_embedding_jobs`
+- `rebuild_embeddings`
 
 Initial implementation:
 
 - stdio MCP server entrypoint for local agent integrations
+- Streamable HTTP MCP endpoint for remote canonical deployments
 - package binary `contextforge-mcp`
 - tool schemas for stable core methods
 - structured JSON results plus text fallback content
-- explicit `promote_memory` primitive for reviewed durable-memory writes
+- start/resume, closeout promotion review, safe auto-promotion dry-run/apply,
+  and memory reconciliation wrappers over the lower-level memory primitives
 
 ## Milestone 6: Promotion Workflow
 
 Tracking issue: #10.
 
-Status: initial implementation in progress.
+Status: 0.3.x implementation in place.
 
 Goals:
 
@@ -146,6 +165,13 @@ Goals:
 Initial implementation:
 
 - checkpoint `memoryCandidates` can be listed without promotion
+- `suggestMemoryPromotions` proposes at most one to three high-signal closeout
+  candidates without scope-wide fallback by default
+- `autoPromoteMemoryCandidates` supports strict closeout-scoped automatic
+  promotion with dry-run defaults and environment-gated real promotion
+- `reconcileMemory` surfaces prior knowledge basis and applies only safe,
+  explicit user corrections
+- preference candidates can record repeated occurrences for later merge/review
 - `promoteMemory` writes durable memory with source checkpoint/session/candidate metadata
 - `correctMemory` updates a durable key while preserving previous content in memory-event metadata
 - `deactivateMemory` marks memories inactive instead of deleting them
@@ -156,7 +182,7 @@ Initial implementation:
 
 Tracking issue: #9.
 
-Status: initial implementation in progress.
+Status: 0.3.x hybrid retrieval and embedding queue implemented.
 
 Possible improvements:
 
@@ -174,7 +200,29 @@ Initial implementation:
 - canonical memory remains in `memories`; FTS is rebuilt/updated as a retrieval index
 - weighted FTS rank is combined with explainable lexical scoring
 - result metadata includes `why` token/field/match-type details and `retrieval.ftsRank`
+- sqlite-vec hybrid retrieval is available when embeddings are configured
+- embedding jobs decouple vector indexing from memory/checkpoint writes
+- `processEmbeddingJobs` retries failed work and resets stale `processing` jobs
+- `dbInfo` and bootstrap storage metadata report vector readiness, stale
+  sources, failed jobs, and degraded retrieval state
 - inactive memories remain excluded from search
+
+## Milestone 8: Embedding Queue Operations
+
+Tracking issues: #77 and #82.
+
+Status: implemented in PR #98.
+
+Delivered:
+
+- persistent `embedding_jobs` table with status, attempts, content hash, and
+  last-error metadata
+- queueing from durable memory, checkpoint, and memory-candidate write paths
+- explicit processing through CLI, remote API, and MCP
+- atomic job claiming for multi-worker safety
+- stale `processing` reset with configurable
+  `CONTEXTFORGE_EMBEDDINGS_STALE_AFTER_MS`
+- rebuild path that enqueues and processes derived vector work
 
 ## Open Decisions
 
@@ -187,10 +235,11 @@ Initial implementation:
   runs; future providers should expose the same metadata contract.
 - `codex_exec` can be checked with a dry doctor command and an opt-in live
   structured smoke before users enable it as the distillation provider.
-- Should checkpoint memory candidates require explicit human approval or allow a
-  configurable auto-promote policy?
 - What is the minimum auth model for remote mode?
-- Should MCP ship before or after the first real provider?
+- Should embedding queue dead-letter/max-attempt behavior preserve stale reset
+  attempts, reset them, or introduce a separate retry budget?
+- Should large-store coverage and `dbInfo` checks move to SQL aggregation or
+  cached counters?
 
 ## Follow-Up Issue Split
 
@@ -205,5 +254,7 @@ Each milestone after v0 has a focused tracking issue:
 - #9: retrieval quality improvements
 - #19: default repo scope key inference
 - #21: distillation provider prompt versioning
+- #77: embedding queue separation
+- #82: embedding job processing operations
 
 Those issues should stay narrow enough to produce reviewable PRs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contextforge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contextforge",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contextforge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Self-hosted memory and distillation runtime for coding agents.",
   "type": "module",
   "bin": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -156,6 +156,7 @@ function toCoreOptions(options) {
     confidence: options.confidence == null ? undefined : Number(options.confidence),
     batchSize: options.batchSize == null ? undefined : Number(options.batchSize),
     force: options.force === true || options.force === 'true',
+    retryFailed: options.retryFailed === true || options.retryFailed === 'true',
   };
 }
 
@@ -187,6 +188,8 @@ async function main() {
     autoPromoteMemoryCandidates: (app, coreOptions) => app.autoPromoteMemoryCandidates(coreOptions),
     search: (app, coreOptions) => app.search(coreOptions),
     rebuildEmbeddings: (app, coreOptions) => app.rebuildEmbeddings(coreOptions),
+    processEmbeddingJobs: (app, coreOptions) => app.processEmbeddingJobs(coreOptions),
+    listEmbeddingJobs: (app, coreOptions) => app.listEmbeddingJobs(coreOptions),
     getMemory: (app, coreOptions) => app.getMemory(coreOptions),
     appendRaw: (app, coreOptions) => app.appendRaw(coreOptions),
     listRawEvents: (app, coreOptions) => app.listRawEvents(coreOptions),

--- a/src/cli.js
+++ b/src/cli.js
@@ -157,6 +157,7 @@ function toCoreOptions(options) {
     batchSize: options.batchSize == null ? undefined : Number(options.batchSize),
     force: options.force === true || options.force === 'true',
     retryFailed: options.retryFailed === true || options.retryFailed === 'true',
+    staleAfterMs: options.staleAfterMs == null ? undefined : Number(options.staleAfterMs),
   };
 }
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -183,6 +183,11 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
     'CONTEXTFORGE_EMBEDDINGS_DIMENSIONS',
     1536,
   );
+  const embeddingsStaleAfterMs = parsePositiveInteger(
+    env.CONTEXTFORGE_EMBEDDINGS_STALE_AFTER_MS,
+    'CONTEXTFORGE_EMBEDDINGS_STALE_AFTER_MS',
+    10 * 60 * 1000,
+  );
   const distillMinIntervalMs = parsePositiveInteger(
     env.CONTEXTFORGE_DISTILL_MIN_INTERVAL_MS,
     'CONTEXTFORGE_DISTILL_MIN_INTERVAL_MS',
@@ -211,6 +216,7 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
         'CONTEXTFORGE_EMBEDDINGS_TIMEOUT_MS',
         30000,
       ),
+      staleAfterMs: embeddingsStaleAfterMs,
     },
     remote: {
       url: env.CONTEXTFORGE_REMOTE_URL || null,

--- a/src/core.js
+++ b/src/core.js
@@ -284,9 +284,7 @@ function resultTextForVerification(result) {
 }
 
 function requiresLiveStateVerification(result) {
-  return /\b(branch\w*|prs?|pull requests?|issues?|ci|checks?|runtimes?|deploy\w*|deployments?|migrations?|migrate\w*|servers?|services?|queues?|status|drafts?|merge\w*|merged|commits?|tags?|releases?|rollbacks?)\b/i.test(
-    resultTextForVerification(result),
-  );
+  return liveStateTermsMatch(resultTextForVerification(result));
 }
 
 function bootstrapTrustForType(type) {
@@ -1014,7 +1012,13 @@ function isLiveStateCorrection(text) {
     /\b(merged?|deployed|released|rolled back|rollback)\s+(to|into|from|on|in)\b/i,
     /\b(ci|check run|github action|workflow run|migration|runtime|deployment|server|service|queue)\s+(failed|passing|passed|running|stopped|down|up|merged|deployed|current|pending)\b/i,
     /\b(alembic|migration|migrations)\s+(current|heads?|upgraded?|downgraded?|applied|pending)\b/i,
-  ].some((pattern) => pattern.test(value));
+  ].some((pattern) => pattern.test(value)) || liveStateTermsMatch(value);
+}
+
+function liveStateTermsMatch(text) {
+  return /(\b(branch\w*|prs?|pull requests?|issues?|ci|checks?|runtimes?|deploy\w*|deployments?|migrations?|migrate\w*|servers?|services?|queues?|status|drafts?|merge\w*|merged|commits?|tags?|releases?|rollbacks?)\b|브랜치|원격|머지|이슈|배포|런타임|마이그레이션|마이그레이트|커밋|릴리즈|롤백|서버|서비스|큐|상태)/i.test(
+    String(text || ''),
+  );
 }
 
 function checkpointTimestamp(checkpoint) {
@@ -2221,8 +2225,8 @@ export function createContextForge(options = {}) {
 
     async reconcileMemory(options = {}) {
       const scope = normalizeScopeOptions(options, config);
-      requireOption(options.query, 'query');
       requireOption(options.correction, 'correction');
+      const baseQuery = options.query || options.correction;
       const mode = options.mode || 'propose';
       if (!['propose', 'apply_safe'].includes(mode)) {
         throw new Error('mode must be propose or apply_safe.');
@@ -2234,14 +2238,14 @@ export function createContextForge(options = {}) {
       );
       const includeShared = truthyOption(options.includeShared);
       const createUpdateCandidates = truthyOption(options.createUpdateCandidates);
-      const reconciliationQuery = `${options.query}\n${options.correction}`;
+      const reconciliationQuery = `${baseQuery}\n${options.correction}`;
       const bootstrap = await this.bootstrapContext({
         ...options,
         query: reconciliationQuery,
         includeShared,
         limit,
       });
-      const liveState = isLiveStateCorrection(`${options.query}\n${options.correction}`);
+      const liveState = isLiveStateCorrection(reconciliationQuery);
       return useStore((store) => {
         const basis = (bootstrap.results || []).slice(0, limit).map(summarizeBasisResult);
         const latestCheckpoint = options.sessionId
@@ -2404,7 +2408,7 @@ export function createContextForge(options = {}) {
                   reason: 'Rejected via reconcile_memory apply_safe after user correction.',
                   metadata: {
                     correction: options.correction,
-                    query: options.query,
+                    query: baseQuery,
                   },
                 });
                 appliedActions.push({
@@ -2438,7 +2442,7 @@ export function createContextForge(options = {}) {
           mode,
           scope: bootstrap.scope,
           storage: bootstrap.storage,
-          query: options.query,
+          query: baseQuery,
           correction: options.correction,
           basis,
           conflicts,

--- a/src/core.js
+++ b/src/core.js
@@ -1236,6 +1236,8 @@ export function createContextForge(options = {}) {
         provider: config.embeddings.provider,
         skipped: true,
         reason: 'embeddings_disabled',
+        model: null,
+        dimensions: null,
         queued: 0,
         bySourceType: {},
       };
@@ -1295,6 +1297,10 @@ export function createContextForge(options = {}) {
     };
     const active = [];
     for (const job of jobs) {
+      const claimedJob = store.markEmbeddingJobProcessing(job.id);
+      if (!claimedJob) {
+        continue;
+      }
       const source = embeddingSourceForJob(store, job);
       if (!source || source.contentHash !== job.contentHash) {
         store.markEmbeddingJobFailed(
@@ -1305,7 +1311,7 @@ export function createContextForge(options = {}) {
         result.missingSources += source ? 0 : 1;
         continue;
       }
-      active.push({ job: store.markEmbeddingJobProcessing(job.id), source });
+      active.push({ job: claimedJob, source });
     }
     if (active.length === 0) {
       return result;
@@ -2653,6 +2659,8 @@ export function createContextForge(options = {}) {
       }
       const batchSize = positiveNumber(options.batchSize == null ? 32 : Number(options.batchSize), 'batchSize');
       const limit = positiveNumber(options.limit == null ? 50 : Number(options.limit), 'limit');
+      const staleAfterMs =
+        options.staleAfterMs == null ? 10 * 60 * 1000 : positiveNumber(Number(options.staleAfterMs), 'staleAfterMs');
       return useStore(async (store) => {
         store.ensureEmbeddingIndex(embeddingProvider.dimensions, { resetOnDimensionChange: truthyOption(options.force) });
         const shouldNarrowScope = Boolean(options.scope || options.scopeKey || options.cwd || options.repoPath);
@@ -2661,6 +2669,11 @@ export function createContextForge(options = {}) {
           scopeKey: shouldNarrowScope ? scope.scopeKey : null,
           limit,
         };
+        const staleReset = store.resetStaleEmbeddingJobs({
+          scopeType: listOptions.scopeType,
+          scopeKey: listOptions.scopeKey,
+          staleBeforeIso: new Date(Date.now() - staleAfterMs).toISOString(),
+        });
         const pending = store.listEmbeddingJobs({ ...listOptions, status: 'pending' });
         const failed = truthyOption(options.retryFailed)
           ? store.listEmbeddingJobs({ ...listOptions, status: 'failed', limit: Math.max(0, limit - pending.length) })
@@ -2678,10 +2691,7 @@ export function createContextForge(options = {}) {
           missingSources: 0,
           bySourceType: {},
           errors: [],
-          jobs: store.countEmbeddingJobs({
-            scopeType: listOptions.scopeType,
-            scopeKey: listOptions.scopeKey,
-          }),
+          staleReset,
         };
         for (let index = 0; index < jobs.length; index += batchSize) {
           const batch = jobs.slice(index, index + batchSize);

--- a/src/core.js
+++ b/src/core.js
@@ -1205,6 +1205,7 @@ export function createContextForge(options = {}) {
         provider: config.embeddings.provider,
         model: config.embeddings.model,
         dimensions: config.embeddings.dimensions,
+        staleAfterMs: config.embeddings.staleAfterMs,
         enabled: Boolean(embeddingProvider),
         requiredForQuality: true,
         degraded: !embeddingProvider || !storeInfo.vector.sqliteVecAvailable || Boolean(coverage?.staleSources) || Boolean(jobs.failed),
@@ -2660,7 +2661,9 @@ export function createContextForge(options = {}) {
       const batchSize = positiveNumber(options.batchSize == null ? 32 : Number(options.batchSize), 'batchSize');
       const limit = positiveNumber(options.limit == null ? 50 : Number(options.limit), 'limit');
       const staleAfterMs =
-        options.staleAfterMs == null ? 10 * 60 * 1000 : positiveNumber(Number(options.staleAfterMs), 'staleAfterMs');
+        options.staleAfterMs == null
+          ? config.embeddings.staleAfterMs
+          : positiveNumber(Number(options.staleAfterMs), 'staleAfterMs');
       return useStore(async (store) => {
         store.ensureEmbeddingIndex(embeddingProvider.dimensions, { resetOnDimensionChange: truthyOption(options.force) });
         const shouldNarrowScope = Boolean(options.scope || options.scopeKey || options.cwd || options.repoPath);

--- a/src/core.js
+++ b/src/core.js
@@ -466,10 +466,17 @@ function bootstrapSummary(results) {
 
 function storageBootstrapInfo(config, info) {
   const vectorReady = Boolean(info.vector?.sqliteVecAvailable && info.embeddings?.enabled);
+  const staleSources = Number(info.embeddings?.coverage?.staleSources || 0);
+  const pendingJobs = Number(info.embeddings?.jobs?.pending || 0);
+  const failedJobs = Number(info.embeddings?.jobs?.failed || 0);
   return {
     mode: config.storageMode,
     authority: config.storageMode === 'remote' ? 'canonical' : config.storageMode === 'local' ? 'local' : 'project-local',
     vectorReady,
+    vectorState: vectorReady && staleSources === 0 && failedJobs === 0 ? 'ready' : 'degraded',
+    vectorStaleSources: staleSources,
+    vectorPendingJobs: pendingJobs,
+    vectorFailedJobs: failedJobs,
     sqliteVecAvailable: Boolean(info.vector?.sqliteVecAvailable),
     sqliteVecVersion: info.vector?.sqliteVecVersion || null,
     embeddingProvider: info.embeddings?.provider || 'none',
@@ -1182,14 +1189,27 @@ export function createContextForge(options = {}) {
   let lastRawPruneAt = 0;
 
   function buildDbInfo(store) {
+    const storeInfo = store.dbInfo();
+    const jobs = store.countEmbeddingJobs();
+    const coverage =
+      embeddingProvider && storeInfo.vector.sqliteVecAvailable
+        ? store.embeddingCoverage({
+            model: embeddingProvider.model,
+            dimensions: embeddingProvider.dimensions,
+          })
+        : null;
     return {
-      ...store.dbInfo(),
+      ...storeInfo,
       storageMode: config.storageMode,
       embeddings: {
         provider: config.embeddings.provider,
         model: config.embeddings.model,
         dimensions: config.embeddings.dimensions,
         enabled: Boolean(embeddingProvider),
+        requiredForQuality: true,
+        degraded: !embeddingProvider || !storeInfo.vector.sqliteVecAvailable || Boolean(coverage?.staleSources) || Boolean(jobs.failed),
+        jobs,
+        coverage,
       },
       rawRetention: {
         ttlDays: config.rawRetention.ttlDays,
@@ -1210,55 +1230,120 @@ export function createContextForge(options = {}) {
     return store.pruneRawEventsOlderThan(rawTtlCutoffIso(config.rawRetention.ttlDays, now));
   }
 
-  async function embedSources(store, sources, { batchSize = 32 } = {}) {
+  function enqueueEmbeddingSources(store, sources, { force = false } = {}) {
     if (!embeddingProvider) {
       return {
         provider: config.embeddings.provider,
         skipped: true,
         reason: 'embeddings_disabled',
-        embedded: 0,
+        queued: 0,
         bySourceType: {},
       };
     }
-    store.ensureEmbeddingIndex(embeddingProvider.dimensions);
-    let embedded = 0;
+    const jobs = store.enqueueEmbeddingJobs(sources, {
+      model: embeddingProvider.model,
+      dimensions: embeddingProvider.dimensions,
+      force,
+    });
     const bySourceType = {};
-    try {
-      for (let index = 0; index < sources.length; index += batchSize) {
-        const batch = sources.slice(index, index + batchSize);
-        const embeddings = await embeddingProvider.embed(batch.map((source) => source.text));
-        for (const [offset, source] of batch.entries()) {
-          store.upsertEmbedding({
-            sourceType: source.sourceType,
-            recordId: source.recordId,
-            scopeType: source.scopeType,
-            scopeKey: source.scopeKey,
-            model: embeddingProvider.model,
-            dimensions: embeddingProvider.dimensions,
-            contentHash: source.contentHash,
-            embedding: embeddings[offset],
-          });
-          embedded += 1;
-          bySourceType[source.sourceType] = (bySourceType[source.sourceType] || 0) + 1;
-        }
-      }
-    } catch (error) {
-      error.embeddingProgress = {
-        scanned: sources.length,
-        embedded,
-        bySourceType,
-      };
-      throw error;
+    for (const job of jobs) {
+      bySourceType[job.sourceType] = (bySourceType[job.sourceType] || 0) + 1;
     }
     return {
       provider: embeddingProvider.name,
       model: embeddingProvider.model,
       dimensions: embeddingProvider.dimensions,
-      scanned: sources.length,
-      embedded,
-      bySourceType,
       skipped: false,
+      queued: jobs.length,
+      bySourceType,
     };
+  }
+
+  function embeddingSourceForJob(store, job) {
+    if (job.sourceType === 'memory') {
+      const memory = store.getMemoryById({
+        scopeType: job.scopeType,
+        scopeKey: job.scopeKey,
+        memoryId: job.recordId,
+      });
+      return memory && store.embeddingSourceForMemory(memory);
+    }
+    if (job.sourceType === 'checkpoint') {
+      const checkpoint = store.getCheckpointById({
+        scopeType: job.scopeType,
+        scopeKey: job.scopeKey,
+        checkpointId: job.recordId,
+      });
+      return checkpoint && store.embeddingSourceForCheckpoint(checkpoint);
+    }
+    const candidate = store.getMemoryCandidate({
+      scopeType: job.scopeType,
+      scopeKey: job.scopeKey,
+      candidateId: job.recordId,
+    });
+    return candidate && store.embeddingSourceForMemoryCandidate(candidate);
+  }
+
+  async function processEmbeddingJobBatch(store, jobs) {
+    const result = {
+      processed: 0,
+      embedded: 0,
+      failed: 0,
+      missingSources: 0,
+      bySourceType: {},
+      errors: [],
+    };
+    const active = [];
+    for (const job of jobs) {
+      const source = embeddingSourceForJob(store, job);
+      if (!source || source.contentHash !== job.contentHash) {
+        store.markEmbeddingJobFailed(
+          job.id,
+          new Error(source ? 'Embedding job source content changed; enqueue a fresh job.' : 'Embedding job source not found.'),
+        );
+        result.failed += 1;
+        result.missingSources += source ? 0 : 1;
+        continue;
+      }
+      active.push({ job: store.markEmbeddingJobProcessing(job.id), source });
+    }
+    if (active.length === 0) {
+      return result;
+    }
+    let embeddings;
+    try {
+      embeddings = await embeddingProvider.embed(active.map((item) => item.source.text));
+    } catch (error) {
+      for (const item of active) {
+        store.markEmbeddingJobFailed(item.job.id, error);
+        result.failed += 1;
+      }
+      result.errors.push({ message: error.message, count: active.length });
+      return result;
+    }
+    for (const [index, item] of active.entries()) {
+      try {
+        store.upsertEmbedding({
+          sourceType: item.source.sourceType,
+          recordId: item.source.recordId,
+          scopeType: item.source.scopeType,
+          scopeKey: item.source.scopeKey,
+          model: embeddingProvider.model,
+          dimensions: embeddingProvider.dimensions,
+          contentHash: item.source.contentHash,
+          embedding: embeddings[index],
+        });
+        store.markEmbeddingJobCompleted(item.job.id);
+        result.processed += 1;
+        result.embedded += 1;
+        result.bySourceType[item.source.sourceType] = (result.bySourceType[item.source.sourceType] || 0) + 1;
+      } catch (error) {
+        store.markEmbeddingJobFailed(item.job.id, error);
+        result.failed += 1;
+        result.errors.push({ message: error.message, sourceType: item.source.sourceType, recordId: item.source.recordId });
+      }
+    }
+    return result;
   }
 
   function searchStoreWithScope(store, scope, options, queryEmbedding = null) {
@@ -1540,16 +1625,18 @@ export function createContextForge(options = {}) {
 
     remember(options) {
       const scope = normalizeScopeOptions(options, config);
-      return useStore((store) =>
-        store.rememberMemory({
+      return useStore((store) => {
+        const memory = store.rememberMemory({
           ...scope,
           key: options.key,
           content: options.content,
           category: options.category,
           tags: options.tags,
           importance: options.importance,
-        }),
-      );
+        });
+        enqueueEmbeddingSources(store, [store.embeddingSourceForMemory(memory)]);
+        return memory;
+      });
     },
 
     promoteMemory(options) {
@@ -1557,8 +1644,8 @@ export function createContextForge(options = {}) {
       requireOption(options.key, 'key');
       requireOption(options.content, 'content');
 
-      return useStore((store) =>
-        store.rememberMemory({
+      return useStore((store) => {
+        const memory = store.rememberMemory({
           ...scope,
           key: options.key,
           content: options.content,
@@ -1574,8 +1661,10 @@ export function createContextForge(options = {}) {
             sourceCandidateIndex: options.sourceCandidateIndex ?? null,
             reason: options.reason || null,
           },
-        }),
-      );
+        });
+        enqueueEmbeddingSources(store, [store.embeddingSourceForMemory(memory)]);
+        return memory;
+      });
     },
 
     correctMemory(options) {
@@ -1589,7 +1678,7 @@ export function createContextForge(options = {}) {
           throw new Error(`Memory not found: ${options.key}`);
         }
 
-        return store.rememberMemory({
+        const memory = store.rememberMemory({
           ...scope,
           key: options.key,
           content: options.content,
@@ -1605,6 +1694,8 @@ export function createContextForge(options = {}) {
             reason: options.reason || null,
           },
         });
+        enqueueEmbeddingSources(store, [store.embeddingSourceForMemory(memory)]);
+        return memory;
       });
     },
 
@@ -2529,8 +2620,100 @@ export function createContextForge(options = {}) {
           ...store.listCheckpointEmbeddingSources(sourceOptions),
           ...store.listMemoryCandidateEmbeddingSources(sourceOptions),
         ];
-        return embedSources(store, sources, { batchSize });
+        const queued = enqueueEmbeddingSources(store, sources, { force: truthyOption(options.force) });
+        const processed = await this.processEmbeddingJobs({
+          ...(shouldNarrowScope ? { scope: scope.scopeType, scopeKey: scope.scopeKey } : {}),
+          batchSize,
+          limit: Math.max(sources.length, 1),
+        });
+        return {
+          ...processed,
+          provider: embeddingProvider.name,
+          model: embeddingProvider.model,
+          dimensions: embeddingProvider.dimensions,
+          scanned: sources.length,
+          queued: queued.queued,
+          bySourceType: processed.bySourceType,
+          skipped: false,
+        };
       });
+    },
+
+    async processEmbeddingJobs(options = {}) {
+      const scope = normalizeScopeOptions(options, config);
+      if (!embeddingProvider) {
+        return {
+          provider: config.embeddings.provider,
+          skipped: true,
+          reason: 'embeddings_disabled',
+          processed: 0,
+          embedded: 0,
+          failed: 0,
+        };
+      }
+      const batchSize = positiveNumber(options.batchSize == null ? 32 : Number(options.batchSize), 'batchSize');
+      const limit = positiveNumber(options.limit == null ? 50 : Number(options.limit), 'limit');
+      return useStore(async (store) => {
+        store.ensureEmbeddingIndex(embeddingProvider.dimensions, { resetOnDimensionChange: truthyOption(options.force) });
+        const shouldNarrowScope = Boolean(options.scope || options.scopeKey || options.cwd || options.repoPath);
+        const listOptions = {
+          scopeType: shouldNarrowScope ? scope.scopeType : null,
+          scopeKey: shouldNarrowScope ? scope.scopeKey : null,
+          limit,
+        };
+        const pending = store.listEmbeddingJobs({ ...listOptions, status: 'pending' });
+        const failed = truthyOption(options.retryFailed)
+          ? store.listEmbeddingJobs({ ...listOptions, status: 'failed', limit: Math.max(0, limit - pending.length) })
+          : [];
+        const jobs = [...pending, ...failed].slice(0, limit);
+        const aggregate = {
+          provider: embeddingProvider.name,
+          model: embeddingProvider.model,
+          dimensions: embeddingProvider.dimensions,
+          skipped: false,
+          scanned: jobs.length,
+          processed: 0,
+          embedded: 0,
+          failed: 0,
+          missingSources: 0,
+          bySourceType: {},
+          errors: [],
+          jobs: store.countEmbeddingJobs({
+            scopeType: listOptions.scopeType,
+            scopeKey: listOptions.scopeKey,
+          }),
+        };
+        for (let index = 0; index < jobs.length; index += batchSize) {
+          const batch = jobs.slice(index, index + batchSize);
+          const result = await processEmbeddingJobBatch(store, batch);
+          aggregate.processed += result.processed;
+          aggregate.embedded += result.embedded;
+          aggregate.failed += result.failed;
+          aggregate.missingSources += result.missingSources;
+          aggregate.errors.push(...result.errors);
+          for (const [sourceType, count] of Object.entries(result.bySourceType)) {
+            aggregate.bySourceType[sourceType] = (aggregate.bySourceType[sourceType] || 0) + count;
+          }
+        }
+        aggregate.jobs = store.countEmbeddingJobs({
+          scopeType: listOptions.scopeType,
+          scopeKey: listOptions.scopeKey,
+        });
+        return aggregate;
+      });
+    },
+
+    listEmbeddingJobs(options = {}) {
+      const scope = normalizeScopeOptions(options, config);
+      const shouldNarrowScope = Boolean(options.scope || options.scopeKey || options.cwd || options.repoPath);
+      return useStore((store) =>
+        store.listEmbeddingJobs({
+          scopeType: shouldNarrowScope ? scope.scopeType : null,
+          scopeKey: shouldNarrowScope ? scope.scopeKey : null,
+          status: options.status || null,
+          limit: options.limit == null ? null : Number(options.limit),
+        }),
+      );
     },
 
     appendRaw(options) {
@@ -2850,7 +3033,7 @@ export function createContextForge(options = {}) {
           provider: config.embeddings.provider,
           skipped: true,
           reason: 'embeddings_disabled',
-          embedded: 0,
+          queued: 0,
           bySourceType: {},
         };
         if (embeddingProvider) {
@@ -2859,14 +3042,14 @@ export function createContextForge(options = {}) {
               ...scope,
               checkpointId: checkpoint.id,
             });
-            embedding = await embedSources(
+            embedding = enqueueEmbeddingSources(
               store,
               [
                 store.embeddingSourceForCheckpoint(checkpoint),
                 ...candidates.map((candidate) => store.embeddingSourceForMemoryCandidate(candidate)),
               ],
-              { batchSize: 32 },
             );
+            embedding.reason = 'queued';
           } catch (error) {
             embedding = embeddingFailureResult(error);
           }

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -215,6 +215,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
         batchSize: z.number().int().positive().optional(),
         limit: z.number().int().positive().optional(),
         retryFailed: z.boolean().optional(),
+        staleAfterMs: z.number().int().positive().optional(),
         force: z.boolean().optional(),
       },
       annotations: {

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -34,6 +34,7 @@ const MCP_INSTRUCTIONS = [
   'For user corrections such as "너 잘못 알고 있잖아", "그거 아니야", "그건 X가 아니라 Y야", or "기억 수정해", call reconcile_memory. Show the basis for prior knowledge, assess conflicts, and only apply safe corrections when the user explicitly asks to fix memory.',
   'Use list_memory_update_candidates to review proposed durable-memory corrections, deactivations, duplicate merges, or corrective notes. reconcile_memory propose mode is read-only by default; pass createUpdateCandidates=true only when persistent review proposals are wanted. Apply or reject update candidates only after explicit user approval.',
   'When resuming a known session, pass sessionId to bootstrap_context or call get_working_summary and get_session_working_context to load latest rolling handoff state separately from durable memory and checkpoint search results.',
+  'Embeddings are the supported retrieval-quality path. If db_info or bootstrap_context reports stale vector sources or failed embedding jobs, call list_embedding_jobs and process_embedding_jobs instead of treating lexical fallback as equivalent.',
   'If working on a repository while the MCP process cwd is elsewhere, pass repoPath or cwd so repo scope resolves to that checkout; repoPath takes precedence when both are provided.',
   'Treat scopeKey as the canonical repo memory key; pass an explicit normalized GitHub key when local paths differ across machines or the checkout cannot infer the right remote.',
   'Use remember for reviewed durable facts the user or assistant intentionally wants saved.',
@@ -201,6 +202,48 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
       },
     },
     async (args) => jsonResult(await app.rebuildEmbeddings(args)),
+  );
+
+  server.registerTool(
+    'process_embedding_jobs',
+    {
+      title: 'Process Embedding Jobs',
+      description:
+        'Process queued embedding jobs for durable memories, checkpoints, and memory candidates. Use to retry stale or failed vector index work independently from writes.',
+      inputSchema: {
+        ...scopedSchema,
+        batchSize: z.number().int().positive().optional(),
+        limit: z.number().int().positive().optional(),
+        retryFailed: z.boolean().optional(),
+        force: z.boolean().optional(),
+      },
+      annotations: {
+        title: 'Process Embedding Jobs',
+        readOnlyHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.processEmbeddingJobs(args)),
+  );
+
+  server.registerTool(
+    'list_embedding_jobs',
+    {
+      title: 'List Embedding Jobs',
+      description:
+        'List queued embedding job state. Jobs record source type/id, attempts, last error, status, and completion time.',
+      inputSchema: {
+        ...scopedSchema,
+        status: z.enum(['pending', 'processing', 'completed', 'failed']).optional(),
+        limit: z.number().int().positive().optional(),
+      },
+      annotations: {
+        title: 'List Embedding Jobs',
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.listEmbeddingJobs(args)),
   );
 
   server.registerTool(

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -34,12 +34,12 @@ const MCP_INSTRUCTIONS = [
   'For user corrections such as "너 잘못 알고 있잖아", "그거 아니야", "그건 X가 아니라 Y야", or "기억 수정해", call reconcile_memory. Show the basis for prior knowledge, assess conflicts, and only apply safe corrections when the user explicitly asks to fix memory.',
   'Use list_memory_update_candidates to review proposed durable-memory corrections, deactivations, duplicate merges, or corrective notes. reconcile_memory propose mode is read-only by default; pass createUpdateCandidates=true only when persistent review proposals are wanted. Apply or reject update candidates only after explicit user approval.',
   'When resuming a known session, pass sessionId to bootstrap_context or call get_working_summary and get_session_working_context to load latest rolling handoff state separately from durable memory and checkpoint search results.',
-  'Embeddings are the supported retrieval-quality path. If db_info or bootstrap_context reports stale vector sources or failed embedding jobs, call list_embedding_jobs and process_embedding_jobs instead of treating lexical fallback as equivalent.',
+  'Embeddings are the supported retrieval-quality path. Successful distill_checkpoint calls queue embedding jobs for the new checkpoint and memory candidates; process queued jobs with process_embedding_jobs. If db_info or bootstrap_context reports stale vector sources or failed embedding jobs, call list_embedding_jobs and process_embedding_jobs instead of treating lexical fallback as equivalent.',
   'If working on a repository while the MCP process cwd is elsewhere, pass repoPath or cwd so repo scope resolves to that checkout; repoPath takes precedence when both are provided.',
   'Treat scopeKey as the canonical repo memory key; pass an explicit normalized GitHub key when local paths differ across machines or the checkout cannot infer the right remote.',
   'Use remember for reviewed durable facts the user or assistant intentionally wants saved.',
-  'After distill_checkpoint, check memoryCandidateCount; if it is greater than zero, call list_memory_candidates and promote only reviewed durable facts with promote_memory_candidate or reject unsuitable candidates with reject_memory_candidate.',
-  'When session_status reports latestCheckpointMemoryCandidateCount, use list_memory_candidates before deciding what should become durable memory.',
+  'At closeout after distill_checkpoint, check memoryCandidateCount; if it is greater than zero, prefer suggest_memory_promotions and promote only reviewed durable facts with promote_memory_candidate or reject unsuitable candidates with reject_memory_candidate.',
+  'When session_status reports latestCheckpointMemoryCandidateCount at closeout, use suggest_memory_promotions or list_memory_candidates before deciding what should become durable memory.',
   'Keep local scope opt-in.',
 ].join(' ');
 

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -688,7 +688,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
         'Search relevant durable memories, checkpoints, and memory candidates for a user correction; explain the basis for existing knowledge, assess conflicts, and optionally apply safe memory corrections only when explicitly requested. Default mode=propose is read-only unless createUpdateCandidates=true persists review proposals; mode=apply_safe may correct durable memory or reject candidates when the correction is unambiguous.',
       inputSchema: {
         ...scopedSchema,
-        query: z.string(),
+        query: z.string().optional(),
         correction: z.string(),
         mode: z.enum(['propose', 'apply_safe']).optional(),
         sessionId: z.string().optional(),

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -26,6 +26,8 @@ const REMOTE_METHODS = [
   'getMemory',
   'search',
   'rebuildEmbeddings',
+  'processEmbeddingJobs',
+  'listEmbeddingJobs',
   'appendRaw',
   'listRawEvents',
   'listCheckpoints',

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -4,7 +4,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import Database from 'better-sqlite3';
 import * as sqliteVec from 'sqlite-vec';
 
-export const SCHEMA_VERSION = 13;
+export const SCHEMA_VERSION = 14;
 
 function nowIso() {
   return new Date().toISOString();
@@ -257,6 +257,26 @@ function hydrateMemoryUpdateCandidate(row) {
     appliedMemoryId: row.applied_memory_id,
     createdAt: row.created_at,
     reviewedAt: row.reviewed_at,
+  };
+}
+
+function hydrateEmbeddingJob(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    sourceType: row.source_type,
+    scopeType: row.scope_type,
+    scopeKey: row.scope_key,
+    recordId: row.record_id,
+    model: row.model,
+    dimensions: row.dimensions,
+    contentHash: row.content_hash,
+    status: row.status,
+    attempts: row.attempts,
+    lastError: row.last_error,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
   };
 }
 
@@ -563,6 +583,24 @@ export class ContextForgeStore {
         UNIQUE (scope_type, scope_key, merge_key)
       );
 
+      CREATE TABLE IF NOT EXISTS embedding_jobs (
+        id TEXT PRIMARY KEY,
+        source_type TEXT NOT NULL CHECK (source_type IN ('memory', 'checkpoint', 'memory_candidate')),
+        scope_type TEXT NOT NULL CHECK (scope_type IN ('shared', 'repo', 'local')),
+        scope_key TEXT NOT NULL,
+        record_id TEXT NOT NULL,
+        model TEXT NOT NULL,
+        dimensions INTEGER NOT NULL,
+        content_hash TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+        attempts INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        completed_at TEXT,
+        UNIQUE (source_type, record_id, model, dimensions)
+      );
+
       CREATE TABLE IF NOT EXISTS memory_update_candidates (
         id TEXT PRIMARY KEY,
         scope_type TEXT NOT NULL CHECK (scope_type IN ('shared', 'repo', 'local')),
@@ -620,6 +658,10 @@ export class ContextForgeStore {
         ON memory_candidate_index(checkpoint_id, candidate_index);
       CREATE INDEX IF NOT EXISTS idx_preference_occurrences_scope
         ON preference_occurrences(scope_type, scope_key, status, updated_at);
+      CREATE INDEX IF NOT EXISTS idx_embedding_jobs_status
+        ON embedding_jobs(status, updated_at);
+      CREATE INDEX IF NOT EXISTS idx_embedding_jobs_scope
+        ON embedding_jobs(scope_type, scope_key, status);
       CREATE INDEX IF NOT EXISTS idx_memory_update_candidates_scope
         ON memory_update_candidates(scope_type, scope_key, status, created_at);
     `);
@@ -649,6 +691,8 @@ export class ContextForgeStore {
     this.ensureColumn('memory_update_candidates', 'review_reason', 'TEXT');
     this.ensureColumn('memory_update_candidates', 'review_metadata_json', "TEXT NOT NULL DEFAULT '{}'");
     this.ensureColumn('memory_update_candidates', 'applied_memory_id', 'TEXT');
+    this.ensureColumn('embedding_jobs', 'last_error', 'TEXT');
+    this.ensureColumn('embedding_jobs', 'completed_at', 'TEXT');
     this.backfillMemoryCandidateIndexOnce();
     this.backfillPreferenceOccurrencesOnce();
     this.ensureMemoryFts();
@@ -687,6 +731,7 @@ export class ContextForgeStore {
         memoryCandidates: count('memory_candidate_index'),
         preferenceOccurrences: count('preference_occurrences'),
         memoryUpdateCandidates: count('memory_update_candidates'),
+        embeddingJobs: count('embedding_jobs'),
         embeddings: embeddingIndexExists ? count('embedding_index') : 0,
       },
       vector: {
@@ -943,6 +988,272 @@ export class ContextForgeStore {
         };
       })
       .filter((source) => force || source.indexedContentHash !== source.contentHash);
+  }
+
+  countEmbeddingSourceTotals({ scopeType = null, scopeKey = null } = {}) {
+    const scopedWhere = (alias, values) => {
+      const conditions = [];
+      if (scopeType) {
+        conditions.push(`${alias}.scope_type = ?`);
+        values.push(scopeType);
+      }
+      if (scopeKey) {
+        conditions.push(`${alias}.scope_key = ?`);
+        values.push(scopeKey);
+      }
+      return conditions.length ? `AND ${conditions.join(' AND ')}` : '';
+    };
+    const memoryValues = [];
+    const checkpointValues = [];
+    const candidateValues = [];
+    const memory = this.db
+      .prepare(`
+        SELECT COUNT(*) AS count FROM memories
+        WHERE status = 'active' ${scopedWhere('memories', memoryValues)}
+      `)
+      .get(...memoryValues).count;
+    const checkpoint = this.db
+      .prepare(`
+        SELECT COUNT(*) AS count FROM checkpoints
+        WHERE 1 = 1 ${scopedWhere('checkpoints', checkpointValues)}
+      `)
+      .get(...checkpointValues).count;
+    const memoryCandidate = this.db
+      .prepare(`
+        SELECT COUNT(*) AS count FROM memory_candidate_index
+        WHERE status IN ('pending', 'promoted') ${scopedWhere('memory_candidate_index', candidateValues)}
+      `)
+      .get(...candidateValues).count;
+    return {
+      total: memory + checkpoint + memoryCandidate,
+      bySourceType: {
+        memory,
+        checkpoint,
+        memory_candidate: memoryCandidate,
+      },
+    };
+  }
+
+  embeddingCoverage({ scopeType = null, scopeKey = null, model, dimensions }) {
+    const totals = this.countEmbeddingSourceTotals({ scopeType, scopeKey });
+    const embeddingIndexExists = this.db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'embedding_index'")
+      .get();
+    if (!embeddingIndexExists) {
+      return {
+        model,
+        dimensions,
+        totalSources: totals.total,
+        indexedSources: 0,
+        staleSources: totals.total,
+        bySourceType: Object.fromEntries(
+          Object.entries(totals.bySourceType).map(([sourceType, total]) => [
+            sourceType,
+            { total, indexed: 0, stale: total },
+          ]),
+        ),
+      };
+    }
+    const sourceOptions = { scopeType, scopeKey, model, dimensions, force: true };
+    const sources = [
+      ...this.listMemoryEmbeddingSources(sourceOptions),
+      ...this.listCheckpointEmbeddingSources(sourceOptions),
+      ...this.listMemoryCandidateEmbeddingSources(sourceOptions),
+    ];
+    const bySourceType = {};
+    let indexedSources = 0;
+    let staleSources = 0;
+    for (const source of sources) {
+      const entry = bySourceType[source.sourceType] || { total: 0, indexed: 0, stale: 0 };
+      entry.total += 1;
+      if (source.indexedContentHash === source.contentHash) {
+        entry.indexed += 1;
+        indexedSources += 1;
+      } else {
+        entry.stale += 1;
+        staleSources += 1;
+      }
+      bySourceType[source.sourceType] = entry;
+    }
+    return {
+      model,
+      dimensions,
+      totalSources: sources.length,
+      indexedSources,
+      staleSources,
+      bySourceType,
+    };
+  }
+
+  enqueueEmbeddingJobs(sources, { model, dimensions, force = false } = {}) {
+    if (!model) throw new Error('model is required.');
+    const parsedDimensions = validateDimensions(dimensions);
+    const timestamp = nowIso();
+    const upsert = this.db.prepare(`
+      INSERT INTO embedding_jobs (
+        id, source_type, scope_type, scope_key, record_id, model, dimensions,
+        content_hash, status, attempts, last_error, created_at, updated_at, completed_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', 0, NULL, ?, ?, NULL)
+      ON CONFLICT(source_type, record_id, model, dimensions) DO UPDATE SET
+        scope_type = excluded.scope_type,
+        scope_key = excluded.scope_key,
+        content_hash = excluded.content_hash,
+        status = CASE
+          WHEN ? THEN 'pending'
+          WHEN embedding_jobs.content_hash != excluded.content_hash THEN 'pending'
+          WHEN embedding_jobs.status = 'failed' THEN 'pending'
+          ELSE embedding_jobs.status
+        END,
+        last_error = CASE
+          WHEN ? OR embedding_jobs.content_hash != excluded.content_hash OR embedding_jobs.status = 'failed' THEN NULL
+          ELSE embedding_jobs.last_error
+        END,
+        completed_at = CASE
+          WHEN ? OR embedding_jobs.content_hash != excluded.content_hash OR embedding_jobs.status = 'failed' THEN NULL
+          ELSE embedding_jobs.completed_at
+        END,
+        updated_at = excluded.updated_at
+    `);
+    const jobs = [];
+    for (const source of sources) {
+      upsert.run(
+        randomUUID(),
+        source.sourceType,
+        source.scopeType,
+        source.scopeKey,
+        source.recordId,
+        model,
+        parsedDimensions,
+        source.contentHash,
+        timestamp,
+        timestamp,
+        force ? 1 : 0,
+        force ? 1 : 0,
+        force ? 1 : 0,
+      );
+      jobs.push(
+        this.getEmbeddingJob({
+          sourceType: source.sourceType,
+          recordId: source.recordId,
+          model,
+          dimensions: parsedDimensions,
+        }),
+      );
+    }
+    return jobs;
+  }
+
+  getEmbeddingJob({ sourceType, recordId, model, dimensions }) {
+    const row = this.db
+      .prepare(`
+        SELECT * FROM embedding_jobs
+        WHERE source_type = ? AND record_id = ? AND model = ? AND dimensions = ?
+      `)
+      .get(sourceType, recordId, model, Number(dimensions));
+    return hydrateEmbeddingJob(row);
+  }
+
+  listEmbeddingJobs({ scopeType = null, scopeKey = null, status = null, limit = null } = {}) {
+    const conditions = [];
+    const values = [];
+    if (scopeType) {
+      conditions.push('scope_type = ?');
+      values.push(scopeType);
+    }
+    if (scopeKey) {
+      conditions.push('scope_key = ?');
+      values.push(scopeKey);
+    }
+    if (status) {
+      conditions.push('status = ?');
+      values.push(status);
+    }
+    const parsedLimit = limit == null ? null : Number(limit);
+    const limitClause = Number.isInteger(parsedLimit) && parsedLimit > 0 ? 'LIMIT ?' : '';
+    if (limitClause) {
+      values.push(parsedLimit);
+    }
+    return this.db
+      .prepare(`
+        SELECT * FROM embedding_jobs
+        ${conditions.length ? `WHERE ${conditions.join(' AND ')}` : ''}
+        ORDER BY updated_at ASC, id ASC
+        ${limitClause}
+      `)
+      .all(...values)
+      .map(hydrateEmbeddingJob);
+  }
+
+  countEmbeddingJobs({ scopeType = null, scopeKey = null } = {}) {
+    const conditions = [];
+    const values = [];
+    if (scopeType) {
+      conditions.push('scope_type = ?');
+      values.push(scopeType);
+    }
+    if (scopeKey) {
+      conditions.push('scope_key = ?');
+      values.push(scopeKey);
+    }
+    const rows = this.db
+      .prepare(`
+        SELECT status, COUNT(*) AS count FROM embedding_jobs
+        ${conditions.length ? `WHERE ${conditions.join(' AND ')}` : ''}
+        GROUP BY status
+      `)
+      .all(...values);
+    const result = { pending: 0, processing: 0, completed: 0, failed: 0 };
+    for (const row of rows) {
+      result[row.status] = row.count;
+    }
+    return result;
+  }
+
+  markEmbeddingJobProcessing(jobId) {
+    const timestamp = nowIso();
+    const row = this.db
+      .prepare(`
+        UPDATE embedding_jobs
+        SET status = 'processing',
+            attempts = attempts + 1,
+            updated_at = ?
+        WHERE id = ?
+        RETURNING *
+      `)
+      .get(timestamp, jobId);
+    return hydrateEmbeddingJob(row);
+  }
+
+  markEmbeddingJobCompleted(jobId) {
+    const timestamp = nowIso();
+    const row = this.db
+      .prepare(`
+        UPDATE embedding_jobs
+        SET status = 'completed',
+            last_error = NULL,
+            completed_at = ?,
+            updated_at = ?
+        WHERE id = ?
+        RETURNING *
+      `)
+      .get(timestamp, timestamp, jobId);
+    return hydrateEmbeddingJob(row);
+  }
+
+  markEmbeddingJobFailed(jobId, error) {
+    const timestamp = nowIso();
+    const row = this.db
+      .prepare(`
+        UPDATE embedding_jobs
+        SET status = 'failed',
+            last_error = ?,
+            updated_at = ?
+        WHERE id = ?
+        RETURNING *
+      `)
+      .get(String(error?.message || error || 'Embedding job failed.'), timestamp, jobId);
+    return hydrateEmbeddingJob(row);
   }
 
   upsertEmbedding({
@@ -1455,6 +1766,26 @@ export class ContextForgeStore {
       `)
       .get(scopeType, scopeKey, key);
     return hydrateMemory(row);
+  }
+
+  getMemoryById({ scopeType, scopeKey, memoryId }) {
+    const row = this.db
+      .prepare(`
+        SELECT * FROM memories
+        WHERE scope_type = ? AND scope_key = ? AND id = ?
+      `)
+      .get(scopeType, scopeKey, memoryId);
+    return hydrateMemory(row);
+  }
+
+  getCheckpointById({ scopeType, scopeKey, checkpointId }) {
+    const row = this.db
+      .prepare(`
+        SELECT * FROM checkpoints
+        WHERE scope_type = ? AND scope_key = ? AND id = ?
+      `)
+      .get(scopeType, scopeKey, checkpointId);
+    return hydrateCheckpoint(row);
   }
 
   searchMemoryIndex({ scopeType, scopeKey, ftsQuery, limit = 50 }) {

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -1105,6 +1105,10 @@ export class ContextForgeStore {
           WHEN embedding_jobs.status = 'failed' THEN 'pending'
           ELSE embedding_jobs.status
         END,
+        attempts = CASE
+          WHEN ? OR embedding_jobs.content_hash != excluded.content_hash THEN 0
+          ELSE embedding_jobs.attempts
+        END,
         last_error = CASE
           WHEN ? OR embedding_jobs.content_hash != excluded.content_hash OR embedding_jobs.status = 'failed' THEN NULL
           ELSE embedding_jobs.last_error
@@ -1128,6 +1132,7 @@ export class ContextForgeStore {
         source.contentHash,
         timestamp,
         timestamp,
+        force ? 1 : 0,
         force ? 1 : 0,
         force ? 1 : 0,
         force ? 1 : 0,
@@ -1219,10 +1224,37 @@ export class ContextForgeStore {
             attempts = attempts + 1,
             updated_at = ?
         WHERE id = ?
+          AND status IN ('pending', 'failed')
         RETURNING *
       `)
       .get(timestamp, jobId);
     return hydrateEmbeddingJob(row);
+  }
+
+  resetStaleEmbeddingJobs({ scopeType = null, scopeKey = null, staleBeforeIso }) {
+    if (!staleBeforeIso) throw new Error('staleBeforeIso is required.');
+    const conditions = ["status = 'processing'", 'updated_at < ?'];
+    const values = [staleBeforeIso];
+    if (scopeType) {
+      conditions.push('scope_type = ?');
+      values.push(scopeType);
+    }
+    if (scopeKey) {
+      conditions.push('scope_key = ?');
+      values.push(scopeKey);
+    }
+    const result = this.db
+      .prepare(`
+        UPDATE embedding_jobs
+        SET status = 'pending',
+            updated_at = ?
+        WHERE ${conditions.join(' AND ')}
+      `)
+      .run(nowIso(), ...values);
+    return {
+      reset: result.changes,
+      staleBeforeIso,
+    };
   }
 
   markEmbeddingJobCompleted(jobId) {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -192,6 +192,10 @@ test('dbInfo initializes a fresh SQLite store', async () => {
 
   assert.equal(info.schemaVersion, SCHEMA_VERSION);
   assert.equal(info.tables.memories, 0);
+  assert.equal(info.tables.embeddingJobs, 0);
+  assert.equal(info.embeddings.requiredForQuality, true);
+  assert.equal(info.embeddings.degraded, true);
+  assert.deepEqual(info.embeddings.jobs, { pending: 0, processing: 0, completed: 0, failed: 0 });
   assert.match(info.dbPath, /contextforge\.db$/);
 });
 
@@ -2487,7 +2491,7 @@ test('hybrid ranking keeps strong lexical matches ahead of weak vector-only matc
   assert.equal(results[1].retrieval.method, 'vector');
 });
 
-test('distillCheckpoint embeds the new checkpoint and candidates when embeddings are enabled', async () => {
+test('distillCheckpoint queues embedding jobs and processEmbeddingJobs indexes them', async () => {
   const dataDir = await makeTempDir();
   const embeddingProvider = {
     name: 'test-vector',
@@ -2547,12 +2551,27 @@ test('distillCheckpoint embeds the new checkpoint and candidates when embeddings
     sessionId: 'distill-vector-session',
   });
 
-  assert.equal(checkpoint.embedding.embedded, 2);
+  assert.equal(checkpoint.embedding.reason, 'queued');
+  assert.equal(checkpoint.embedding.queued, 2);
   assert.deepEqual(checkpoint.embedding.bySourceType, {
     checkpoint: 1,
     memory_candidate: 1,
   });
+  assert.equal(app.dbInfo().tables.embeddings, 0);
+  assert.equal(app.dbInfo().embeddings.jobs.pending, 2);
+
+  const processed = await app.processEmbeddingJobs({
+    scope: 'repo',
+    scopeKey: 'repo-distill-vector',
+  });
+  assert.equal(processed.embedded, 2);
+  assert.deepEqual(processed.bySourceType, {
+    checkpoint: 1,
+    memory_candidate: 1,
+  });
   assert.equal(app.dbInfo().tables.embeddings, 2);
+  assert.equal(app.dbInfo().embeddings.jobs.completed, 2);
+  assert.equal(app.dbInfo().embeddings.coverage.staleSources, 0);
 
   const checkpointResults = await app.search({
     scope: 'repo',
@@ -2573,7 +2592,7 @@ test('distillCheckpoint embeds the new checkpoint and candidates when embeddings
   assert.equal(candidateResults[0].retrieval.vectorModel, 'test-embedding');
 });
 
-test('distillCheckpoint reports partial embedding progress when a later upsert fails', async () => {
+test('embedding jobs can fail and be retried independently after distill succeeds', async () => {
   const dataDir = await makeTempDir();
   const embeddingProvider = {
     name: 'test-vector',
@@ -2628,10 +2647,23 @@ test('distillCheckpoint reports partial embedding progress when a later upsert f
     sessionId: 'partial-embedding-session',
   });
 
-  assert.equal(checkpoint.embedding.reason, 'embedding_failed');
-  assert.equal(checkpoint.embedding.embedded, 1);
-  assert.equal(checkpoint.embedding.partialFailure, true);
-  assert.deepEqual(checkpoint.embedding.bySourceType, { checkpoint: 1 });
+  assert.equal(checkpoint.embedding.reason, 'queued');
+  assert.equal(checkpoint.embedding.queued, 2);
+  const processed = await app.processEmbeddingJobs({
+    scope: 'repo',
+    scopeKey: 'repo-partial-embedding',
+  });
+  assert.equal(processed.embedded, 1);
+  assert.equal(processed.failed, 1);
+  assert.deepEqual(processed.bySourceType, { checkpoint: 1 });
+  const failedJobs = app.listEmbeddingJobs({
+    scope: 'repo',
+    scopeKey: 'repo-partial-embedding',
+    status: 'failed',
+  });
+  assert.equal(failedJobs.length, 1);
+  assert.match(failedJobs[0].lastError, /dimensions/);
+  assert.equal(app.dbInfo().embeddings.coverage.staleSources, 1);
 });
 
 test('search unions lexical candidates with FTS candidates', () => {
@@ -5258,6 +5290,8 @@ test('REMOTE_METHODS exposes resume, suggestion, auto-promotion, and reconciliat
   assert.ok(REMOTE_METHODS.includes('applyMemoryUpdateCandidate'));
   assert.ok(REMOTE_METHODS.includes('rejectMemoryUpdateCandidate'));
   assert.ok(REMOTE_METHODS.includes('skipMemoryUpdateCandidate'));
+  assert.ok(REMOTE_METHODS.includes('processEmbeddingJobs'));
+  assert.ok(REMOTE_METHODS.includes('listEmbeddingJobs'));
   assert.ok(REMOTE_METHODS.includes('listCheckpoints'));
   assert.ok(REMOTE_METHODS.includes('getSessionWorkingContext'));
   assert.ok(REMOTE_METHODS.includes('upsertSessionWorkingContext'));
@@ -5423,10 +5457,12 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'get_session_working_context',
       'get_working_summary',
       'list_checkpoints',
+      'list_embedding_jobs',
       'list_memory_candidates',
       'list_memory_events',
       'list_memory_update_candidates',
       'list_preference_occurrences',
+      'process_embedding_jobs',
       'promote_memory',
       'promote_memory_candidate',
       'prune_raw_events',
@@ -5456,6 +5492,10 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     assert.ok(listCheckpointsTool.inputSchema.properties.level);
     const distillUsageTool = toolList.tools.find((tool) => tool.name === 'distill_usage');
     assert.ok(distillUsageTool.inputSchema.properties.charsPerToken);
+    const processEmbeddingJobsTool = toolList.tools.find((tool) => tool.name === 'process_embedding_jobs');
+    assert.ok(processEmbeddingJobsTool.inputSchema.properties.retryFailed);
+    const listEmbeddingJobsTool = toolList.tools.find((tool) => tool.name === 'list_embedding_jobs');
+    assert.ok(listEmbeddingJobsTool.inputSchema.properties.status);
     const bootstrapTool = toolList.tools.find((tool) => tool.name === 'bootstrap_context');
     assert.ok(bootstrapTool.inputSchema.properties.sessionId);
     assert.ok(bootstrapTool.inputSchema.properties.rawTailLimit);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -2633,6 +2633,15 @@ test('distillCheckpoint queues embedding jobs and processEmbeddingJobs indexes t
   assert.equal(checkpointResults[0].checkpoint.id, checkpoint.id);
   assert.equal(checkpointResults[0].retrieval.method, 'vector');
 
+  const bootstrap = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-distill-vector',
+    query: 'checkpoint search',
+  });
+  const bootstrapCheckpoint = bootstrap.results.find((item) => item.type === 'checkpoint');
+  assert.equal(bootstrapCheckpoint.trust, 'credible_recent_handoff');
+  assert.match(bootstrapCheckpoint.whyUse, /Credible recent handoff state/);
+
   const candidateResults = await app.search({
     scope: 'repo',
     scopeKey: 'repo-distill-vector',
@@ -5032,6 +5041,18 @@ test('reconcileMemory proposes by default and apply_safe only changes unambiguou
     sessionId: 'reconcile-session',
   });
 
+  const proposedWithoutQuery = await app.reconcileMemory({
+    scope: 'repo',
+    scopeKey: 'reconcile-repo',
+    sessionId: 'reconcile-session',
+    correction: 'API REST only transport is wrong; the API supports REST and GraphQL.',
+  });
+  assert.equal(
+    proposedWithoutQuery.query,
+    'API REST only transport is wrong; the API supports REST and GraphQL.',
+  );
+  assert.ok(proposedWithoutQuery.basis.some((item) => item.type === 'memory'));
+
   const proposed = await app.reconcileMemory({
     scope: 'repo',
     scopeKey: 'reconcile-repo',
@@ -5124,6 +5145,16 @@ test('reconcileMemory proposes by default and apply_safe only changes unambiguou
   });
   assert.ok(live.warnings.some((warning) => warning.code === 'live_state_verification_required'));
   assert.equal(live.appliedActions.length, 0);
+
+  const koreanLive = await app.reconcileMemory({
+    scope: 'repo',
+    scopeKey: 'reconcile-repo',
+    sessionId: 'reconcile-session',
+    correction: '그 PR 아직 안 머지됐잖아. 이슈 상태랑 원격 브랜치를 확인해야 해.',
+    mode: 'apply_safe',
+  });
+  assert.ok(koreanLive.warnings.some((warning) => warning.code === 'live_state_verification_required'));
+  assert.equal(koreanLive.appliedActions.length, 0);
 });
 
 test('memory update candidates can be rejected without mutating memory', async () => {
@@ -5577,6 +5608,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     assert.ok(autoPromoteTool.inputSchema.properties.allowedCategories);
     const reconcileTool = toolList.tools.find((tool) => tool.name === 'reconcile_memory');
     assert.ok(reconcileTool.inputSchema.properties.correction);
+    assert.ok(!reconcileTool.inputSchema.required?.includes('query'));
     assert.ok(reconcileTool.inputSchema.properties.mode);
     assert.ok(reconcileTool.inputSchema.properties.createUpdateCandidates);
     const appendRawTool = toolList.tools.find((tool) => tool.name === 'append_raw');

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -194,9 +194,23 @@ test('dbInfo initializes a fresh SQLite store', async () => {
   assert.equal(info.tables.memories, 0);
   assert.equal(info.tables.embeddingJobs, 0);
   assert.equal(info.embeddings.requiredForQuality, true);
+  assert.equal(info.embeddings.staleAfterMs, 10 * 60 * 1000);
   assert.equal(info.embeddings.degraded, true);
   assert.deepEqual(info.embeddings.jobs, { pending: 0, processing: 0, completed: 0, failed: 0 });
   assert.match(info.dbPath, /contextforge\.db$/);
+});
+
+test('dbInfo reports configured embedding stale timeout', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_EMBEDDINGS_STALE_AFTER_MS: '1234',
+    },
+    cwd: process.cwd(),
+  });
+
+  assert.equal(app.dbInfo().embeddings.staleAfterMs, 1234);
 });
 
 test('ContextForgeStore.withTransaction returns results and rolls back on throw', async () => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -237,6 +237,43 @@ test('ContextForgeStore.withTransaction returns results and rolls back on throw'
   }
 });
 
+test('embedding jobs claim atomically and stale processing jobs reset', async () => {
+  const dataDir = await makeTempDir();
+  const store = new ContextForgeStore({ dataDir });
+  try {
+    const [job] = store.enqueueEmbeddingJobs(
+      [
+        {
+          sourceType: 'memory',
+          scopeType: 'repo',
+          scopeKey: 'embedding-job-repo',
+          recordId: 'memory-1',
+          contentHash: 'hash-1',
+        },
+      ],
+      { model: 'test-embedding', dimensions: 3 },
+    );
+
+    const claimed = store.markEmbeddingJobProcessing(job.id);
+    assert.equal(claimed.status, 'processing');
+    assert.equal(claimed.attempts, 1);
+    assert.equal(store.markEmbeddingJobProcessing(job.id), null);
+
+    store.db.prepare("UPDATE embedding_jobs SET updated_at = '2000-01-01T00:00:00.000Z' WHERE id = ?").run(job.id);
+    const reset = store.resetStaleEmbeddingJobs({
+      scopeType: 'repo',
+      scopeKey: 'embedding-job-repo',
+      staleBeforeIso: '2000-01-01T00:00:01.000Z',
+    });
+    assert.equal(reset.reset, 1);
+    const reclaimed = store.markEmbeddingJobProcessing(job.id);
+    assert.equal(reclaimed.status, 'processing');
+    assert.equal(reclaimed.attempts, 2);
+  } finally {
+    store.close();
+  }
+});
+
 test('session working context is mutable scoped session state', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
@@ -2599,7 +2636,7 @@ test('embedding jobs can fail and be retried independently after distill succeed
     model: 'test-embedding',
     dimensions: 3,
     async embed(texts) {
-      return texts.map((_, index) => (index === 0 ? [1, 0, 0] : [0, 1]));
+      return texts.map((text) => (String(text).includes('bad-candidate-vector') ? [0, 1] : [1, 0, 0]));
     },
   };
   const app = createContextForge({


### PR DESCRIPTION
## Summary
- add an embedding_jobs table with queued, processing, completed, and failed states
- queue checkpoint/candidate embeddings after distill so writes succeed before vector work
- add processEmbeddingJobs/listEmbeddingJobs across core, CLI, MCP, and remote client
- report embedding queue and stale coverage in dbInfo/bootstrap storage metadata
- document embedding job operations and the embedding-backed retrieval expectation

## Validation
- npm test
- git diff --check

Closes #77
Closes #82