### PR TITLE
fix: clarify connection access metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,9 +59,9 @@ Do not recommend git as the live storage backend for SQLite or raw runtime data.
 ## Runtime Mode
 Runtime mode is checkout-local. Do not assume a clone is the live server.
 
-At task start, check `connection.mode` with `node src/cli.js dbInfo` or
-`bootstrap_context`. Verify `/healthz`, the service manager, and current git
-state before making live runtime claims.
+At task start, check `connection.summary` or `connection.accessMode` with
+`node src/cli.js dbInfo` or `bootstrap_context`. Verify `/healthz`, the service
+manager, and current git state before making live runtime claims.
 
 Keep env files, tokens, API keys, DB files, and raw runtime data out of git and
 reports. For local all-in-one, HTTP server, and external remote client

--- a/README.md
+++ b/README.md
@@ -1236,8 +1236,8 @@ For downstream repositories that consume an external ContextForge service,
 state the expected connection mode and storage authority directly in
 `AGENTS.md`; sandboxed agents may not be able to inspect the ContextForge
 server's env files, service manager, or local database. When available, use
-`db_info` or `bootstrap_context` `connection.mode` as the live access-path
-check.
+`db_info` or `bootstrap_context` `connection.summary` or `connection.accessMode`
+as the live access-path check.
 For loose continuation prompts like "yesterday", "continue", "previous work",
 issue/PR follow-up, or cross-agent handoff, agents should call
 `bootstrap_context` or `bootstrapContext` early. The bootstrap response reviews

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -78,9 +78,9 @@ state from live sources.
 Use the installed `contextforge-memory` skill for session IDs, distillation,
 candidate review, closeout promotion, correction, and embedding maintenance.
 
-Use `connection.mode` from `db_info` or `bootstrap_context` when present:
-`remote-client`, `http-server`, or `direct-local`. Treat local `.contextforge/`
-state as relevant only for local/project-local modes.
+Use `connection.summary` or `connection.accessMode` from `db_info` or
+`bootstrap_context` when present. Treat local `.contextforge/` state as
+relevant only for local/project-local modes.
 ```
 
 ## Local Or Project-Local Variant

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -79,7 +79,8 @@ Use the installed `contextforge-memory` skill for session IDs, distillation,
 candidate review, closeout promotion, correction, and embedding maintenance.
 
 Use `connection.summary` or `connection.accessMode` from `db_info` or
-`bootstrap_context` when present. Treat local `.contextforge/` state as
+`bootstrap_context` when present. `accessMode` is `direct-local`,
+`server-process`, or `remote-client`. Treat local `.contextforge/` state as
 relevant only for local/project-local modes.
 ```
 

--- a/docs/agents-md-guide.md
+++ b/docs/agents-md-guide.md
@@ -66,16 +66,16 @@ of pasting the full local/server/remote setup guide.
 ## Runtime Mode Section Pattern
 
 Runtime mode is checkout-local. Keep tracked `AGENTS.md` clone-safe and prefer
-live `connection.mode`.
+live `connection.summary` or `connection.accessMode`.
 
 ```text
 ## Runtime Mode
 
 Runtime mode is checkout-local. Do not assume a clone is the live server.
 
-At task start, check `connection.mode` with `db_info` or `bootstrap_context`.
-Verify `/healthz`, the service manager, and current git state before making
-live runtime claims.
+At task start, check `connection.summary` or `connection.accessMode` with
+`db_info` or `bootstrap_context`. Verify `/healthz`, the service manager, and
+current git state before making live runtime claims.
 
 Keep env files, tokens, API keys, DB files, and raw runtime data out of git and
 reports. For local all-in-one, HTTP server, and external remote client

--- a/docs/runtime-modes.md
+++ b/docs/runtime-modes.md
@@ -197,8 +197,8 @@ This repo uses ContextForge as an external remote memory service.
 - Use the installed `contextforge-memory` skill.
 - At task start, call `bootstrap_context` with this repo's canonical scope key:
   `github.com/owner/repo`.
-- Use `connection.mode` from `db_info` or `bootstrap_context` when present:
-  `remote-client`, `http-server`, or `direct-local`.
+- Use `connection.summary` or `connection.accessMode` from `db_info` or
+  `bootstrap_context` when present.
 - Treat local `.contextforge/` state as relevant only for local/project-local
   modes.
 ```
