### PR TITLE
fix: report remote access mode for HTTP callers

### DIFF
--- a/docs/skills/contextforge-memory/SKILL.md
+++ b/docs/skills/contextforge-memory/SKILL.md
@@ -35,10 +35,11 @@ Always set scope intentionally:
 
 Before relying on results, check connection metadata and storage authority from `bootstrap_context` or `db_info`:
 
-- `connection.mode: "remote-client"`: this agent is delegating to a remote ContextForge server.
-- `connection.mode: "http-server"`: the tool is running on the ContextForge HTTP server itself.
+- `connection.mode: "remote-client"`: this agent reaches ContextForge through HTTP or a remote wrapper.
+- `connection.mode: "http-server"`: the tool is running inside the ContextForge HTTP server process.
 - `connection.mode: "direct-local"`: the tool is running as a local ContextForge process.
-- `storageMode`: storage used by the responding ContextForge process.
+- top-level `storageMode`: storage used by the responding ContextForge process.
+- `connection.server`: server process details behind a remote call, when present.
 - `remote-client` access means server-backed canonical memory for the configured scope.
 - `direct-local` with `local` or `project-local` storage is local context unless the repo `AGENTS.md` says otherwise.
 

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -26,7 +26,7 @@ const MCP_INSTRUCTIONS = [
   'Use ContextForge for scoped memory retrieval on demand.',
   'At the start of non-trivial project work, call bootstrap_context with repoPath, cwd, or an explicit scopeKey. It summarizes storage authority, vector readiness, repo semantic retrieval results, and trust hints in one response.',
   'bootstrap_context does not create a session. In Codex or Claude Code auto-ingest environments, preserve or recover the adapter session id such as codex:<native-session-id> or claude_code:<native-session-id> before session_status, distill_checkpoint, or closeout promotion. Use begin_session only for manual ContextForge evidence streams where the agent will call append_raw itself; do not create a fresh cf_... session at closeout to review candidates from an existing Codex/Claude session.',
-  'Use db_info connection metadata for access path: direct-local, http-server, or remote-client. storageMode describes the responding ContextForge process.',
+  'Use db_info connection metadata for access path: remote-client for HTTP or remote-wrapper callers, http-server for the server process itself, or direct-local for local processes. Top-level storageMode describes the responding ContextForge process; connection.server may describe the server-owned store behind a remote call.',
   'Search result types have different trust roles: memory is reviewed durable fact or decision; checkpoint is credible recent handoff state for continuity, planning, prior intent, recent decisions, and unfinished work, but mutable live-state claims must be verified with git/GitHub/CI/runtime/migrations before acting; memory_candidate is unreviewed promotion material and not durable truth.',
   'For start/resume requests such as "지난 환경 작업과 동기화", "어제 하던 거 이어서", "previous work", or "continue", call sync_resume_context. Use checkpoints actively as handoff notes, then verify mutable state with git/GitHub/CI/runtime/migrations. Do not propose memory promotions during resume sync.',
   'For closeout triggers only, call suggest_memory_promotions with the current sessionId or the checkpointId returned by distill_checkpoint: after this agent merges a PR, after the user says they merged and the agent syncs main/cleans branches, or when the user explicitly says today\'s work is done. Suggest at most 1-3 durable memory promotions and never promote automatically.',
@@ -60,7 +60,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Database Info',
       description:
-        'Inspect ContextForge connection metadata, storage backend, table counts, raw retention, and sqlite-vec/embeddings readiness. Use connection.mode for access path; storageMode describes the responding process.',
+        'Inspect ContextForge connection metadata, storage backend, table counts, raw retention, and sqlite-vec/embeddings readiness. Use connection.mode for caller access path; top-level storageMode describes the responding process.',
       inputSchema: {},
       annotations: {
         title: 'Database Info',

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -114,6 +114,14 @@ export function createRemoteContextForge(config, options = {}) {
   const api = { config };
 
   function remoteClientConnection(serverConnection) {
+    if (serverConnection?.mode === 'remote-client') {
+      return {
+        ...serverConnection,
+        viewpoint: 'this client delegates to a remote ContextForge server',
+        remoteUrl: config.remote.url,
+        clientStorageMode: config.storageMode,
+      };
+    }
     return {
       mode: 'remote-client',
       viewpoint: 'this client delegates to a remote ContextForge server',
@@ -153,7 +161,7 @@ export function createRemoteContextForge(config, options = {}) {
         });
         return {
           ...result,
-          connection: remoteClientConnection(result.connection || null),
+          connection: remoteClientConnection(result.connection || result.storage?.connection || null),
           storage: {
             ...result.storage,
             mode: 'remote',

--- a/src/server.js
+++ b/src/server.js
@@ -90,6 +90,52 @@ function isAuthorized(request, token) {
   return timingSafeStringEqual(request.headers.authorization, `Bearer ${token}`);
 }
 
+function remoteAccessConnection(serverConnection, transport) {
+  return {
+    mode: 'remote-client',
+    transport,
+    viewpoint: 'this caller reaches ContextForge through a remote HTTP endpoint',
+    storageMode: 'remote',
+    storageAuthority: 'canonical',
+    server: serverConnection || null,
+    note: 'This response crossed a ContextForge HTTP boundary. server.storageMode describes the server-owned store.',
+  };
+}
+
+function wrapRemoteAccessResult(result, transport) {
+  if (!result || typeof result !== 'object') {
+    return result;
+  }
+  if (result.connection) {
+    return {
+      ...result,
+      connection: remoteAccessConnection(result.connection, transport),
+    };
+  }
+  if (result.storage?.connection) {
+    return {
+      ...result,
+      storage: {
+        ...result.storage,
+        connection: remoteAccessConnection(result.storage.connection, transport),
+      },
+    };
+  }
+  return result;
+}
+
+function createRemoteAccessApp(app, transport) {
+  return new Proxy(app, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+      if (!['dbInfo', 'bootstrapContext', 'syncResumeContext'].includes(property) || typeof value !== 'function') {
+        return value;
+      }
+      return async (...args) => wrapRemoteAccessResult(await value.apply(target, args), transport);
+    },
+  });
+}
+
 function serverStorageEnv(env) {
   const storageMode = env.CONTEXTFORGE_SERVER_STORAGE_MODE || env.CONTEXTFORGE_STORAGE_MODE;
   return {
@@ -117,7 +163,7 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
         sendJson(response, 401, { error: { message: 'Unauthorized.' } });
         return;
       }
-      const mcpServer = createContextForgeMcpServer({ app: serverApp });
+      const mcpServer = createContextForgeMcpServer({ app: createRemoteAccessApp(serverApp, 'http-mcp') });
       try {
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: undefined,
@@ -162,7 +208,7 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
     try {
       const options = await readJsonBody(request, { maxBodyBytes });
       const result = await serverApp[method](options);
-      sendJson(response, 200, { result });
+      sendJson(response, 200, { result: wrapRemoteAccessResult(result, 'http-api') });
     } catch (error) {
       sendJson(response, error.statusCode || 500, {
         error: {

--- a/src/server.js
+++ b/src/server.js
@@ -106,29 +106,30 @@ function wrapRemoteAccessResult(result, transport) {
   if (!result || typeof result !== 'object') {
     return result;
   }
+  let wrapped = result;
   if (result.connection) {
-    return {
-      ...result,
+    wrapped = {
+      ...wrapped,
       connection: remoteAccessConnection(result.connection, transport),
     };
   }
-  if (result.storage?.connection) {
-    return {
-      ...result,
+  if (wrapped.storage?.connection) {
+    wrapped = {
+      ...wrapped,
       storage: {
-        ...result.storage,
-        connection: remoteAccessConnection(result.storage.connection, transport),
+        ...wrapped.storage,
+        connection: remoteAccessConnection(wrapped.storage.connection, transport),
       },
     };
   }
-  return result;
+  return wrapped;
 }
 
 function createRemoteAccessApp(app, transport) {
   return new Proxy(app, {
     get(target, property, receiver) {
       const value = Reflect.get(target, property, receiver);
-      if (!['dbInfo', 'bootstrapContext', 'syncResumeContext'].includes(property) || typeof value !== 'function') {
+      if (typeof value !== 'function') {
         return value;
       }
       return async (...args) => wrapRemoteAccessResult(await value.apply(target, args), transport);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -5842,6 +5842,18 @@ test('MCP streamable HTTP endpoint exposes core tools with bearer auth', async (
     assert.equal(bootstrap.structuredContent.result.storage.connection.transport, 'http-mcp');
     assert.equal(bootstrap.structuredContent.result.storage.connection.server.mode, 'direct-local');
 
+    const syncResume = await client.callTool({
+      name: 'sync_resume_context',
+      arguments: {
+        scope: 'repo',
+        scopeKey: 'http-mcp-repo',
+        query: 'canonical remote previous work',
+      },
+    });
+    assert.equal(syncResume.structuredContent.result.storage.connection.mode, 'remote-client');
+    assert.equal(syncResume.structuredContent.result.storage.connection.transport, 'http-mcp');
+    assert.equal(syncResume.structuredContent.result.storage.connection.server.mode, 'direct-local');
+
     await client.callTool({
       name: 'append_raw',
       arguments: {
@@ -5934,6 +5946,24 @@ test('HTTP v0 callers see remote-client connection metadata', async () => {
     assert.equal(body.result.connection.transport, 'http-api');
     assert.equal(body.result.connection.server.mode, 'http-server');
     assert.equal(body.result.connection.server.storageMode, 'project-local');
+
+    const resumeResponse = await fetch(`${remote.url}/v0/syncResumeContext`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        scope: 'repo',
+        scopeKey: 'http-api-repo',
+        query: 'previous work',
+      }),
+    });
+    assert.equal(resumeResponse.status, 200);
+    const resumeBody = await resumeResponse.json();
+    assert.equal(resumeBody.result.storage.connection.mode, 'remote-client');
+    assert.equal(resumeBody.result.storage.connection.transport, 'http-api');
+    assert.equal(resumeBody.result.storage.connection.server.mode, 'http-server');
   } finally {
     await remote.close();
   }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -5804,6 +5804,11 @@ test('MCP streamable HTTP endpoint exposes core tools with bearer auth', async (
     const toolList = await client.listTools();
     assert.ok(toolList.tools.some((tool) => tool.name === 'remember'));
 
+    const infoResult = await client.callTool({ name: 'db_info', arguments: {} });
+    assert.equal(infoResult.structuredContent.result.connection.mode, 'remote-client');
+    assert.equal(infoResult.structuredContent.result.connection.transport, 'http-mcp');
+    assert.equal(infoResult.structuredContent.result.connection.server.mode, 'direct-local');
+
     const remembered = await client.callTool({
       name: 'remember',
       arguments: {
@@ -5824,6 +5829,18 @@ test('MCP streamable HTTP endpoint exposes core tools with bearer auth', async (
       },
     });
     assert.equal(searched.structuredContent.result[0].memory.key, 'http-mcp-rule');
+
+    const bootstrap = await client.callTool({
+      name: 'bootstrap_context',
+      arguments: {
+        scope: 'repo',
+        scopeKey: 'http-mcp-repo',
+        query: 'canonical remote',
+      },
+    });
+    assert.equal(bootstrap.structuredContent.result.storage.connection.mode, 'remote-client');
+    assert.equal(bootstrap.structuredContent.result.storage.connection.transport, 'http-mcp');
+    assert.equal(bootstrap.structuredContent.result.storage.connection.server.mode, 'direct-local');
 
     await client.callTool({
       name: 'append_raw',
@@ -5858,6 +5875,67 @@ test('MCP streamable HTTP endpoint exposes core tools with bearer auth', async (
     await client.close();
     await remote.close();
     app.close();
+  }
+});
+
+test('MCP streamable HTTP db_info reports remote-client for HTTP callers', async () => {
+  const dataDir = await makeTempDir();
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+    },
+  });
+  const client = new Client({ name: 'contextforge-http-dbinfo-client', version: '0.0.0' }, { capabilities: {} });
+  const transport = new StreamableHTTPClientTransport(new URL(`${remote.url}/mcp`), {
+    requestInit: {
+      headers: {
+        authorization: 'Bearer test-token',
+      },
+    },
+  });
+
+  try {
+    await client.connect(transport);
+    const info = await client.callTool({ name: 'db_info', arguments: {} });
+    assert.equal(info.structuredContent.result.connection.mode, 'remote-client');
+    assert.equal(info.structuredContent.result.connection.transport, 'http-mcp');
+    assert.equal(info.structuredContent.result.connection.server.mode, 'http-server');
+    assert.equal(info.structuredContent.result.connection.server.storageMode, 'project-local');
+  } finally {
+    await client.close();
+    await remote.close();
+  }
+});
+
+test('HTTP v0 callers see remote-client connection metadata', async () => {
+  const dataDir = await makeTempDir();
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+    },
+  });
+
+  try {
+    const response = await fetch(`${remote.url}/v0/dbInfo`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json',
+      },
+      body: '{}',
+    });
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.result.connection.mode, 'remote-client');
+    assert.equal(body.result.connection.transport, 'http-api');
+    assert.equal(body.result.connection.server.mode, 'http-server');
+    assert.equal(body.result.connection.server.storageMode, 'project-local');
+  } finally {
+    await remote.close();
   }
 });
 


### PR DESCRIPTION
## Summary
- wrap HTTP API and HTTP MCP connection metadata so remote callers see connection.mode=remote-client
- preserve server process details under connection.server
- keep direct local CLI/server-internal metadata distinct from remote access metadata
- update MCP/skill wording for the new connection model

## Verification
- npm test
- targeted remote connection tests added for HTTP API and HTTP MCP callers

## Notes
- This PR does not deploy or restart the live server.
- Agents must not merge this PR unless explicitly instructed.