### PR TITLE
[codex] Accept zero raw tail limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,9 @@ node src/cli.js bootstrapContext \
   --rawTailLimit 5
 ```
 
+`rawTailLimit` defaults to `0`, which omits raw events. Set a positive value
+only when last-mile transcript continuity is needed.
+
 The bootstrap response keeps these channels separate:
 
 - `results`: durable memories, checkpoints, and memory candidates from search.

--- a/src/core.js
+++ b/src/core.js
@@ -101,6 +101,13 @@ function positiveNumber(value, name) {
   return value;
 }
 
+function nonnegativeNumber(value, name) {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative number.`);
+  }
+  return value;
+}
+
 function withStore(config, fn) {
   const store = new ContextForgeStore({ dataDir: config.dataDir });
   try {
@@ -1450,9 +1457,7 @@ export function createContextForge(options = {}) {
       const includeShared = truthyOption(options.includeShared);
       const sessionId = options.sessionId || null;
       const rawTailLimit = sessionId
-        ? options.rawTailLimit == null
-          ? 5
-          : positiveNumber(Number(options.rawTailLimit), 'rawTailLimit')
+        ? nonnegativeNumber(options.rawTailLimit == null ? 0 : Number(options.rawTailLimit), 'rawTailLimit')
         : null;
       return useStore(async (store) => {
         const info = buildDbInfo(store);
@@ -1500,7 +1505,7 @@ export function createContextForge(options = {}) {
         const structuredWorkingContext = sessionId
           ? bootstrapSessionWorkingContext(store.getSessionWorkingContext({ ...scope, sessionId }))
           : null;
-        const rawTail = sessionId
+        const rawTail = sessionId && rawTailLimit > 0
           ? store
               .listRecentRawEvents({ ...scope, sessionId, limit: rawTailLimit })
               .map((event) => bootstrapRawTailEvent(event))

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -76,12 +76,12 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Bootstrap Context',
       description:
-        'Resolve scoped ContextForge memory for a task in one call. Searches repo scope semantically across memory, checkpoint, and memory_candidate results, optionally includes up to 3 shared-scope results, and annotates trust and verification hints for agents. Does not create a session; pass a known Codex/Claude/ContextForge sessionId only to load session working state and raw tail.',
+        'Resolve scoped ContextForge memory for a task in one call. Searches repo scope semantically across memory, checkpoint, and memory_candidate results, optionally includes up to 3 shared-scope results, and annotates trust and verification hints for agents. Does not create a session; pass a known Codex/Claude/ContextForge sessionId to load session working state. rawTailLimit defaults to 0; set a positive value to include raw tail.',
       inputSchema: {
         ...scopedSchema,
         query: z.string(),
         sessionId: z.string().optional(),
-        rawTailLimit: z.number().int().positive().optional(),
+        rawTailLimit: z.number().int().nonnegative().optional(),
         includeShared: z.boolean().optional(),
         limit: z.number().int().positive().optional(),
         sharedScopeKey: z.string().optional(),
@@ -100,14 +100,14 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Sync Resume Context',
       description:
-        'Build a start/resume handoff package for continuing work across machines or agent environments. Use checkpoints as credible recent handoff notes, durable memories as canonical long-term context, and memory candidates only as review material. This tool must not propose or perform durable memory promotion.',
+        'Build a start/resume handoff package for continuing work across machines or agent environments. Use checkpoints as credible recent handoff notes, durable memories as canonical long-term context, and memory candidates only as review material. rawTailLimit defaults to 0; set a positive value to include raw tail. This tool must not propose or perform durable memory promotion.',
       inputSchema: {
         ...scopedSchema,
         query: z.string(),
         sessionId: z.string().optional(),
         includeShared: z.boolean().optional(),
         limit: z.number().int().positive().optional(),
-        rawTailLimit: z.number().int().positive().optional(),
+        rawTailLimit: z.number().int().nonnegative().optional(),
         sharedScopeKey: z.string().optional(),
       },
       annotations: {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -3128,6 +3128,25 @@ test('bootstrapContext includes working summary and recent raw tail separately f
     content: 'Bootstrap wiring is now in progress.',
   });
 
+  const defaultBootstrap = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-working',
+    sessionId: 'working-session',
+    query: 'durable working summary bootstrap',
+  });
+  assert.deepEqual(defaultBootstrap.rawTail, []);
+  assert.equal(defaultBootstrap.rawTailLimit, 0);
+
+  const zeroBootstrap = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-working',
+    sessionId: 'working-session',
+    query: 'durable working summary bootstrap',
+    rawTailLimit: 0,
+  });
+  assert.deepEqual(zeroBootstrap.rawTail, []);
+  assert.equal(zeroBootstrap.rawTailLimit, 0);
+
   const bootstrap = await app.bootstrapContext({
     scope: 'repo',
     scopeKey: 'repo-working',
@@ -5829,6 +5848,19 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     });
     assert.equal(invalidAppendResult.isError, true);
     assert.match(invalidAppendResult.content[0].text, /Invalid arguments|tool_result/);
+
+    const zeroRawTailBootstrap = await client.callTool({
+      name: 'bootstrap_context',
+      arguments: {
+        scope: 'repo',
+        scopeKey: 'mcp-repo',
+        sessionId: 'mcp-session',
+        query: 'session status before distilling',
+        rawTailLimit: 0,
+      },
+    });
+    assert.equal(zeroRawTailBootstrap.structuredContent.result.rawTailLimit, 0);
+    assert.deepEqual(zeroRawTailBootstrap.structuredContent.result.rawTail, []);
 
     const statusResult = await client.callTool({
       name: 'session_status',


### PR DESCRIPTION
## Summary
- accept rawTailLimit: 0 in bootstrap_context and sync_resume_context MCP schemas
- treat omitted or zero rawTailLimit as no raw tail, while positive values still include recent raw events
- document the default and add core plus MCP regression coverage

## Root Cause
MCP schema used positive() for rawTailLimit, so agents could not pass 0 to mean skip raw tail even though that is a natural no-tail request.

## Validation
- git diff --check
- node --test test/core.test.js --test-name-pattern "bootstrapContext includes working summary|MCP stdio server exposes core tools"
- npm test

Closes #110