@@ -209,7 +209,7 @@ At task start, agents should identify which mode they are in before making
 storage or deployment claims:
 
 1. Inspect declared repo guidance, then `db_info` or `bootstrap_context`
-   `connection.mode` when available.
+   `connection.summary` or `connection.accessMode` when available.
 2. Check whether this process is talking to local/project-local storage or a
    remote server.
 3. If operating a server, verify `/healthz` and recent server logs before

--- a/docs/runtime-modes.md
+++ b/docs/runtime-modes.md
@@ -198,7 +198,8 @@ This repo uses ContextForge as an external remote memory service.
 - At task start, call `bootstrap_context` with this repo's canonical scope key:
   `github.com/owner/repo`.
 - Use `connection.summary` or `connection.accessMode` from `db_info` or
-  `bootstrap_context` when present.
+  `bootstrap_context` when present. `accessMode` is `direct-local`,
+  `server-process`, or `remote-client`.
 - Treat local `.contextforge/` state as relevant only for local/project-local
   modes.
 ```

--- a/docs/skills/contextforge-memory/SKILL.md
+++ b/docs/skills/contextforge-memory/SKILL.md
@@ -35,6 +35,10 @@ Always set scope intentionally:
 
 Before relying on results, check connection metadata and storage authority from `bootstrap_context` or `db_info`:
 
+- `connection.summary`: quickest human-readable access/process summary.
+- `connection.accessMode`: how this caller reached ContextForge.
+- `connection.accessPath`: concrete path such as `direct-local`, `http-api`, or `http-mcp`.
+- `connection.serverRole`: server process role behind a remote call, when present.
 - `connection.mode: "remote-client"`: this agent reaches ContextForge through HTTP or a remote wrapper.
 - `connection.mode: "http-server"`: the tool is running inside the ContextForge HTTP server process.
 - `connection.mode: "direct-local"`: the tool is running as a local ContextForge process.

--- a/docs/skills/contextforge-memory/SKILL.md
+++ b/docs/skills/contextforge-memory/SKILL.md
@@ -36,7 +36,7 @@ Always set scope intentionally:
 Before relying on results, check connection metadata and storage authority from `bootstrap_context` or `db_info`:
 
 - `connection.summary`: quickest human-readable access/process summary.
-- `connection.accessMode`: how this caller reached ContextForge.
+- `connection.accessMode`: how this caller reached ContextForge: `direct-local`, `server-process`, or `remote-client`.
 - `connection.accessPath`: concrete path such as `direct-local`, `http-api`, or `http-mcp`.
 - `connection.serverRole`: server process role behind a remote call, when present.
 - `connection.mode: "remote-client"`: this agent reaches ContextForge through HTTP or a remote wrapper.

--- a/src/core.js
+++ b/src/core.js
@@ -1203,6 +1203,10 @@ export function createContextForge(options = {}) {
   function buildDbInfo(store) {
     const storeInfo = store.dbInfo();
     const jobs = store.countEmbeddingJobs();
+    const processConnectionMode = config.runtime.role === 'http-server' ? 'http-server' : 'direct-local';
+    const accessMode = config.runtime.role === 'http-server' ? 'server-process' : 'direct-local';
+    const accessPath = config.runtime.role === 'http-server' ? 'in-process' : 'direct-local';
+    const serverRole = config.runtime.role === 'http-server' ? 'http-server' : null;
     const coverage =
       embeddingProvider && storeInfo.vector.sqliteVecAvailable
         ? store.embeddingCoverage({
@@ -1214,8 +1218,11 @@ export function createContextForge(options = {}) {
       ...storeInfo,
       storageMode: config.storageMode,
       connection: {
-        mode: config.runtime.role === 'http-server' ? 'http-server' : 'direct-local',
+        mode: processConnectionMode,
+        accessMode,
+        accessPath,
         processRole: config.runtime.role,
+        serverRole,
         viewpoint: 'this ContextForge process',
         storageMode: config.storageMode,
         storageAuthority:
@@ -1228,6 +1235,7 @@ export function createContextForge(options = {}) {
           config.runtime.role === 'http-server'
             ? 'This response is from the ContextForge HTTP server process. Its storageMode describes the server-owned store.'
             : 'This response is from a local ContextForge process. Its storageMode describes this process.',
+        summary: serverRole ? `${accessPath} ${serverRole}` : `${accessPath} ${config.runtime.role}`,
       },
       embeddings: {
         provider: config.embeddings.provider,

--- a/src/core.js
+++ b/src/core.js
@@ -1235,7 +1235,7 @@ export function createContextForge(options = {}) {
           config.runtime.role === 'http-server'
             ? 'This response is from the ContextForge HTTP server process. Its storageMode describes the server-owned store.'
             : 'This response is from a local ContextForge process. Its storageMode describes this process.',
-        summary: serverRole ? `${accessPath} ${serverRole}` : `${accessPath} ${config.runtime.role}`,
+        summary: `${accessPath} ${config.runtime.role}`,
       },
       embeddings: {
         provider: config.embeddings.provider,

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -26,7 +26,7 @@ const MCP_INSTRUCTIONS = [
   'Use ContextForge for scoped memory retrieval on demand.',
   'At the start of non-trivial project work, call bootstrap_context with repoPath, cwd, or an explicit scopeKey. It summarizes storage authority, vector readiness, repo semantic retrieval results, and trust hints in one response.',
   'bootstrap_context does not create a session. In Codex or Claude Code auto-ingest environments, preserve or recover the adapter session id such as codex:<native-session-id> or claude_code:<native-session-id> before session_status, distill_checkpoint, or closeout promotion. Use begin_session only for manual ContextForge evidence streams where the agent will call append_raw itself; do not create a fresh cf_... session at closeout to review candidates from an existing Codex/Claude session.',
-  'Use db_info connection metadata for access path: remote-client for HTTP or remote-wrapper callers, http-server for the server process itself, or direct-local for local processes. Top-level storageMode describes the responding ContextForge process; connection.server may describe the server-owned store behind a remote call.',
+  'Use db_info connection metadata for access path: prefer connection.summary, then connection.accessMode/accessPath and connection.serverRole. connection.mode is kept for compatibility. Top-level storageMode describes the responding ContextForge process; connection.server may describe the server-owned store behind a remote call.',
   'Search result types have different trust roles: memory is reviewed durable fact or decision; checkpoint is credible recent handoff state for continuity, planning, prior intent, recent decisions, and unfinished work, but mutable live-state claims must be verified with git/GitHub/CI/runtime/migrations before acting; memory_candidate is unreviewed promotion material and not durable truth.',
   'For start/resume requests such as "지난 환경 작업과 동기화", "어제 하던 거 이어서", "previous work", or "continue", call sync_resume_context. Use checkpoints actively as handoff notes, then verify mutable state with git/GitHub/CI/runtime/migrations. Do not propose memory promotions during resume sync.',
   'For closeout triggers only, call suggest_memory_promotions with the current sessionId or the checkpointId returned by distill_checkpoint: after this agent merges a PR, after the user says they merged and the agent syncs main/cleans branches, or when the user explicitly says today\'s work is done. Suggest at most 1-3 durable memory promotions and never promote automatically.',
@@ -60,7 +60,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Database Info',
       description:
-        'Inspect ContextForge connection metadata, storage backend, table counts, raw retention, and sqlite-vec/embeddings readiness. Use connection.mode for caller access path; top-level storageMode describes the responding process.',
+        'Inspect ContextForge connection metadata, storage backend, table counts, raw retention, and sqlite-vec/embeddings readiness. Prefer connection.summary and accessMode/accessPath for caller access path; top-level storageMode describes the responding process.',
       inputSchema: {},
       annotations: {
         title: 'Database Info',

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -113,13 +113,12 @@ export function createRemoteContextForge(config, options = {}) {
   });
   const api = { config };
 
+  function connectionServerRole(connection) {
+    return connection?.serverRole || connection?.server?.processRole || connection?.processRole || connection?.mode || null;
+  }
+
   function remoteClientConnection(serverConnection) {
-    const serverRole =
-      serverConnection?.serverRole ||
-      serverConnection?.server?.processRole ||
-      serverConnection?.processRole ||
-      serverConnection?.mode ||
-      null;
+    const serverRole = connectionServerRole(serverConnection);
     const accessPath = serverConnection?.accessPath || serverConnection?.transport || 'http-api';
     if (serverConnection?.mode === 'remote-client') {
       return {

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -114,22 +114,39 @@ export function createRemoteContextForge(config, options = {}) {
   const api = { config };
 
   function remoteClientConnection(serverConnection) {
+    const serverRole =
+      serverConnection?.serverRole ||
+      serverConnection?.server?.processRole ||
+      serverConnection?.processRole ||
+      serverConnection?.mode ||
+      null;
+    const accessPath = serverConnection?.accessPath || serverConnection?.transport || 'http-api';
     if (serverConnection?.mode === 'remote-client') {
       return {
         ...serverConnection,
+        accessMode: serverConnection.accessMode || 'remote-client',
+        accessPath,
+        serverRole,
         viewpoint: 'this client delegates to a remote ContextForge server',
         remoteUrl: config.remote.url,
         clientStorageMode: config.storageMode,
+        summary: serverConnection.summary || `remote-client over ${accessPath}${serverRole ? ` to ${serverRole}` : ''}`,
       };
     }
     return {
       mode: 'remote-client',
+      accessMode: 'remote-client',
+      accessPath: 'http-api',
       viewpoint: 'this client delegates to a remote ContextForge server',
       remoteUrl: config.remote.url,
       clientStorageMode: config.storageMode,
+      storageMode: 'remote',
+      storageAuthority: 'canonical',
+      serverRole,
       server: serverConnection || null,
       note:
         'This client is configured with CONTEXTFORGE_STORAGE_MODE=remote. The server may report its own storageMode as local because it owns the canonical SQLite store.',
+      summary: `remote-client over http-api${serverRole ? ` to ${serverRole}` : ''}`,
     };
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -90,8 +90,12 @@ function isAuthorized(request, token) {
   return timingSafeStringEqual(request.headers.authorization, `Bearer ${token}`);
 }
 
+function connectionServerRole(connection) {
+  return connection?.serverRole || connection?.server?.processRole || connection?.processRole || connection?.mode || null;
+}
+
 function remoteAccessConnection(serverConnection, transport) {
-  const serverRole = serverConnection?.processRole || serverConnection?.mode || null;
+  const serverRole = connectionServerRole(serverConnection);
   return {
     mode: 'remote-client',
     accessMode: 'remote-client',

--- a/src/server.js
+++ b/src/server.js
@@ -91,14 +91,19 @@ function isAuthorized(request, token) {
 }
 
 function remoteAccessConnection(serverConnection, transport) {
+  const serverRole = serverConnection?.processRole || serverConnection?.mode || null;
   return {
     mode: 'remote-client',
+    accessMode: 'remote-client',
+    accessPath: transport,
     transport,
     viewpoint: 'this caller reaches ContextForge through a remote HTTP endpoint',
     storageMode: 'remote',
     storageAuthority: 'canonical',
+    serverRole,
     server: serverConnection || null,
     note: 'This response crossed a ContextForge HTTP boundary. server.storageMode describes the server-owned store.',
+    summary: `remote-client over ${transport}${serverRole ? ` to ${serverRole}` : ''}`,
   };
 }
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -198,6 +198,11 @@ test('dbInfo initializes a fresh SQLite store', async () => {
   assert.equal(info.embeddings.degraded, true);
   assert.deepEqual(info.embeddings.jobs, { pending: 0, processing: 0, completed: 0, failed: 0 });
   assert.equal(info.connection.mode, 'direct-local');
+  assert.equal(info.connection.accessMode, 'direct-local');
+  assert.equal(info.connection.accessPath, 'direct-local');
+  assert.equal(info.connection.processRole, 'local-process');
+  assert.equal(info.connection.serverRole, null);
+  assert.equal(info.connection.summary, 'direct-local local-process');
   assert.equal(info.connection.storageMode, 'project-local');
   assert.match(info.dbPath, /contextforge\.db$/);
 });
@@ -5806,7 +5811,11 @@ test('MCP streamable HTTP endpoint exposes core tools with bearer auth', async (
 
     const infoResult = await client.callTool({ name: 'db_info', arguments: {} });
     assert.equal(infoResult.structuredContent.result.connection.mode, 'remote-client');
+    assert.equal(infoResult.structuredContent.result.connection.accessMode, 'remote-client');
+    assert.equal(infoResult.structuredContent.result.connection.accessPath, 'http-mcp');
     assert.equal(infoResult.structuredContent.result.connection.transport, 'http-mcp');
+    assert.equal(infoResult.structuredContent.result.connection.serverRole, 'local-process');
+    assert.equal(infoResult.structuredContent.result.connection.summary, 'remote-client over http-mcp to local-process');
     assert.equal(infoResult.structuredContent.result.connection.server.mode, 'direct-local');
 
     const remembered = await client.callTool({
@@ -5839,7 +5848,10 @@ test('MCP streamable HTTP endpoint exposes core tools with bearer auth', async (
       },
     });
     assert.equal(bootstrap.structuredContent.result.storage.connection.mode, 'remote-client');
+    assert.equal(bootstrap.structuredContent.result.storage.connection.accessMode, 'remote-client');
+    assert.equal(bootstrap.structuredContent.result.storage.connection.accessPath, 'http-mcp');
     assert.equal(bootstrap.structuredContent.result.storage.connection.transport, 'http-mcp');
+    assert.equal(bootstrap.structuredContent.result.storage.connection.serverRole, 'local-process');
     assert.equal(bootstrap.structuredContent.result.storage.connection.server.mode, 'direct-local');
 
     const syncResume = await client.callTool({
@@ -5851,7 +5863,10 @@ test('MCP streamable HTTP endpoint exposes core tools with bearer auth', async (
       },
     });
     assert.equal(syncResume.structuredContent.result.storage.connection.mode, 'remote-client');
+    assert.equal(syncResume.structuredContent.result.storage.connection.accessMode, 'remote-client');
+    assert.equal(syncResume.structuredContent.result.storage.connection.accessPath, 'http-mcp');
     assert.equal(syncResume.structuredContent.result.storage.connection.transport, 'http-mcp');
+    assert.equal(syncResume.structuredContent.result.storage.connection.serverRole, 'local-process');
     assert.equal(syncResume.structuredContent.result.storage.connection.server.mode, 'direct-local');
 
     await client.callTool({
@@ -5912,8 +5927,15 @@ test('MCP streamable HTTP db_info reports remote-client for HTTP callers', async
     await client.connect(transport);
     const info = await client.callTool({ name: 'db_info', arguments: {} });
     assert.equal(info.structuredContent.result.connection.mode, 'remote-client');
+    assert.equal(info.structuredContent.result.connection.accessMode, 'remote-client');
+    assert.equal(info.structuredContent.result.connection.accessPath, 'http-mcp');
     assert.equal(info.structuredContent.result.connection.transport, 'http-mcp');
+    assert.equal(info.structuredContent.result.connection.serverRole, 'http-server');
+    assert.equal(info.structuredContent.result.connection.summary, 'remote-client over http-mcp to http-server');
     assert.equal(info.structuredContent.result.connection.server.mode, 'http-server');
+    assert.equal(info.structuredContent.result.connection.server.accessMode, 'server-process');
+    assert.equal(info.structuredContent.result.connection.server.accessPath, 'in-process');
+    assert.equal(info.structuredContent.result.connection.server.serverRole, 'http-server');
     assert.equal(info.structuredContent.result.connection.server.storageMode, 'project-local');
   } finally {
     await client.close();
@@ -5943,8 +5965,15 @@ test('HTTP v0 callers see remote-client connection metadata', async () => {
     assert.equal(response.status, 200);
     const body = await response.json();
     assert.equal(body.result.connection.mode, 'remote-client');
+    assert.equal(body.result.connection.accessMode, 'remote-client');
+    assert.equal(body.result.connection.accessPath, 'http-api');
     assert.equal(body.result.connection.transport, 'http-api');
+    assert.equal(body.result.connection.serverRole, 'http-server');
+    assert.equal(body.result.connection.summary, 'remote-client over http-api to http-server');
     assert.equal(body.result.connection.server.mode, 'http-server');
+    assert.equal(body.result.connection.server.accessMode, 'server-process');
+    assert.equal(body.result.connection.server.accessPath, 'in-process');
+    assert.equal(body.result.connection.server.serverRole, 'http-server');
     assert.equal(body.result.connection.server.storageMode, 'project-local');
 
     const resumeResponse = await fetch(`${remote.url}/v0/syncResumeContext`, {
@@ -5962,7 +5991,10 @@ test('HTTP v0 callers see remote-client connection metadata', async () => {
     assert.equal(resumeResponse.status, 200);
     const resumeBody = await resumeResponse.json();
     assert.equal(resumeBody.result.storage.connection.mode, 'remote-client');
+    assert.equal(resumeBody.result.storage.connection.accessMode, 'remote-client');
+    assert.equal(resumeBody.result.storage.connection.accessPath, 'http-api');
     assert.equal(resumeBody.result.storage.connection.transport, 'http-api');
+    assert.equal(resumeBody.result.storage.connection.serverRole, 'http-server');
     assert.equal(resumeBody.result.storage.connection.server.mode, 'http-server');
   } finally {
     await remote.close();
@@ -6055,6 +6087,9 @@ test('remote storage mode delegates core calls and preserves scope semantics', a
     });
     assert.equal(bootstrap.scope.scopeKey, 'repo-remote');
     assert.equal(bootstrap.connection.mode, 'remote-client');
+    assert.equal(bootstrap.connection.accessMode, 'remote-client');
+    assert.equal(bootstrap.connection.accessPath, 'http-api');
+    assert.equal(bootstrap.connection.serverRole, 'http-server');
     assert.equal(bootstrap.storage.mode, 'remote');
     assert.equal(bootstrap.storage.authority, 'canonical');
     assert.equal(bootstrap.storage.serverMode, 'project-local');
@@ -6081,7 +6116,11 @@ test('remote storage mode delegates core calls and preserves scope semantics', a
     const info = await app.dbInfo();
     assert.equal(info.tables.memories, 2);
     assert.equal(info.connection.mode, 'remote-client');
+    assert.equal(info.connection.accessMode, 'remote-client');
+    assert.equal(info.connection.accessPath, 'http-api');
+    assert.equal(info.connection.serverRole, 'http-server');
     assert.equal(info.connection.clientStorageMode, 'remote');
+    assert.equal(info.connection.summary, 'remote-client over http-api to http-server');
     assert.equal(info.connection.server.mode, 'http-server');
     assert.equal(info.connection.server.storageMode, 'project-local');
   } finally {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -5936,6 +5936,7 @@ test('MCP streamable HTTP db_info reports remote-client for HTTP callers', async
     assert.equal(info.structuredContent.result.connection.server.accessMode, 'server-process');
     assert.equal(info.structuredContent.result.connection.server.accessPath, 'in-process');
     assert.equal(info.structuredContent.result.connection.server.serverRole, 'http-server');
+    assert.equal(info.structuredContent.result.connection.server.summary, 'in-process http-server');
     assert.equal(info.structuredContent.result.connection.server.storageMode, 'project-local');
   } finally {
     await client.close();
@@ -5974,6 +5975,7 @@ test('HTTP v0 callers see remote-client connection metadata', async () => {
     assert.equal(body.result.connection.server.accessMode, 'server-process');
     assert.equal(body.result.connection.server.accessPath, 'in-process');
     assert.equal(body.result.connection.server.serverRole, 'http-server');
+    assert.equal(body.result.connection.server.summary, 'in-process http-server');
     assert.equal(body.result.connection.server.storageMode, 'project-local');
 
     const resumeResponse = await fetch(`${remote.url}/v0/syncResumeContext`, {


### PR DESCRIPTION
## Summary
- add explicit connection.accessMode, accessPath, serverRole, and summary fields while preserving connection.mode
- populate the new fields for direct local, HTTP API, HTTP MCP, and remote-storage client paths
- update agent/runtime docs to prefer summary/accessMode for live mode checks
- expand tests across dbInfo, bootstrap_context, sync_resume_context, HTTP API, MCP, and remote storage client metadata

## Verification
- node --test --test-name-pattern "dbInfo initializes|HTTP|MCP streamable HTTP|remote storage mode" test/core.test.js
- npm test
- git diff --check