### PR TITLE
Add ContextForge admin UI and provider management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+## 0.4.0 - 2026-05-14
+
+- Added a Korean operator UI at `/ui/` for runtime dashboards, provider
+  settings, distillation policy controls, memory management, candidate review,
+  and recent distillation run inspection.
+- Added DB-backed runtime settings that override environment defaults for new
+  server-side calls, while keeping provider API keys write-only and redacted
+  from read APIs.
+- Added an OpenAI-compatible Chat Completions distillation provider for
+  DeepSeek-style APIs, including DeepSeek presets, manual model entry,
+  JSON-output modes, local checkpoint schema validation, and one repair retry.
+- Kept `codex_exec` as a first-class selectable distillation provider with UI
+  controls for command, model, reasoning effort, sandbox, timeout, and input
+  limits.
+- Added conservative automatic memory-promotion auditing through a separate
+  `codex_exec` audit runner, defaulting to `gpt-5.5` with reasoning effort
+  `low`, and rejecting unsupported audit provider configuration.
+- Added admin login sessions, login state restoration, logout, no-store UI
+  responses, scope-key dropdowns, bulk memory/candidate actions, and dashboard
+  recent-run loading across remote-client deployments.
+- Added `listDistillRuns` newest-first ordering support for dashboards and CLI
+  inspection.
+
 ## 0.3.6 - 2026-05-08
 
 - Added explicit ContextForge connection metadata to `dbInfo`, distinguishing

--- a/README.md
+++ b/README.md
@@ -266,10 +266,11 @@ Use `examples/server.env.example` as the public template. Example contents:
 CONTEXTFORGE_REMOTE_HOST=127.0.0.1
 CONTEXTFORGE_REMOTE_PORT=8765
 CONTEXTFORGE_REMOTE_TOKEN=change-me
-# Optional admin UI login. Generate a PBKDF2 value with the documented helper or
-# leave unset to disable password login and use bearer-token API access only.
-CONTEXTFORGE_ADMIN_USER=admin
-CONTEXTFORGE_ADMIN_PASSWORD_PBKDF2=310000:saltHex:hashHex
+# Optional admin UI login. Leave unset to disable password login and use
+# bearer-token API access only. The password value is PBKDF2:
+# iterations:saltHex:hashHex
+# CONTEXTFORGE_ADMIN_USER=admin
+# CONTEXTFORGE_ADMIN_PASSWORD_PBKDF2=
 CONTEXTFORGE_SERVER_STORAGE_MODE=local
 CONTEXTFORGE_DATA_DIR=/var/lib/contextforge
 CONTEXTFORGE_RAW_TTL_DAYS=30

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ ContextForge is a sidecar memory runtime. It complements existing agent memory
 systems by providing canonical project/repo memory, evidence retention, and
 LLM-backed distillation.
 
-Current 0.3.x builds add remote-first MCP workflows, start/resume handoff
-tools, closeout memory promotion review, correction reconciliation, hybrid
-retrieval, and an embedding job queue so vector indexing can recover
-independently from memory or checkpoint writes.
+Current 0.4.x builds add a server-hosted operator UI, DB-backed runtime
+settings, OpenAI-compatible distillation for DeepSeek-style Chat Completions
+APIs, separate auto-promotion audit runners, remote-first MCP workflows,
+start/resume handoff tools, correction reconciliation, hybrid retrieval, and an
+embedding job queue so vector indexing can recover independently from memory or
+checkpoint writes.
 
 ## Goals
 
@@ -77,10 +79,13 @@ bring-your-own distillation providers, such as:
 - direct model APIs
 - local model runners
 
-The current implementation ships with a deterministic `mock` provider and a
-`codex_exec` provider. The `codex_exec` provider shells out to `codex exec`,
-requests JSON-only output with a schema, validates the result, and records
-provider run metadata, including prompt and output schema versions.
+The current implementation ships with a deterministic `mock` provider,
+`codex_exec`, and `openai_compatible`. The `codex_exec` provider shells out to
+`codex exec`, requests JSON-only output with a schema, validates the result,
+and records provider run metadata, including prompt and output schema versions.
+The OpenAI-compatible provider calls Chat Completions APIs such as DeepSeek at
+`{baseUrl}/chat/completions`, validates the same checkpoint contract locally,
+and records provider metadata without returning API keys.
 
 ## Quick Start
 
@@ -318,13 +323,16 @@ it can call every remote API method, including pruning raw evidence and running
 provider health checks. Do not put this file in git.
 
 The HTTP server also serves an operator UI at `/ui/`. The UI can inspect
-runtime/storage state, update DB-backed runtime settings, select `codex_exec` or
-OpenAI-compatible distillation, tune distillation thresholds, review memory
-candidates, promote candidates manually, correct durable memories, and
-deactivate wrong memories with provenance. Runtime settings saved in the UI
-override env defaults for new calls without restarting the server. API keys are
-write-only in the UI/API: callers can set, replace, clear, and test them, but
-stored values are never returned.
+runtime/storage state, view recent distillation runs, update DB-backed runtime
+settings, select `codex_exec` or OpenAI-compatible distillation, pick preset or
+manual distillation models, tune distillation thresholds, review memory
+candidates, promote candidates manually, correct durable memories, bulk reject
+or deactivate bad memory material, and deactivate wrong memories with
+provenance. Runtime settings saved in the UI override env defaults for new
+calls without restarting the server. API keys are write-only in the UI/API:
+callers can set, replace, clear, and test them, but stored values are never
+returned. Optional admin password login is cookie-session based; bearer-token
+access remains available for API clients.
 
 `CONTEXTFORGE_OPENAI_API_KEY` is only needed on the process that performs
 embedding calls. In remote/server-backed deployments, keep that key only in the
@@ -1381,11 +1389,11 @@ deleting raw evidence.
 
 ## Status
 
-0.3.x runtime. The current implementation includes SQLite migrations, scoped
+0.4.x runtime. The current implementation includes SQLite migrations, scoped
 durable memories, raw event capture, rolling working summaries, checkpoint
-distillation with `mock` and `codex_exec` providers, remote HTTP mode for
-server-backed canonical memory, stdio and Streamable HTTP MCP, explainable
-hybrid retrieval, embedding job processing, closeout promotion review, strict
-safe auto-promotion controls, and memory reconciliation for user corrections.
-Additional distillation providers and large-store performance hardening remain
-future work.
+distillation with `mock`, `codex_exec`, and `openai_compatible` providers,
+remote HTTP mode for server-backed canonical memory, an operator UI, stdio and
+Streamable HTTP MCP, explainable hybrid retrieval, embedding job processing,
+closeout promotion review, audited strict safe auto-promotion controls, and
+memory reconciliation for user corrections. Further provider adapters and
+large-store performance hardening remain future work.

--- a/README.md
+++ b/README.md
@@ -266,12 +266,21 @@ Use `examples/server.env.example` as the public template. Example contents:
 CONTEXTFORGE_REMOTE_HOST=127.0.0.1
 CONTEXTFORGE_REMOTE_PORT=8765
 CONTEXTFORGE_REMOTE_TOKEN=change-me
+# Optional admin UI login. Generate a PBKDF2 value with the documented helper or
+# leave unset to disable password login and use bearer-token API access only.
+CONTEXTFORGE_ADMIN_USER=admin
+CONTEXTFORGE_ADMIN_PASSWORD_PBKDF2=310000:saltHex:hashHex
 CONTEXTFORGE_SERVER_STORAGE_MODE=local
 CONTEXTFORGE_DATA_DIR=/var/lib/contextforge
 CONTEXTFORGE_RAW_TTL_DAYS=30
 CONTEXTFORGE_DISTILL_PROVIDER=codex_exec
 CONTEXTFORGE_CODEX_EXEC_MODEL=gpt-5.4-mini
 CONTEXTFORGE_CODEX_EXEC_REASONING_EFFORT=low
+CONTEXTFORGE_OPENAI_COMPATIBLE_PRESET=deepseek
+CONTEXTFORGE_OPENAI_COMPATIBLE_BASE_URL=https://api.deepseek.com
+CONTEXTFORGE_OPENAI_COMPATIBLE_MODEL=deepseek-v4-flash
+CONTEXTFORGE_OPENAI_COMPATIBLE_RESPONSE_FORMAT=json_object
+CONTEXTFORGE_OPENAI_COMPATIBLE_API_KEY=sk-...
 CONTEXTFORGE_EMBEDDINGS_PROVIDER=openai
 CONTEXTFORGE_OPENAI_API_KEY=sk-...
 CONTEXTFORGE_EMBEDDINGS_MODEL=text-embedding-3-small
@@ -297,6 +306,15 @@ Use a long random token and store the same value on client machines as
 `CONTEXTFORGE_REMOTE_TOKEN`. Treat this token as an administrator credential:
 it can call every remote API method, including pruning raw evidence and running
 provider health checks. Do not put this file in git.
+
+The HTTP server also serves an operator UI at `/ui/`. The UI can inspect
+runtime/storage state, update DB-backed runtime settings, select `codex_exec` or
+OpenAI-compatible distillation, tune distillation thresholds, review memory
+candidates, promote candidates manually, correct durable memories, and
+deactivate wrong memories with provenance. Runtime settings saved in the UI
+override env defaults for new calls without restarting the server. API keys are
+write-only in the UI/API: callers can set, replace, clear, and test them, but
+stored values are never returned.
 
 `CONTEXTFORGE_OPENAI_API_KEY` is only needed on the process that performs
 embedding calls. In remote/server-backed deployments, keep that key only in the
@@ -1301,6 +1319,31 @@ non-zero, times out, or returns malformed JSON, ContextForge records a failed
 `distill_runs` row and leaves raw events untouched for retry or debugging.
 Failed and successful runs include provider prompt/schema version metadata so
 operators can tell which prompt contract produced the result.
+
+## OpenAI-Compatible Provider
+
+Use `openai_compatible` for DeepSeek or another Chat Completions-compatible
+provider:
+
+```bash
+CONTEXTFORGE_DISTILL_PROVIDER=openai_compatible \
+CONTEXTFORGE_OPENAI_COMPATIBLE_PRESET=deepseek \
+CONTEXTFORGE_OPENAI_COMPATIBLE_BASE_URL=https://api.deepseek.com \
+CONTEXTFORGE_OPENAI_COMPATIBLE_MODEL=deepseek-v4-flash \
+CONTEXTFORGE_OPENAI_COMPATIBLE_RESPONSE_FORMAT=json_object \
+CONTEXTFORGE_OPENAI_COMPATIBLE_API_KEY=sk-... \
+node src/cli.js distillCheckpoint \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --sessionId demo-session
+```
+
+DeepSeek is configured as the first built-in template. As of 2026-05-14, the
+official DeepSeek docs list `https://api.deepseek.com` as the OpenAI-compatible
+base URL, `deepseek-v4-flash` and `deepseek-v4-pro` as current V4 model ids, and
+JSON output via `response_format: {"type":"json_object"}`. The provider still
+validates the returned checkpoint JSON locally and records failed runs without
+deleting raw evidence.
 
 ## Public Repo Hygiene
 

--- a/README.md
+++ b/README.md
@@ -288,8 +288,13 @@ CONTEXTFORGE_EMBEDDINGS_DIMENSIONS=1536
 CONTEXTFORGE_EMBEDDINGS_TIMEOUT_MS=30000
 CONTEXTFORGE_EMBEDDINGS_STALE_AFTER_MS=600000
 # Keep false unless this trusted deployment should allow dryRun=false
-# closeout-scoped safe auto-promotion.
+# closeout-scoped safe auto-promotion. Real auto-promotion uses a separate
+# audit runner before writing durable memory.
 CONTEXTFORGE_AUTO_PROMOTE_ENABLED=false
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_ENABLED=true
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER=codex_exec
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_MODEL=gpt-5.5
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_REASONING_EFFORT=low
 ```
 
 The default and recommended embedding model is `text-embedding-3-small`.
@@ -300,7 +305,11 @@ not support that request field and must return the configured dimension count.
 embedding job is returned to `pending`; the default is 10 minutes.
 `CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true` is required before
 `auto_promote_memory_candidates` can run with `dryRun=false`; even then, the
-tool only promotes strict closeout-scoped safe candidates.
+tool only promotes strict closeout-scoped safe candidates. When real
+auto-promotion is enabled, `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_ENABLED=true`
+uses a separate audit runner before the durable memory write. The default audit
+runner is `codex_exec` with `gpt-5.5` and reasoning effort `low`, independent
+from the distillation runner.
 
 Use a long random token and store the same value on client machines as
 `CONTEXTFORGE_REMOTE_TOKEN`. Treat this token as an administrator credential:
@@ -1313,6 +1322,23 @@ Optional environment variables:
   `12000`.
 - `CONTEXTFORGE_CODEX_EXEC_CWD`: working directory passed to `codex exec --cd`.
   Default: current working directory.
+
+Auto-promotion audit runner variables are intentionally separate from the
+distillation runner:
+
+- `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_ENABLED`: set to `false` to disable the
+  audit gate and rely only on local strict checks. Default: enabled.
+- `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER`: currently `codex_exec`.
+- `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_COMMAND`: Codex executable for the
+  audit runner. Defaults to `CONTEXTFORGE_CODEX_EXEC_COMMAND` or `codex`.
+- `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_MODEL`: audit model. Default:
+  `gpt-5.5`.
+- `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_REASONING_EFFORT`: audit reasoning
+  effort. Default: `low`.
+- `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_SANDBOX`: sandbox for the audit
+  runner. Default: `read-only`.
+- `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_TIMEOUT_MS`: audit timeout. Default:
+  `120000`.
 
 Failure modes are preserved as distillation runs. If `codex exec` exits
 non-zero, times out, or returns malformed JSON, ContextForge records a failed

--- a/examples/server.env.example
+++ b/examples/server.env.example
@@ -6,6 +6,12 @@ CONTEXTFORGE_REMOTE_HOST=127.0.0.1
 CONTEXTFORGE_REMOTE_PORT=8765
 CONTEXTFORGE_REMOTE_TOKEN=change-me
 
+# Optional admin UI login at /ui/. Password login is disabled unless both values
+# are configured. The password value uses PBKDF2 format:
+# iterations:saltHex:hashHex
+CONTEXTFORGE_ADMIN_USER=admin
+CONTEXTFORGE_ADMIN_PASSWORD_PBKDF2=310000:saltHex:hashHex
+
 # Server storage controls where the remote server keeps canonical data.
 # Use `local` for a normal single-server SQLite deployment with DATA_DIR below.
 # Do not set this to `remote` for the server process itself.
@@ -22,6 +28,15 @@ CONTEXTFORGE_RAW_TTL_DAYS=30
 CONTEXTFORGE_DISTILL_PROVIDER=codex_exec
 CONTEXTFORGE_CODEX_EXEC_MODEL=gpt-5.4-mini
 CONTEXTFORGE_CODEX_EXEC_REASONING_EFFORT=low
+
+# OpenAI-compatible distillation provider defaults for DeepSeek. These can also
+# be changed at runtime through the admin UI and are hot-applied to new
+# distillation calls.
+CONTEXTFORGE_OPENAI_COMPATIBLE_PRESET=deepseek
+CONTEXTFORGE_OPENAI_COMPATIBLE_BASE_URL=https://api.deepseek.com
+CONTEXTFORGE_OPENAI_COMPATIBLE_MODEL=deepseek-v4-flash
+CONTEXTFORGE_OPENAI_COMPATIBLE_RESPONSE_FORMAT=json_object
+CONTEXTFORGE_OPENAI_COMPATIBLE_API_KEY=sk-...
 
 # Embeddings are required for high-quality semantic retrieval. Keep the OpenAI
 # key on the server/worker process, not on remote clients.

--- a/examples/server.env.example
+++ b/examples/server.env.example
@@ -54,5 +54,10 @@ CONTEXTFORGE_EMBEDDINGS_STALE_AFTER_MS=600000
 # intentional trusted deployment where closeout-scoped safe candidates should be
 # allowed to promote with dryRun=false. The tool still requires sessionId or
 # checkpointId, never scans scope-wide backlog, excludes preference candidates,
-# and applies strict confidence/stability/sensitivity/duplicate checks.
+# applies strict confidence/stability/sensitivity/duplicate checks, and runs a
+# separate Codex audit gate before writing durable memory.
 CONTEXTFORGE_AUTO_PROMOTE_ENABLED=false
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_ENABLED=true
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER=codex_exec
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_MODEL=gpt-5.5
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_REASONING_EFFORT=low

--- a/examples/server.env.example
+++ b/examples/server.env.example
@@ -9,8 +9,8 @@ CONTEXTFORGE_REMOTE_TOKEN=change-me
 # Optional admin UI login at /ui/. Password login is disabled unless both values
 # are configured. The password value uses PBKDF2 format:
 # iterations:saltHex:hashHex
-CONTEXTFORGE_ADMIN_USER=admin
-CONTEXTFORGE_ADMIN_PASSWORD_PBKDF2=310000:saltHex:hashHex
+# CONTEXTFORGE_ADMIN_USER=admin
+# CONTEXTFORGE_ADMIN_PASSWORD_PBKDF2=
 
 # Server storage controls where the remote server keeps canonical data.
 # Use `local` for a normal single-server SQLite deployment with DATA_DIR below.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contextforge",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contextforge",
-      "version": "0.3.6",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contextforge",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "Self-hosted memory and distillation runtime for coding agents.",
   "type": "module",
   "bin": {

--- a/src/admin-ui/app.js
+++ b/src/admin-ui/app.js
@@ -15,6 +15,18 @@ function setLoginState(loggedIn, username = '') {
   $('#loginMessage').textContent = loggedIn ? `${username || '관리자'} 로그인됨` : '';
 }
 
+async function refreshDashboardRuns() {
+  await loadRuns('#recentRuns', dashboardRunScope());
+}
+
+async function restoreLoginSession() {
+  const response = await fetch('/ui/session', { method: 'GET' }).catch(() => null);
+  if (!response?.ok) return false;
+  const body = await response.json().catch(() => ({}));
+  setLoginState(true, body.username || '관리자');
+  return true;
+}
+
 $('#loginForm').addEventListener('submit', async (event) => {
   event.preventDefault();
   const form = event.currentTarget;
@@ -27,13 +39,14 @@ $('#loginForm').addEventListener('submit', async (event) => {
       password: form.password.value,
     }),
   });
+  form.password.value = '';
   if (!response.ok) {
     $('#connection').textContent = '로그인 실패';
     return;
   }
-  form.password.value = '';
   setLoginState(true, username);
   await refreshRuntime();
+  await refreshDashboardRuns();
 });
 
 $('#logoutButton').addEventListener('click', async () => {
@@ -513,8 +526,10 @@ document.querySelectorAll('.tabs button').forEach((button) => {
   });
 });
 
-refreshRuntime()
-  .then(() => loadRuns('#recentRuns', dashboardRunScope()).catch(() => {}))
+restoreLoginSession()
+  .catch(() => false)
+  .then(() => refreshRuntime())
+  .then(() => refreshDashboardRuns().catch(() => {}))
   .catch((error) => {
     $('#connection').textContent = error.message;
   });

--- a/src/admin-ui/app.js
+++ b/src/admin-ui/app.js
@@ -1,0 +1,452 @@
+const state = {
+  runtime: null,
+  db: null,
+  scopeKeys: [],
+  memories: [],
+  candidates: [],
+};
+
+const $ = (selector) => document.querySelector(selector);
+const tokenInput = $('#token');
+tokenInput.value = localStorage.getItem('contextforgeToken') || '';
+tokenInput.addEventListener('input', () => localStorage.setItem('contextforgeToken', tokenInput.value));
+
+$('#loginForm').addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const response = await fetch('/ui/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      username: form.username.value,
+      password: form.password.value,
+    }),
+  });
+  if (!response.ok) {
+    $('#connection').textContent = '로그인 실패';
+    return;
+  }
+  form.password.value = '';
+  await refreshRuntime();
+});
+
+function headers() {
+  const token = tokenInput.value.trim();
+  return {
+    'content-type': 'application/json',
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+async function call(method, body = {}) {
+  const response = await fetch(`/v0/${method}`, {
+    method: 'POST',
+    headers: headers(),
+    body: JSON.stringify(body),
+  });
+  const payload = await response.json();
+  if (!response.ok) {
+    throw new Error(payload?.error?.message || `${method} failed`);
+  }
+  return payload.result;
+}
+
+function dl(target, entries) {
+  target.innerHTML = entries
+    .map(([key, value]) => `<dt>${escapeHtml(key)}</dt><dd>${escapeHtml(value == null ? '' : String(value))}</dd>`)
+    .join('');
+}
+
+const DISTILL_POLICY_LABELS = {
+  minEvents: '최소 이벤트 수',
+  minIntervalMs: '최소 시간 간격(ms)',
+  charMinIntervalMs: '문자 기준 최소 간격(ms)',
+  charThreshold: '문자 수 기준',
+  maxEvents: '최대 이벤트 수',
+  maxChars: '최대 입력 문자 수',
+};
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+function table(rows, columns) {
+  if (!rows.length) return '<p class="muted">표시할 항목이 없습니다.</p>';
+  return `<table><thead><tr>${columns.map((col) => `<th>${escapeHtml(col.label)}</th>`).join('')}</tr></thead><tbody>${rows
+    .map((row) => `<tr>${columns.map((col) => `<td>${escapeHtml(col.value(row) ?? '')}</td>`).join('')}</tr>`)
+    .join('')}</tbody></table>`;
+}
+
+function showDetail(title, content) {
+  $('#detail').innerHTML = `<h2>${escapeHtml(title)}</h2><pre>${escapeHtml(JSON.stringify(content, null, 2))}</pre>`;
+  $('#detailDialog').showModal();
+}
+
+async function refreshRuntime() {
+  const [runtime, db, scopeKeys] = await Promise.all([
+    call('getRuntimeSettings'),
+    call('dbInfo'),
+    call('listScopeKeys', { limit: 500 }),
+  ]);
+  state.runtime = runtime;
+  state.db = db;
+  state.scopeKeys = scopeKeys;
+  $('#connection').textContent = `${db.connection.summary} · ${db.storageMode} · schema ${db.schemaVersion}`;
+  const effective = runtime.effective;
+  const runtimeRows = [
+    ['프로바이더', effective.distillProvider],
+    ['모델', effective.distillProvider === 'codex_exec' ? effective.codexExec.model || '(기본값)' : effective.openAiCompatible.model],
+  ];
+  if (effective.distillProvider === 'codex_exec') {
+    runtimeRows.push(
+      ['런타임 백엔드', 'Codex exec'],
+      ['Codex 명령', effective.codexExec.command || 'codex'],
+      ['OpenAI 호환 API', '비활성; API 키 필요 없음'],
+    );
+  } else if (effective.distillProvider === 'openai_compatible') {
+    runtimeRows.push(
+      ['런타임 백엔드', 'OpenAI 호환 API'],
+      ['Base URL', effective.openAiCompatible.baseUrl],
+      ['API 키', effective.openAiCompatible.secretPresent ? '있음' : '없음'],
+    );
+  } else {
+    runtimeRows.push(['런타임 백엔드', 'mock']);
+  }
+  runtimeRows.push(['메모리 수', db.tables.memories], ['후보 수', db.tables.memoryCandidates]);
+  dl($('#runtimeSummary'), runtimeRows);
+  dl(
+    $('#policySummary'),
+    Object.entries(effective.distillPolicy).map(([key, value]) => [DISTILL_POLICY_LABELS[key] || key, value]),
+  );
+  fillSettingsForm();
+  fillScopeKeySelects();
+}
+
+function fillSettingsForm() {
+  const form = $('#settingsForm');
+  const { effective } = state.runtime;
+  form.distillProvider.value = effective.distillProvider;
+  form.preset.value = effective.openAiCompatible.preset || 'deepseek';
+  form.baseUrl.value = effective.openAiCompatible.baseUrl || '';
+  form.model.value = effective.openAiCompatible.model || '';
+  form.responseFormat.value = effective.openAiCompatible.responseFormat || 'json_object';
+  form.codexCommand.value = effective.codexExec.command || 'codex';
+  form.codexModel.value = effective.codexExec.model || '';
+  form.codexReasoningEffort.value = effective.codexExec.reasoningEffort || '';
+  for (const [key, value] of Object.entries(effective.distillPolicy)) {
+    if (form[key]) form[key].value = value;
+  }
+  updateProviderSections();
+}
+
+function updateProviderSections() {
+  const provider = $('#settingsForm').distillProvider.value;
+  document.querySelectorAll('[data-provider-section]').forEach((section) => {
+    section.hidden = section.dataset.providerSection !== provider;
+  });
+  $('#deepseekPreset').hidden = provider !== 'openai_compatible';
+}
+
+function scopeKeyLabel(item) {
+  const counts = [
+    item.memories ? `메모리 ${item.memories}` : '',
+    item.candidates ? `후보 ${item.candidates}` : '',
+    item.distillRuns ? `실행 ${item.distillRuns}` : '',
+  ].filter(Boolean);
+  return `${item.scopeKey}${counts.length ? ` (${counts.join(', ')})` : ''}`;
+}
+
+function fillScopeKeySelect(select, scope, preferred = '') {
+  const matches = state.scopeKeys.filter((item) => item.scopeType === scope);
+  const fallback = preferred || state.db?.defaultScopeKey || '';
+  select.innerHTML = matches
+    .map((item) => `<option value="${escapeHtml(item.scopeKey)}">${escapeHtml(scopeKeyLabel(item))}</option>`)
+    .join('');
+  if (!matches.length && fallback) {
+    select.innerHTML = `<option value="${escapeHtml(fallback)}">${escapeHtml(fallback)}</option>`;
+  }
+  if (preferred && [...select.options].some((option) => option.value === preferred)) {
+    select.value = preferred;
+  } else if (matches.length) {
+    select.value = matches[0].scopeKey;
+  }
+}
+
+function fillScopeKeySelects() {
+  fillScopeKeySelect($('#memoryScopeKey'), $('#memoryScope').value, $('#memoryScopeKey').value);
+  fillScopeKeySelect($('#runScopeKey'), $('#runScope').value, $('#runScopeKey').value);
+}
+
+function formNumber(form, key) {
+  const value = Number(form[key].value);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+$('#settingsForm').addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const values = {
+    distillProvider: form.distillProvider.value,
+    distillPolicy: {
+      minEvents: formNumber(form, 'minEvents'),
+      minIntervalMs: formNumber(form, 'minIntervalMs'),
+      charMinIntervalMs: formNumber(form, 'charMinIntervalMs'),
+      charThreshold: formNumber(form, 'charThreshold'),
+      maxEvents: formNumber(form, 'maxEvents'),
+      maxChars: formNumber(form, 'maxChars'),
+    },
+  };
+  if (form.distillProvider.value === 'openai_compatible') {
+    values.openAiCompatible = {
+      preset: form.preset.value,
+      baseUrl: form.baseUrl.value,
+      model: form.model.value,
+      responseFormat: form.responseFormat.value,
+    };
+  }
+  if (form.distillProvider.value === 'codex_exec') {
+    values.codexExec = {
+      command: form.codexCommand.value,
+      model: form.codexModel.value || null,
+      reasoningEffort: form.codexReasoningEffort.value || null,
+    };
+  }
+  const secrets = {};
+  if (form.distillProvider.value === 'openai_compatible' && form.apiKey.value.trim()) {
+    secrets.openAiCompatibleApiKey = form.apiKey.value.trim();
+  }
+  const result = await call('updateRuntimeSettings', { values, secrets });
+  form.apiKey.value = '';
+  $('#settingsMessage').textContent = JSON.stringify(result.effective, null, 2);
+  await refreshRuntime();
+});
+
+$('#deepseekPreset').addEventListener('click', () => {
+  const form = $('#settingsForm');
+  form.distillProvider.value = 'openai_compatible';
+  form.preset.value = 'deepseek';
+  form.baseUrl.value = 'https://api.deepseek.com';
+  form.model.value = 'deepseek-v4-flash';
+  form.responseFormat.value = 'json_object';
+  updateProviderSections();
+});
+
+$('#checkProvider').addEventListener('click', async () => {
+  const result = await call('checkDistillProvider', { live: true });
+  $('#settingsMessage').textContent = JSON.stringify(result, null, 2);
+});
+
+$('#settingsForm').distillProvider.addEventListener('change', updateProviderSections);
+$('#memoryScope').addEventListener('change', () => fillScopeKeySelect($('#memoryScopeKey'), $('#memoryScope').value));
+$('#runScope').addEventListener('change', () => fillScopeKeySelect($('#runScopeKey'), $('#runScope').value));
+
+async function loadRuns(target = '#runsTable', options = {}) {
+  const scope = options.scope || $('#runScope')?.value || 'repo';
+  const scopeKey = options.scopeKey || $('#runScopeKey')?.value || state.db?.connection?.scopeKey || '';
+  if (!scopeKey) return;
+  const sessionId = options.sessionId ?? $('#runSession')?.value;
+  const runs = await call('listDistillRuns', { scope, scopeKey, ...(sessionId ? { sessionId } : {}), limit: 100 });
+  $(target).innerHTML = table(runs.slice(-25).reverse(), [
+    { label: '생성 시각', value: (row) => row.createdAt },
+    { label: '프로바이더', value: (row) => row.provider },
+    { label: '상태', value: (row) => row.status },
+    { label: '세션', value: (row) => row.sessionId },
+    { label: '이벤트', value: (row) => row.sourceEventCount },
+    { label: '오류', value: (row) => row.errorMessage || '' },
+  ]);
+}
+
+$('#loadRuns').addEventListener('click', (event) => {
+  event.preventDefault();
+  loadRuns();
+});
+
+$('#loadMemories').addEventListener('click', async (event) => {
+  event.preventDefault();
+  const scope = $('#memoryScope').value;
+  const scopeKey = $('#memoryScopeKey').value;
+  const query = $('#memoryQuery').value;
+  const status = $('#memoryStatus').value;
+  const memories = await call('listMemories', { scope, scopeKey, query, status, limit: 100 });
+  state.memories = memories;
+  $('#memories').innerHTML = memories.map(memoryItem).join('') || '<p class="muted">메모리가 없습니다.</p>';
+  document.querySelectorAll('[data-memory]').forEach((button) => {
+    button.addEventListener('click', () => showDetail('메모리', memories[Number(button.dataset.memory)]));
+  });
+  document.querySelectorAll('[data-deactivate]').forEach((button) => {
+    button.addEventListener('click', async () => {
+      const memory = memories[Number(button.dataset.deactivate)];
+      const reason = prompt(`${memory.key} 메모리를 비활성화하는 이유를 입력하세요.`);
+      if (!reason) return;
+      await call('deactivateMemory', { scope, scopeKey, key: memory.key, reason });
+      $('#loadMemories').click();
+    });
+  });
+  document.querySelectorAll('[data-correct]').forEach((button) => {
+    button.addEventListener('click', async () => {
+      const memory = memories[Number(button.dataset.correct)];
+      const content = prompt(`${memory.key} 메모리의 수정 내용을 입력하세요.`, memory.content);
+      if (!content || content === memory.content) return;
+      const reason = prompt('수정 이유를 입력하세요.') || 'admin-ui correction';
+      await call('correctMemory', {
+        scope,
+        scopeKey,
+        key: memory.key,
+        content,
+        category: memory.category,
+        tags: memory.tags,
+        importance: memory.importance,
+        reason,
+      });
+      $('#loadMemories').click();
+    });
+  });
+});
+
+function memoryItem(memory, index) {
+  return `<article class="item">
+    <header><span class="item-title"><input type="checkbox" data-memory-select="${index}" aria-label="메모리 선택" /><strong>${escapeHtml(memory.key)}</strong></span><span class="muted">${escapeHtml(memory.category)} · ${memory.importance}</span></header>
+    <p>${escapeHtml(memory.content.slice(0, 280))}</p>
+    <div class="actions">
+      <button data-memory="${index}">상세</button>
+      <button data-correct="${index}">수정</button>
+      <button class="danger" data-deactivate="${index}">비활성화</button>
+    </div>
+  </article>`;
+}
+
+$('#loadCandidates').addEventListener('click', async (event) => {
+  event.preventDefault();
+  const scope = $('#memoryScope').value;
+  const scopeKey = $('#memoryScopeKey').value;
+  const candidates = await call('listMemoryCandidates', { scope, scopeKey, limit: 100 });
+  state.candidates = candidates;
+  $('#candidates').innerHTML = candidates.map(candidateItem).join('') || '<p class="muted">후보가 없습니다.</p>';
+  document.querySelectorAll('[data-candidate]').forEach((button) => {
+    button.addEventListener('click', () => showDetail('후보', candidates[Number(button.dataset.candidate)]));
+  });
+  document.querySelectorAll('[data-promote]').forEach((button) => {
+    button.addEventListener('click', async () => {
+      const candidate = candidates[Number(button.dataset.promote)];
+      const key = prompt('메모리 키', candidate.candidate.key);
+      if (!key) return;
+      const content = prompt('메모리 내용', candidate.candidate.content);
+      if (!content) return;
+      await call('promoteMemoryCandidate', {
+        scope,
+        scopeKey,
+        candidateId: candidate.id,
+        key,
+        content,
+        category: candidate.candidate.category || 'note',
+        tags: candidate.candidate.tags || [],
+        importance: candidate.candidate.importance || 0,
+        allowWarnings: true,
+      });
+      $('#loadCandidates').click();
+    });
+  });
+  document.querySelectorAll('[data-reject]').forEach((button) => {
+    button.addEventListener('click', async () => {
+      const candidate = candidates[Number(button.dataset.reject)];
+      const reason = prompt('후보 거절 이유를 입력하세요.');
+      if (!reason) return;
+      await call('rejectMemoryCandidate', { scope, scopeKey, candidateId: candidate.id, reason });
+      $('#loadCandidates').click();
+    });
+  });
+});
+
+function candidateItem(candidate, index) {
+  return `<article class="item">
+    <header><span class="item-title"><input type="checkbox" data-candidate-select="${index}" aria-label="후보 선택" /><strong>${escapeHtml(candidate.candidate.key)}</strong></span><span class="muted">${escapeHtml(candidate.status)}</span></header>
+    <p>${escapeHtml(candidate.candidate.content.slice(0, 220))}</p>
+    <div class="actions">
+      <button data-candidate="${index}">상세</button>
+      <button data-promote="${index}">승격</button>
+      <button class="danger" data-reject="${index}">거절</button>
+    </div>
+  </article>`;
+}
+
+function checkedIndexes(selector) {
+  return [...document.querySelectorAll(`${selector}:checked`)].map((input) => Number(input.dataset.memorySelect ?? input.dataset.candidateSelect));
+}
+
+function setChecked(selector, checked) {
+  document.querySelectorAll(selector).forEach((input) => {
+    input.checked = checked;
+  });
+}
+
+$('#selectAllMemories').addEventListener('click', (event) => {
+  event.preventDefault();
+  setChecked('[data-memory-select]', true);
+});
+
+$('#clearMemorySelection').addEventListener('click', (event) => {
+  event.preventDefault();
+  setChecked('[data-memory-select]', false);
+});
+
+$('#deactivateSelectedMemories').addEventListener('click', async (event) => {
+  event.preventDefault();
+  const indexes = checkedIndexes('[data-memory-select]');
+  if (!indexes.length) return;
+  const reason = prompt(`선택한 메모리 ${indexes.length}개를 비활성화하는 이유를 입력하세요.`);
+  if (!reason) return;
+  const scope = $('#memoryScope').value;
+  const scopeKey = $('#memoryScopeKey').value;
+  for (const index of indexes) {
+    const memory = state.memories[index];
+    if (memory) {
+      await call('deactivateMemory', { scope, scopeKey, key: memory.key, reason });
+    }
+  }
+  $('#loadMemories').click();
+});
+
+$('#selectAllCandidates').addEventListener('click', (event) => {
+  event.preventDefault();
+  setChecked('[data-candidate-select]', true);
+});
+
+$('#clearCandidateSelection').addEventListener('click', (event) => {
+  event.preventDefault();
+  setChecked('[data-candidate-select]', false);
+});
+
+$('#rejectSelectedCandidates').addEventListener('click', async (event) => {
+  event.preventDefault();
+  const indexes = checkedIndexes('[data-candidate-select]');
+  if (!indexes.length) return;
+  const reason = prompt(`선택한 후보 ${indexes.length}개를 거절하는 이유를 입력하세요.`);
+  if (!reason) return;
+  const scope = $('#memoryScope').value;
+  const scopeKey = $('#memoryScopeKey').value;
+  for (const index of indexes) {
+    const candidate = state.candidates[index];
+    if (candidate) {
+      await call('rejectMemoryCandidate', { scope, scopeKey, candidateId: candidate.id, reason });
+    }
+  }
+  $('#loadCandidates').click();
+});
+
+document.querySelectorAll('.tabs button').forEach((button) => {
+  button.addEventListener('click', () => {
+    document.querySelectorAll('.tabs button, .tab').forEach((item) => item.classList.remove('active'));
+    button.classList.add('active');
+    $(`#${button.dataset.tab}`).classList.add('active');
+  });
+});
+
+refreshRuntime()
+  .then(() => loadRuns('#recentRuns', { scope: 'repo', scopeKey: state.db?.defaultScopeKey || '' }).catch(() => {}))
+  .catch((error) => {
+    $('#connection').textContent = error.message;
+  });

--- a/src/admin-ui/app.js
+++ b/src/admin-ui/app.js
@@ -9,14 +9,21 @@ const state = {
 const $ = (selector) => document.querySelector(selector);
 const tokenInput = $('#token');
 
+function setLoginState(loggedIn, username = '') {
+  $('#loginForm').hidden = loggedIn;
+  $('#loginStatus').hidden = !loggedIn;
+  $('#loginMessage').textContent = loggedIn ? `${username || '관리자'} 로그인됨` : '';
+}
+
 $('#loginForm').addEventListener('submit', async (event) => {
   event.preventDefault();
   const form = event.currentTarget;
+  const username = form.username.value.trim();
   const response = await fetch('/ui/login', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
-      username: form.username.value,
+      username,
       password: form.password.value,
     }),
   });
@@ -25,7 +32,14 @@ $('#loginForm').addEventListener('submit', async (event) => {
     return;
   }
   form.password.value = '';
+  setLoginState(true, username);
   await refreshRuntime();
+});
+
+$('#logoutButton').addEventListener('click', async () => {
+  await fetch('/ui/logout', { method: 'POST' }).catch(() => {});
+  setLoginState(false);
+  $('#connection').textContent = '로그아웃됨';
 });
 
 function headers() {

--- a/src/admin-ui/app.js
+++ b/src/admin-ui/app.js
@@ -137,6 +137,12 @@ function fillSettingsForm() {
   form.codexCommand.value = effective.codexExec.command || 'codex';
   form.codexModel.value = effective.codexExec.model || '';
   form.codexReasoningEffort.value = effective.codexExec.reasoningEffort || '';
+  form.auditEnabled.checked = effective.autoPromoteAudit.enabled !== false;
+  form.auditProvider.value = effective.autoPromoteAudit.provider || 'codex_exec';
+  form.auditCommand.value = effective.autoPromoteAudit.command || 'codex';
+  form.auditModel.value = effective.autoPromoteAudit.model || 'gpt-5.5';
+  form.auditReasoningEffort.value = effective.autoPromoteAudit.reasoningEffort || 'low';
+  form.auditTimeoutMs.value = effective.autoPromoteAudit.timeoutMs || 120000;
   for (const [key, value] of Object.entries(effective.distillPolicy)) {
     if (form[key]) form[key].value = value;
   }
@@ -198,6 +204,14 @@ $('#settingsForm').addEventListener('submit', async (event) => {
       charThreshold: formNumber(form, 'charThreshold'),
       maxEvents: formNumber(form, 'maxEvents'),
       maxChars: formNumber(form, 'maxChars'),
+    },
+    autoPromoteAudit: {
+      enabled: form.auditEnabled.checked,
+      provider: form.auditProvider.value,
+      command: form.auditCommand.value,
+      model: form.auditModel.value || 'gpt-5.5',
+      reasoningEffort: form.auditReasoningEffort.value || 'low',
+      timeoutMs: formNumber(form, 'auditTimeoutMs') || 120000,
     },
   };
   if (form.distillProvider.value === 'openai_compatible') {

--- a/src/admin-ui/app.js
+++ b/src/admin-ui/app.js
@@ -204,6 +204,16 @@ function fillScopeKeySelects() {
   fillScopeKeySelect($('#runScopeKey'), $('#runScope').value, $('#runScopeKey').value);
 }
 
+function dashboardRunScope() {
+  const repoWithRuns = state.scopeKeys.find((item) => item.scopeType === 'repo' && item.distillRuns > 0);
+  const anyWithRuns = state.scopeKeys.find((item) => item.distillRuns > 0);
+  const selected = repoWithRuns || anyWithRuns;
+  if (selected) {
+    return { scope: selected.scopeType, scopeKey: selected.scopeKey };
+  }
+  return { scope: 'repo', scopeKey: state.db?.defaultScopeKey || '' };
+}
+
 function formNumber(form, key) {
   const value = Number(form[key].value);
   return Number.isFinite(value) && value > 0 ? value : undefined;
@@ -293,8 +303,8 @@ async function loadRuns(target = '#runsTable', options = {}) {
   const scopeKey = options.scopeKey || $('#runScopeKey')?.value || state.db?.connection?.scopeKey || '';
   if (!scopeKey) return;
   const sessionId = options.sessionId ?? $('#runSession')?.value;
-  const runs = await call('listDistillRuns', { scope, scopeKey, ...(sessionId ? { sessionId } : {}), limit: 100 });
-  $(target).innerHTML = table(runs.slice(-25).reverse(), [
+  const runs = await call('listDistillRuns', { scope, scopeKey, ...(sessionId ? { sessionId } : {}), limit: 25, order: 'desc' });
+  $(target).innerHTML = table(runs, [
     { label: '생성 시각', value: (row) => row.createdAt },
     { label: '프로바이더', value: (row) => row.provider },
     { label: '상태', value: (row) => row.status },
@@ -490,7 +500,7 @@ document.querySelectorAll('.tabs button').forEach((button) => {
 });
 
 refreshRuntime()
-  .then(() => loadRuns('#recentRuns', { scope: 'repo', scopeKey: state.db?.defaultScopeKey || '' }).catch(() => {}))
+  .then(() => loadRuns('#recentRuns', dashboardRunScope()).catch(() => {}))
   .catch((error) => {
     $('#connection').textContent = error.message;
   });

--- a/src/admin-ui/app.js
+++ b/src/admin-ui/app.js
@@ -8,8 +8,6 @@ const state = {
 
 const $ = (selector) => document.querySelector(selector);
 const tokenInput = $('#token');
-tokenInput.value = localStorage.getItem('contextforgeToken') || '';
-tokenInput.addEventListener('input', () => localStorage.setItem('contextforgeToken', tokenInput.value));
 
 $('#loginForm').addEventListener('submit', async (event) => {
   event.preventDefault();
@@ -134,9 +132,16 @@ function fillSettingsForm() {
   form.baseUrl.value = effective.openAiCompatible.baseUrl || '';
   form.model.value = effective.openAiCompatible.model || '';
   form.responseFormat.value = effective.openAiCompatible.responseFormat || 'json_object';
+  form.openAiTimeoutMs.value = effective.openAiCompatible.timeoutMs || 120000;
+  form.openAiMaxInputChars.value = effective.openAiCompatible.maxInputChars || 12000;
+  form.openAiMaxTokens.value = effective.openAiCompatible.maxTokens || '';
   form.codexCommand.value = effective.codexExec.command || 'codex';
   form.codexModel.value = effective.codexExec.model || '';
   form.codexReasoningEffort.value = effective.codexExec.reasoningEffort || '';
+  form.codexSandbox.value = effective.codexExec.sandbox || 'read-only';
+  form.codexCwd.value = effective.codexExec.cwd || '';
+  form.codexTimeoutMs.value = effective.codexExec.timeoutMs || 120000;
+  form.codexMaxInputChars.value = effective.codexExec.maxInputChars || 12000;
   form.auditEnabled.checked = effective.autoPromoteAudit.enabled !== false;
   form.auditProvider.value = effective.autoPromoteAudit.provider || 'codex_exec';
   form.auditCommand.value = effective.autoPromoteAudit.command || 'codex';
@@ -155,6 +160,18 @@ function updateProviderSections() {
     section.hidden = section.dataset.providerSection !== provider;
   });
   $('#deepseekPreset').hidden = provider !== 'openai_compatible';
+}
+
+function applyOpenAiPreset(presetKey) {
+  const preset = state.runtime?.effective?.presets?.openai_compatible?.[presetKey];
+  if (!preset || presetKey === 'custom') return;
+  const form = $('#settingsForm');
+  form.baseUrl.value = preset.baseUrl || '';
+  form.model.value = preset.model || '';
+  form.responseFormat.value = preset.responseFormat || 'json_object';
+  form.openAiTimeoutMs.value = 120000;
+  form.openAiMaxInputChars.value = 12000;
+  form.openAiMaxTokens.value = '';
 }
 
 function scopeKeyLabel(item) {
@@ -220,6 +237,9 @@ $('#settingsForm').addEventListener('submit', async (event) => {
       baseUrl: form.baseUrl.value,
       model: form.model.value,
       responseFormat: form.responseFormat.value,
+      timeoutMs: formNumber(form, 'openAiTimeoutMs') || 120000,
+      maxInputChars: formNumber(form, 'openAiMaxInputChars') || 12000,
+      maxTokens: formNumber(form, 'openAiMaxTokens') || null,
     };
   }
   if (form.distillProvider.value === 'codex_exec') {
@@ -227,14 +247,25 @@ $('#settingsForm').addEventListener('submit', async (event) => {
       command: form.codexCommand.value,
       model: form.codexModel.value || null,
       reasoningEffort: form.codexReasoningEffort.value || null,
+      sandbox: form.codexSandbox.value || 'read-only',
+      timeoutMs: formNumber(form, 'codexTimeoutMs') || 120000,
+      maxInputChars: formNumber(form, 'codexMaxInputChars') || 12000,
     };
+    if (form.codexCwd.value.trim()) {
+      values.codexExec.cwd = form.codexCwd.value.trim();
+    }
   }
   const secrets = {};
+  const clearSecrets = [];
   if (form.distillProvider.value === 'openai_compatible' && form.apiKey.value.trim()) {
     secrets.openAiCompatibleApiKey = form.apiKey.value.trim();
   }
-  const result = await call('updateRuntimeSettings', { values, secrets });
+  if (form.clearApiKey.checked) {
+    clearSecrets.push('openAiCompatibleApiKey');
+  }
+  const result = await call('updateRuntimeSettings', { values, secrets, clearSecrets });
   form.apiKey.value = '';
+  form.clearApiKey.checked = false;
   $('#settingsMessage').textContent = JSON.stringify(result.effective, null, 2);
   await refreshRuntime();
 });
@@ -243,9 +274,7 @@ $('#deepseekPreset').addEventListener('click', () => {
   const form = $('#settingsForm');
   form.distillProvider.value = 'openai_compatible';
   form.preset.value = 'deepseek';
-  form.baseUrl.value = 'https://api.deepseek.com';
-  form.model.value = 'deepseek-v4-flash';
-  form.responseFormat.value = 'json_object';
+  applyOpenAiPreset('deepseek');
   updateProviderSections();
 });
 
@@ -255,6 +284,7 @@ $('#checkProvider').addEventListener('click', async () => {
 });
 
 $('#settingsForm').distillProvider.addEventListener('change', updateProviderSections);
+$('#settingsForm').preset.addEventListener('change', (event) => applyOpenAiPreset(event.target.value));
 $('#memoryScope').addEventListener('change', () => fillScopeKeySelect($('#memoryScopeKey'), $('#memoryScope').value));
 $('#runScope').addEventListener('change', () => fillScopeKeySelect($('#runScopeKey'), $('#runScope').value));
 
@@ -323,7 +353,7 @@ $('#loadMemories').addEventListener('click', async (event) => {
 
 function memoryItem(memory, index) {
   return `<article class="item">
-    <header><span class="item-title"><input type="checkbox" data-memory-select="${index}" aria-label="메모리 선택" /><strong>${escapeHtml(memory.key)}</strong></span><span class="muted">${escapeHtml(memory.category)} · ${memory.importance}</span></header>
+    <header><span class="item-title"><input type="checkbox" data-memory-select="${index}" aria-label="메모리 선택" /><strong>${escapeHtml(memory.key)}</strong></span><span class="muted">${escapeHtml(memory.category)} · ${escapeHtml(memory.importance)}</span></header>
     <p>${escapeHtml(memory.content.slice(0, 280))}</p>
     <div class="actions">
       <button data-memory="${index}">상세</button>

--- a/src/admin-ui/index.html
+++ b/src/admin-ui/index.html
@@ -21,6 +21,10 @@
         <input name="password" type="password" autocomplete="current-password" placeholder="비밀번호" />
         <button type="submit">로그인</button>
       </form>
+      <div id="loginStatus" class="login-status" hidden>
+        <span id="loginMessage">로그인됨</span>
+        <button type="button" id="logoutButton">로그아웃</button>
+      </div>
     </header>
 
     <nav class="tabs" aria-label="관리 메뉴">

--- a/src/admin-ui/index.html
+++ b/src/admin-ui/index.html
@@ -97,6 +97,23 @@
             </div>
           </fieldset>
           <fieldset>
+            <legend>자동승격 감사 설정</legend>
+            <div class="row">
+              <label class="checkbox"><input name="auditEnabled" type="checkbox" /> 감사 사용</label>
+              <label>감사 프로바이더
+                <select name="auditProvider">
+                  <option value="codex_exec">codex_exec</option>
+                </select>
+              </label>
+            </div>
+            <div class="row">
+              <label>감사 Codex 명령 <input name="auditCommand" /></label>
+              <label>감사 모델 <input name="auditModel" placeholder="gpt-5.5" /></label>
+              <label>감사 추론 강도 <input name="auditReasoningEffort" placeholder="low" /></label>
+              <label>감사 제한 시간(ms) <input name="auditTimeoutMs" type="number" min="1" /></label>
+            </div>
+          </fieldset>
+          <fieldset>
             <legend>디스틸 정책</legend>
             <div class="row compact">
               <label>최소 이벤트 수 <input name="minEvents" type="number" min="1" /></label>

--- a/src/admin-ui/index.html
+++ b/src/admin-ui/index.html
@@ -17,7 +17,7 @@
         <input id="token" type="password" autocomplete="off" placeholder="로그인 세션 사용 시 비워둠" />
       </label>
       <form id="loginForm" class="login">
-        <input name="username" autocomplete="username" placeholder="아이디" value="ginishuh" />
+        <input name="username" autocomplete="username" placeholder="아이디" />
         <input name="password" type="password" autocomplete="current-password" placeholder="비밀번호" />
         <button type="submit">로그인</button>
       </form>
@@ -65,6 +65,9 @@
               <label>프리셋
                 <select name="preset">
                   <option value="deepseek">DeepSeek V4 Flash</option>
+                  <option value="deepseekPro">DeepSeek V4 Pro</option>
+                  <option value="deepseekChat">DeepSeek Chat</option>
+                  <option value="deepseekReasoner">DeepSeek Reasoner</option>
                   <option value="custom">직접 입력</option>
                 </select>
               </label>
@@ -78,22 +81,42 @@
             </div>
             <div class="row">
               <label>Base URL <input name="baseUrl" /></label>
-              <label>모델 <input name="model" list="modelPresets" /></label>
+              <label>디스틸 모델 <input name="model" list="modelPresets" placeholder="프리셋 선택 또는 직접 입력" /></label>
               <datalist id="modelPresets">
                 <option value="deepseek-v4-flash"></option>
                 <option value="deepseek-v4-pro"></option>
+                <option value="deepseek-chat"></option>
+                <option value="deepseek-reasoner"></option>
               </datalist>
             </div>
             <div class="row">
+              <label>제한 시간(ms) <input name="openAiTimeoutMs" type="number" min="1" /></label>
+              <label>최대 입력 문자 수 <input name="openAiMaxInputChars" type="number" min="1" /></label>
+              <label>최대 출력 토큰 <input name="openAiMaxTokens" type="number" min="1" placeholder="비우면 기본값" /></label>
+            </div>
+            <div class="row">
               <label>API 키 <input name="apiKey" type="password" autocomplete="off" placeholder="저장 전용" /></label>
+              <label class="checkbox"><input name="clearApiKey" type="checkbox" /> 저장된 API 키 지우기</label>
             </div>
           </fieldset>
           <fieldset class="provider-section" data-provider-section="codex_exec">
             <legend>Codex Exec 설정</legend>
             <div class="row">
               <label>Codex 명령 <input name="codexCommand" /></label>
-              <label>Codex 모델 <input name="codexModel" placeholder="직접 입력 또는 비움" /></label>
+              <label>디스틸 모델 <input name="codexModel" list="codexModelPresets" placeholder="프리셋 선택 또는 직접 입력" /></label>
+              <datalist id="codexModelPresets">
+                <option value="gpt-5.5"></option>
+                <option value="gpt-5.4"></option>
+                <option value="gpt-5.4-mini"></option>
+                <option value="gpt-5.3-codex"></option>
+              </datalist>
               <label>추론 강도 <input name="codexReasoningEffort" placeholder="low" /></label>
+            </div>
+            <div class="row">
+              <label>샌드박스 <input name="codexSandbox" placeholder="read-only" /></label>
+              <label>실행 위치 <input name="codexCwd" placeholder="비우면 서버 기본값" /></label>
+              <label>제한 시간(ms) <input name="codexTimeoutMs" type="number" min="1" /></label>
+              <label>최대 입력 문자 수 <input name="codexMaxInputChars" type="number" min="1" /></label>
             </div>
           </fieldset>
           <fieldset>
@@ -108,7 +131,7 @@
             </div>
             <div class="row">
               <label>감사 Codex 명령 <input name="auditCommand" /></label>
-              <label>감사 모델 <input name="auditModel" placeholder="gpt-5.5" /></label>
+              <label>감사 모델 <input name="auditModel" list="codexModelPresets" placeholder="gpt-5.5" /></label>
               <label>감사 추론 강도 <input name="auditReasoningEffort" placeholder="low" /></label>
               <label>감사 제한 시간(ms) <input name="auditTimeoutMs" type="number" min="1" /></label>
             </div>

--- a/src/admin-ui/index.html
+++ b/src/admin-ui/index.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ContextForge 관리</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <div>
+        <h1>ContextForge</h1>
+        <p id="connection">런타임 불러오는 중...</p>
+      </div>
+      <label class="token">
+        <span>원격 API 토큰</span>
+        <input id="token" type="password" autocomplete="off" placeholder="로그인 세션 사용 시 비워둠" />
+      </label>
+      <form id="loginForm" class="login">
+        <input name="username" autocomplete="username" placeholder="아이디" value="ginishuh" />
+        <input name="password" type="password" autocomplete="current-password" placeholder="비밀번호" />
+        <button type="submit">로그인</button>
+      </form>
+    </header>
+
+    <nav class="tabs" aria-label="관리 메뉴">
+      <button class="active" data-tab="dashboard">대시보드</button>
+      <button data-tab="settings">설정</button>
+      <button data-tab="memory">메모리</button>
+      <button data-tab="runs">실행 기록</button>
+    </nav>
+
+    <main>
+      <section id="dashboard" class="tab active">
+        <div class="grid">
+          <section class="panel">
+            <h2>런타임</h2>
+            <dl id="runtimeSummary"></dl>
+          </section>
+          <section class="panel">
+            <h2>디스틸 정책</h2>
+            <dl id="policySummary"></dl>
+          </section>
+          <section class="panel wide">
+            <h2>최근 실행</h2>
+            <div id="recentRuns" class="table"></div>
+          </section>
+        </div>
+      </section>
+
+      <section id="settings" class="tab">
+        <form id="settingsForm" class="panel form">
+          <div class="row">
+            <label>프로바이더
+              <select name="distillProvider">
+                <option value="codex_exec">codex_exec</option>
+                <option value="openai_compatible">openai_compatible</option>
+                <option value="mock">mock</option>
+              </select>
+            </label>
+          </div>
+          <fieldset class="provider-section" data-provider-section="openai_compatible">
+            <legend>OpenAI 호환 API 설정</legend>
+            <div class="row">
+              <label>프리셋
+                <select name="preset">
+                  <option value="deepseek">DeepSeek V4 Flash</option>
+                  <option value="custom">직접 입력</option>
+                </select>
+              </label>
+              <label>응답 모드
+                <select name="responseFormat">
+                  <option value="json_object">json_object</option>
+                  <option value="json_schema">json_schema</option>
+                  <option value="text">text</option>
+                </select>
+              </label>
+            </div>
+            <div class="row">
+              <label>Base URL <input name="baseUrl" /></label>
+              <label>모델 <input name="model" list="modelPresets" /></label>
+              <datalist id="modelPresets">
+                <option value="deepseek-v4-flash"></option>
+                <option value="deepseek-v4-pro"></option>
+              </datalist>
+            </div>
+            <div class="row">
+              <label>API 키 <input name="apiKey" type="password" autocomplete="off" placeholder="저장 전용" /></label>
+            </div>
+          </fieldset>
+          <fieldset class="provider-section" data-provider-section="codex_exec">
+            <legend>Codex Exec 설정</legend>
+            <div class="row">
+              <label>Codex 명령 <input name="codexCommand" /></label>
+              <label>Codex 모델 <input name="codexModel" placeholder="직접 입력 또는 비움" /></label>
+              <label>추론 강도 <input name="codexReasoningEffort" placeholder="low" /></label>
+            </div>
+          </fieldset>
+          <fieldset>
+            <legend>디스틸 정책</legend>
+            <div class="row compact">
+              <label>최소 이벤트 수 <input name="minEvents" type="number" min="1" /></label>
+              <label>최소 시간 간격(ms) <input name="minIntervalMs" type="number" min="1" /></label>
+              <label>문자 기준 최소 간격(ms) <input name="charMinIntervalMs" type="number" min="1" /></label>
+              <label>문자 수 기준 <input name="charThreshold" type="number" min="1" /></label>
+              <label>최대 이벤트 수 <input name="maxEvents" type="number" min="1" /></label>
+              <label>최대 입력 문자 수 <input name="maxChars" type="number" min="1" /></label>
+            </div>
+          </fieldset>
+          <div class="actions">
+            <button type="button" id="deepseekPreset">DeepSeek 프리셋</button>
+            <button type="button" id="checkProvider">프로바이더 실사용 테스트</button>
+            <button type="submit" class="primary">설정 저장</button>
+          </div>
+          <pre id="settingsMessage"></pre>
+        </form>
+      </section>
+
+      <section id="memory" class="tab">
+        <section class="panel form">
+          <div class="row">
+            <label>스코프 <select id="memoryScope"><option>repo</option><option>shared</option><option>local</option></select></label>
+            <label>스코프 키 <select id="memoryScopeKey"></select></label>
+            <label>검색 <input id="memoryQuery" /></label>
+            <label>상태 <select id="memoryStatus"><option value="active">활성</option><option value="inactive">비활성</option><option value="all">전체</option></select></label>
+          </div>
+          <div class="actions">
+            <button id="loadMemories">메모리 불러오기</button>
+            <button id="loadCandidates">후보 불러오기</button>
+          </div>
+        </section>
+        <div class="split">
+          <section class="panel">
+            <h2>영구 메모리</h2>
+            <div class="actions bulkbar">
+              <button id="selectAllMemories">전체 선택</button>
+              <button id="clearMemorySelection">선택 해제</button>
+              <button class="danger" id="deactivateSelectedMemories">선택 메모리 비활성화</button>
+            </div>
+            <div id="memories" class="list"></div>
+          </section>
+          <section class="panel">
+            <h2>승격 후보</h2>
+            <div class="actions bulkbar">
+              <button id="selectAllCandidates">전체 선택</button>
+              <button id="clearCandidateSelection">선택 해제</button>
+              <button class="danger" id="rejectSelectedCandidates">선택 후보 거절</button>
+            </div>
+            <div id="candidates" class="list"></div>
+          </section>
+        </div>
+      </section>
+
+      <section id="runs" class="tab">
+        <section class="panel form">
+          <div class="row">
+            <label>스코프 <select id="runScope"><option>repo</option><option>shared</option><option>local</option></select></label>
+            <label>스코프 키 <select id="runScopeKey"></select></label>
+            <label>세션 <input id="runSession" placeholder="선택 사항" /></label>
+          </div>
+          <button id="loadRuns">실행 기록 불러오기</button>
+        </section>
+        <section class="panel">
+          <div id="runsTable" class="table"></div>
+        </section>
+      </section>
+    </main>
+
+    <dialog id="detailDialog">
+      <form method="dialog">
+        <button class="close">닫기</button>
+      </form>
+      <div id="detail"></div>
+    </dialog>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/src/admin-ui/styles.css
+++ b/src/admin-ui/styles.css
@@ -40,6 +40,17 @@ h2 { font-size: 15px; margin-bottom: 12px; }
 }
 .login input { min-width: 0; }
 .login button { background: #ffffff; color: #18202d; }
+.login-status {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  color: #dce5f3;
+}
+.login-status[hidden] { display: none; }
+.login-status button {
+  background: #ffffff;
+  color: #18202d;
+}
 .token input, input, select, textarea {
   width: 100%;
   border: 1px solid var(--line);

--- a/src/admin-ui/styles.css
+++ b/src/admin-ui/styles.css
@@ -40,6 +40,7 @@ h2 { font-size: 15px; margin-bottom: 12px; }
 }
 .login input { min-width: 0; }
 .login button { background: #ffffff; color: #18202d; }
+.login[hidden] { display: none; }
 .login-status {
   display: flex;
   gap: 10px;

--- a/src/admin-ui/styles.css
+++ b/src/admin-ui/styles.css
@@ -85,6 +85,12 @@ main { padding: 20px 24px 40px; }
 }
 .row.compact { grid-template-columns: repeat(3, minmax(120px, 1fr)); }
 label { display: grid; gap: 5px; color: var(--muted); }
+label.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+label.checkbox input { width: auto; }
 fieldset { border: 1px solid var(--line); border-radius: 8px; margin: 0 0 12px; }
 legend { color: var(--muted); }
 .provider-section[hidden] { display: none; }

--- a/src/admin-ui/styles.css
+++ b/src/admin-ui/styles.css
@@ -1,0 +1,145 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f7f9;
+  --panel: #ffffff;
+  --ink: #1d2430;
+  --muted: #647084;
+  --line: #d9dee7;
+  --accent: #0b6bcb;
+  --danger: #b42318;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font: 14px/1.45 system-ui, -apple-system, Segoe UI, sans-serif;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: center;
+  padding: 18px 24px;
+  background: #18202d;
+  color: white;
+}
+h1, h2, p { margin: 0; }
+h1 { font-size: 20px; }
+h2 { font-size: 15px; margin-bottom: 12px; }
+.topbar p { color: #c3ccda; margin-top: 4px; }
+
+.token { display: grid; gap: 5px; min-width: min(280px, 32vw); }
+.login {
+  display: grid;
+  grid-template-columns: minmax(90px, 1fr) minmax(130px, 1fr) auto;
+  gap: 8px;
+  align-items: end;
+}
+.login input { min-width: 0; }
+.login button { background: #ffffff; color: #18202d; }
+.token input, input, select, textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font: inherit;
+  background: white;
+}
+
+.tabs {
+  display: flex;
+  gap: 4px;
+  padding: 10px 24px 0;
+  background: white;
+  border-bottom: 1px solid var(--line);
+}
+.tabs button {
+  border: 0;
+  background: transparent;
+  padding: 10px 14px;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+}
+.tabs button.active { border-color: var(--accent); color: var(--accent); }
+
+main { padding: 20px 24px 40px; }
+.tab { display: none; }
+.tab.active { display: block; }
+.grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+.wide { grid-column: 1 / -1; }
+.split { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 16px; }
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 16px;
+}
+.row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(180px, 1fr));
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.row.compact { grid-template-columns: repeat(3, minmax(120px, 1fr)); }
+label { display: grid; gap: 5px; color: var(--muted); }
+fieldset { border: 1px solid var(--line); border-radius: 8px; margin: 0 0 12px; }
+legend { color: var(--muted); }
+.provider-section[hidden] { display: none; }
+.actions { display: flex; gap: 8px; flex-wrap: wrap; }
+button {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: white;
+  padding: 8px 11px;
+  cursor: pointer;
+}
+button.primary { background: var(--accent); color: white; border-color: var(--accent); }
+button.danger { color: white; background: var(--danger); border-color: var(--danger); }
+
+dl { display: grid; grid-template-columns: 160px 1fr; gap: 8px 12px; margin: 0; }
+dt { color: var(--muted); }
+dd { margin: 0; word-break: break-word; }
+.table { overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; }
+th, td { text-align: left; padding: 8px; border-bottom: 1px solid var(--line); vertical-align: top; }
+th { color: var(--muted); font-weight: 600; }
+.list { display: grid; gap: 10px; }
+.item {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 10px;
+  display: grid;
+  gap: 8px;
+}
+.item header { display: flex; justify-content: space-between; gap: 12px; }
+.item-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.item-title input { width: auto; }
+.bulkbar { margin: 0 0 12px; }
+.muted { color: var(--muted); }
+pre {
+  margin: 12px 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--muted);
+}
+dialog {
+  width: min(900px, 92vw);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+.close { float: right; }
+textarea { min-height: 140px; }
+
+@media (max-width: 820px) {
+  .topbar, .grid, .split, .row, .row.compact { display: block; }
+  .topbar > *, .row > *, .split > * { margin-bottom: 12px; }
+  main { padding: 14px; }
+}

--- a/src/audit/codex_exec.js
+++ b/src/audit/codex_exec.js
@@ -1,0 +1,163 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { parseCodexExecJson, runCodexExecCommand } from '../distill/providers/codex_exec.js';
+
+export const AUTO_PROMOTE_AUDIT_PROMPT_VERSION = 'auto_promote_audit.codex_exec.v1';
+export const AUTO_PROMOTE_AUDIT_SCHEMA_VERSION = 'contextforge.auto_promote_audit.v1';
+
+const AUDIT_OUTPUT_SCHEMA = {
+  $id: AUTO_PROMOTE_AUDIT_SCHEMA_VERSION,
+  type: 'object',
+  additionalProperties: false,
+  required: ['approved', 'decision', 'reason', 'riskCodes'],
+  properties: {
+    approved: { type: 'boolean' },
+    decision: { type: 'string', enum: ['approve', 'reject', 'needs_review'] },
+    reason: { type: 'string' },
+    riskCodes: { type: 'array', items: { type: 'string' } },
+  },
+};
+
+const REASONING_EFFORTS = new Set(['minimal', 'low', 'medium', 'high']);
+
+function appendReasoningEffortConfig(args, reasoningEffort) {
+  if (!reasoningEffort) return;
+  if (!REASONING_EFFORTS.has(reasoningEffort)) {
+    throw new Error(
+      `Invalid auto-promote audit reasoning effort "${reasoningEffort}". Expected one of: minimal, low, medium, high.`,
+    );
+  }
+  args.push('-c', `model_reasoning_effort="${reasoningEffort}"`);
+}
+
+function truncate(value, maxChars = 2000) {
+  const text = String(value || '');
+  return text.length > maxChars ? `${text.slice(0, maxChars)}\n[truncated]` : text;
+}
+
+function buildAuditPrompt(input, metadata) {
+  const candidate = input.candidate?.candidate || {};
+  const payload = {
+    task: 'Audit whether one ContextForge memory candidate is safe for automatic durable-memory promotion.',
+    rules: [
+      'Return exactly one JSON object and no surrounding text.',
+      'Approve only if the candidate is stable, specific, useful beyond the current session, and directly supported by the checkpoint/candidate evidence.',
+      'Reject if it contains secrets, personal data, credentials, broad guesses, temporary state, user preferences, or unsupported claims.',
+      'Use needs_review when the candidate might be useful but needs a human edit, narrower wording, or live verification.',
+      'Do not approve merely because promotionRecommendation is promote or confidence is high.',
+      'Treat this as an audit gate before automatic promotion; be conservative.',
+    ],
+    requestedOutputSchema: AUDIT_OUTPUT_SCHEMA,
+    auditProvider: metadata,
+    scope: {
+      scopeType: input.candidate?.scopeType || null,
+      scopeKey: input.candidate?.scopeKey || null,
+    },
+    source: {
+      sessionId: input.candidate?.sessionId || null,
+      checkpointId: input.candidate?.checkpointId || null,
+      checkpointSummaryShort: truncate(input.checkpoint?.summaryShort, 800),
+      checkpointSummaryText: truncate(input.checkpoint?.summaryText, 3000),
+    },
+    localWarnings: input.warnings || [],
+    candidate: {
+      key: candidate.key,
+      content: truncate(candidate.content, 3000),
+      reason: truncate(candidate.reason, 1200),
+      category: candidate.category,
+      tags: candidate.tags || [],
+      importance: candidate.importance,
+      candidateType: candidate.candidateType,
+      confidence: candidate.confidence,
+      stability: candidate.stability,
+      sensitivity: candidate.sensitivity,
+      promotionRecommendation: candidate.promotionRecommendation,
+      sourceEventIds: candidate.sourceEventIds || [],
+    },
+  };
+
+  return [
+    'You are the ContextForge automatic memory promotion auditor.',
+    'Audit the supplied candidate for automatic promotion.',
+    'Return exactly one JSON object and no surrounding text.',
+    '',
+    JSON.stringify(payload, null, 2),
+  ].join('\n');
+}
+
+export function createCodexExecAutoPromoteAuditor(options = {}) {
+  const runner = options.runner || runCodexExecCommand;
+  const command = options.command || 'codex';
+  const model = options.model || 'gpt-5.5';
+  const reasoningEffort = options.reasoningEffort || 'low';
+  const sandbox = options.sandbox || 'read-only';
+  const cwd = options.cwd || process.cwd();
+  const timeoutMs = options.timeoutMs || 120000;
+
+  const metadata = {
+    provider: 'codex_exec',
+    promptVersion: AUTO_PROMOTE_AUDIT_PROMPT_VERSION,
+    outputSchemaVersion: AUTO_PROMOTE_AUDIT_SCHEMA_VERSION,
+    command,
+    model,
+    reasoningEffort,
+    sandbox,
+    timeoutMs,
+  };
+
+  async function audit(input) {
+    const startedAt = Date.now();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'contextforge-auto-promote-audit-'));
+    const schemaPath = path.join(tempDir, 'audit.schema.json');
+    const outputPath = path.join(tempDir, 'audit.json');
+    try {
+      await fs.writeFile(schemaPath, `${JSON.stringify(AUDIT_OUTPUT_SCHEMA, null, 2)}\n`, 'utf8');
+      const args = [
+        'exec',
+        '--skip-git-repo-check',
+        '--ephemeral',
+        '--sandbox',
+        sandbox,
+        '--cd',
+        cwd,
+        '--output-schema',
+        schemaPath,
+        '--output-last-message',
+        outputPath,
+      ];
+      if (model) {
+        args.push('--model', model);
+      }
+      appendReasoningEffortConfig(args, reasoningEffort);
+      args.push('-');
+
+      const result = await runner({
+        command,
+        args,
+        prompt: buildAuditPrompt(input, metadata),
+        timeoutMs,
+        cwd,
+        env: process.env,
+      });
+      const outputText = (await fs.readFile(outputPath, 'utf8').catch(() => '')) || result.stdout || '';
+      const output = parseCodexExecJson(outputText);
+      const approved = output.approved === true && output.decision === 'approve';
+      return {
+        approved,
+        decision: output.decision || (approved ? 'approve' : 'needs_review'),
+        reason: output.reason || '',
+        riskCodes: Array.isArray(output.riskCodes) ? output.riskCodes : [],
+        metadata: {
+          ...metadata,
+          elapsedMs: Date.now() - startedAt,
+        },
+      };
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  audit.metadata = metadata;
+  return audit;
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -134,6 +134,12 @@ function toCoreOptions(options) {
     iterations: options.iterations == null ? undefined : Number(options.iterations),
     charsPerToken: options.charsPerToken == null ? undefined : Number(options.charsPerToken),
     rawTailLimit: options.rawTailLimit == null ? undefined : Number(options.rawTailLimit),
+    settings: options.settings ? JSON.parse(options.settings) : undefined,
+    values: options.values ? JSON.parse(options.values) : undefined,
+    secrets: options.secrets ? JSON.parse(options.secrets) : undefined,
+    openAiCompatibleApiKey: options.openAiCompatibleApiKey,
+    clearOpenAiCompatibleApiKey:
+      options.clearOpenAiCompatibleApiKey === true || options.clearOpenAiCompatibleApiKey === 'true',
     mode: options.mode,
     currentTask: options.currentTask,
     currentUserIntent: options.currentUserIntent,
@@ -169,6 +175,9 @@ async function main() {
   const { command, options } = parseArgs(process.argv);
   const commands = {
     dbInfo: (app) => app.dbInfo(),
+    getRuntimeSettings: (app) => app.getRuntimeSettings(),
+    updateRuntimeSettings: (app, coreOptions) => app.updateRuntimeSettings(coreOptions),
+    checkDistillProvider: (app, coreOptions) => app.checkDistillProvider(coreOptions),
     bootstrapContext: (app, coreOptions) => app.bootstrapContext(coreOptions),
     doctorCodexExec: (app, coreOptions) => app.checkCodexExec(coreOptions),
     beginSession: (app, coreOptions) => app.beginSession(coreOptions),
@@ -191,7 +200,9 @@ async function main() {
     rebuildEmbeddings: (app, coreOptions) => app.rebuildEmbeddings(coreOptions),
     processEmbeddingJobs: (app, coreOptions) => app.processEmbeddingJobs(coreOptions),
     listEmbeddingJobs: (app, coreOptions) => app.listEmbeddingJobs(coreOptions),
+    listScopeKeys: (app, coreOptions) => app.listScopeKeys(coreOptions),
     getMemory: (app, coreOptions) => app.getMemory(coreOptions),
+    listMemories: (app, coreOptions) => app.listMemories(coreOptions),
     appendRaw: (app, coreOptions) => app.appendRaw(coreOptions),
     listRawEvents: (app, coreOptions) => app.listRawEvents(coreOptions),
     listCheckpoints: (app, coreOptions) => app.listCheckpoints(coreOptions),

--- a/src/cli.js
+++ b/src/cli.js
@@ -102,6 +102,7 @@ function toCoreOptions(options) {
           .filter(Boolean)
       : undefined,
     sort: options.sort,
+    order: options.order,
     allowWarnings: options.allowWarnings === true || options.allowWarnings === 'true',
     allowStatusOverride: options.allowStatusOverride === true || options.allowStatusOverride === 'true',
     reason: options.reason,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -232,6 +232,22 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
     },
     autoPromote: {
       enabled: parseBoolean(env.CONTEXTFORGE_AUTO_PROMOTE_ENABLED),
+      audit: {
+        enabled: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_ENABLED !== 'false',
+        provider: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER || 'codex_exec',
+        command: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_COMMAND || env.CONTEXTFORGE_CODEX_EXEC_COMMAND || 'codex',
+        model: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_MODEL || 'gpt-5.5',
+        reasoningEffort: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_REASONING_EFFORT || 'low',
+        sandbox: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_SANDBOX || 'read-only',
+        cwd: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_CWD
+          ? path.resolve(resolvedCwd, env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_CWD)
+          : resolvedCwd,
+        timeoutMs: parsePositiveInteger(
+          env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_TIMEOUT_MS,
+          'CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_TIMEOUT_MS',
+          120000,
+        ),
+      },
     },
     codexExec: {
       command: env.CONTEXTFORGE_CODEX_EXEC_COMMAND || 'codex',

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -248,6 +248,31 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
       ),
       maxInputChars: codexExecMaxInputChars,
     },
+    openAiCompatible: {
+      preset: env.CONTEXTFORGE_OPENAI_COMPATIBLE_PRESET || 'deepseek',
+      baseUrl: env.CONTEXTFORGE_OPENAI_COMPATIBLE_BASE_URL || 'https://api.deepseek.com',
+      apiKey:
+        env.CONTEXTFORGE_OPENAI_COMPATIBLE_API_KEY ||
+        env.CONTEXTFORGE_DEEPSEEK_API_KEY ||
+        env.DEEPSEEK_API_KEY ||
+        null,
+      model: env.CONTEXTFORGE_OPENAI_COMPATIBLE_MODEL || 'deepseek-v4-flash',
+      responseFormat: env.CONTEXTFORGE_OPENAI_COMPATIBLE_RESPONSE_FORMAT || 'json_object',
+      timeoutMs: parsePositiveInteger(
+        env.CONTEXTFORGE_OPENAI_COMPATIBLE_TIMEOUT_MS,
+        'CONTEXTFORGE_OPENAI_COMPATIBLE_TIMEOUT_MS',
+        120000,
+      ),
+      maxInputChars: parsePositiveInteger(
+        env.CONTEXTFORGE_OPENAI_COMPATIBLE_MAX_INPUT_CHARS,
+        'CONTEXTFORGE_OPENAI_COMPATIBLE_MAX_INPUT_CHARS',
+        12000,
+      ),
+      maxTokens: parseOptionalPositiveInteger(
+        env.CONTEXTFORGE_OPENAI_COMPATIBLE_MAX_TOKENS,
+        'CONTEXTFORGE_OPENAI_COMPATIBLE_MAX_TOKENS',
+      ),
+    },
     distillPolicy: {
       minEvents: parsePositiveInteger(env.CONTEXTFORGE_DISTILL_MIN_EVENTS, 'CONTEXTFORGE_DISTILL_MIN_EVENTS', 5),
       minIntervalMs: distillMinIntervalMs,

--- a/src/core.js
+++ b/src/core.js
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { createCodexExecAutoPromoteAuditor } from './audit/codex_exec.js';
 import { loadConfig } from './config/index.js';
 import { createDistillProvider } from './distill/index.js';
 import { checkCodexExecProvider } from './distill/providers/codex_exec.js';
@@ -974,7 +975,7 @@ function promoteCandidateToMemory(
   });
 }
 
-function autoPromoteIndexedCandidate(store, scope, indexedCandidate, warnings, reason) {
+function autoPromoteIndexedCandidate(store, scope, indexedCandidate, warnings, reason, audit = null) {
   const candidate = indexedCandidate.candidate || {};
   return promoteCandidateToMemory(store, scope, {
     candidate,
@@ -989,9 +990,34 @@ function autoPromoteIndexedCandidate(store, scope, indexedCandidate, warnings, r
     importance: candidate.importance ?? 0,
     reason,
     warnings,
-    eventMetadata: { autoPromoted: true },
-    reviewMetadata: { autoPromoted: true },
+    eventMetadata: { autoPromoted: true, autoPromotionAudit: audit },
+    reviewMetadata: { autoPromoted: true, autoPromotionAudit: audit },
   });
+}
+
+async function auditAutoPromotionCandidate({ auditor, store, scope, item }) {
+  if (!auditor) {
+    return {
+      approved: true,
+      decision: 'approve',
+      reason: 'Auto-promotion audit disabled; local strict safety checks only.',
+      riskCodes: [],
+      metadata: { provider: 'none' },
+    };
+  }
+  const checkpoint = item.candidate.checkpointId
+    ? store.getCheckpointById({ ...scope, checkpointId: item.candidate.checkpointId })
+    : null;
+  return auditor({
+    candidate: item.candidate,
+    warnings: item.warnings,
+    checkpoint,
+  });
+}
+
+function auditSkipReason(audit) {
+  const riskCodes = Array.isArray(audit?.riskCodes) && audit.riskCodes.length ? `: ${audit.riskCodes.join(', ')}` : '';
+  return `audit_${audit?.decision || 'failed'}${riskCodes}`;
 }
 
 function summarizeBasisResult(result) {
@@ -1190,6 +1216,7 @@ const RUNTIME_SETTING_KEYS = new Set([
   'distillPolicy',
   'codexExec',
   'openAiCompatible',
+  'autoPromoteAudit',
 ]);
 
 const SECRET_KEYS = {
@@ -1246,11 +1273,16 @@ function effectiveRuntimeConfig(config, runtimeSettings = { settings: {}, secret
     ...(settings.openAiCompatible || {}),
     apiKey: runtimeSettings.secrets?.[SECRET_KEYS.openAiCompatibleApiKey] || config.openAiCompatible.apiKey || null,
   };
+  const autoPromoteAudit = {
+    ...config.autoPromote.audit,
+    ...(settings.autoPromoteAudit || {}),
+  };
   return {
     distillProvider: settings.distillProvider || config.distillProvider,
     distillPolicy,
     codexExec,
     openAiCompatible,
+    autoPromoteAudit,
   };
 }
 
@@ -1269,6 +1301,7 @@ function sanitizedRuntimeSettings(config, runtimeSettings = { settings: {}, secr
         apiKey: undefined,
         secretPresent: Boolean(effective.openAiCompatible.apiKey),
       },
+      autoPromoteAudit: effective.autoPromoteAudit,
       presets: DISTILL_MODEL_PRESETS,
     },
     stored: runtimeSettings.settings,
@@ -1319,6 +1352,20 @@ export function createContextForge(options = {}) {
 
   function getEffectiveRuntime(store) {
     return effectiveRuntimeConfig(config, store.getRuntimeSettings({ includeSecrets: true }));
+  }
+
+  function getAutoPromoteAuditor(store) {
+    if (Object.prototype.hasOwnProperty.call(options, 'autoPromoteAuditor')) {
+      return options.autoPromoteAuditor;
+    }
+    const audit = getEffectiveRuntime(store).autoPromoteAudit;
+    if (!audit.enabled || audit.provider !== 'codex_exec') {
+      return null;
+    }
+    return createCodexExecAutoPromoteAuditor({
+      ...audit,
+      runner: options.autoPromoteAuditRunner,
+    });
   }
 
   function buildDbInfo(store) {
@@ -2166,7 +2213,7 @@ export function createContextForge(options = {}) {
       const scanLimit = positiveNumber(options.scanLimit == null ? 10 : Number(options.scanLimit), 'scanLimit');
       const promotionRecommendation = options.promotionRecommendation || 'promote';
 
-      return useStore((store) => {
+      return useStore(async (store) => {
         let checkpointId = options.checkpointId || null;
         let sourceMode = null;
         if (checkpointId) {
@@ -2244,7 +2291,6 @@ export function createContextForge(options = {}) {
           .filter((item) => item.score > 0)
           .sort((a, b) => b.score - a.score)
           .slice(0, limit);
-
         return {
           kind: 'memory_promotion_suggestions',
           trigger,
@@ -2346,7 +2392,7 @@ export function createContextForge(options = {}) {
         };
       }
 
-      return useStore((store) => {
+      return useStore(async (store) => {
         let checkpointId = options.checkpointId || null;
         let sourceMode = null;
         if (checkpointId) {
@@ -2403,6 +2449,37 @@ export function createContextForge(options = {}) {
           .filter((item) => item.score > 0)
           .sort((a, b) => b.score - a.score)
           .slice(0, limit);
+        const auditor = getAutoPromoteAuditor(store);
+        const audited = [];
+        if (!dryRun) {
+          for (const item of selected) {
+            try {
+              const audit = await auditAutoPromotionCandidate({ auditor, store, scope, item });
+              audited.push({ ...item, audit });
+            } catch (error) {
+              audited.push({
+                ...item,
+                audit: {
+                  approved: false,
+                  decision: 'needs_review',
+                  reason: `Auto-promotion audit failed: ${error.message}`,
+                  riskCodes: ['audit_failed'],
+                  metadata: { errorName: error.name },
+                },
+              });
+            }
+          }
+        }
+        const auditApproved = dryRun ? [] : audited.filter((item) => item.audit?.approved === true);
+        const auditSkipped = dryRun
+          ? []
+          : audited
+              .filter((item) => item.audit?.approved !== true)
+              .map((item) => ({
+                candidateId: item.candidate.id,
+                reason: auditSkipReason(item.audit),
+                audit: item.audit,
+              }));
 
         return {
           kind: 'auto_memory_promotion_result',
@@ -2419,16 +2496,22 @@ export function createContextForge(options = {}) {
             allowedCategories: Array.from(allowedCategories),
             scopeFallback: false,
             realPromotionEnabled: config.autoPromote.enabled,
+            audit: {
+              enabled: Boolean(auditor),
+              provider: auditor?.metadata?.provider || 'none',
+              model: auditor?.metadata?.model || null,
+              reasoningEffort: auditor?.metadata?.reasoningEffort || null,
+            },
           },
           wouldPromote: dryRun
             ? selected.map((item, index) => autoPromotionWouldPromote(item.candidate, item.warnings, index + 1))
             : [],
           promoted: dryRun
             ? []
-            : selected.map((item, index) => {
+            : auditApproved.map((item, index) => {
                 const reason =
-                  'Auto-promoted by auto_promote_memory_candidates after strict closeout-scoped safety checks.';
-                const memory = autoPromoteIndexedCandidate(store, scope, item.candidate, item.warnings, reason);
+                  'Auto-promoted by auto_promote_memory_candidates after strict closeout-scoped safety checks and audit approval.';
+                const memory = autoPromoteIndexedCandidate(store, scope, item.candidate, item.warnings, reason, item.audit);
                 enqueueEmbeddingSources(store, [store.embeddingSourceForMemory(memory)]);
                 return {
                   ...promotionProposal(item.candidate, item.warnings, index + 1),
@@ -2439,19 +2522,24 @@ export function createContextForge(options = {}) {
                     status: 'promoted',
                   },
                   auditReason: reason,
+                  audit: item.audit,
                 };
               }),
-          skipped: assessed
-            .filter((item) => item.score <= 0)
-            .map((item) => ({
-              candidateId: item.candidate.id,
-              reason: candidateWarningReason(item.warnings) || 'low_score',
-            })),
+          skipped: [
+            ...assessed
+              .filter((item) => item.score <= 0)
+              .map((item) => ({
+                candidateId: item.candidate.id,
+                reason: candidateWarningReason(item.warnings) || 'low_score',
+              })),
+            ...auditSkipped,
+          ],
           requestWarnings,
           nextActions: [
             dryRun
               ? 'Inspect wouldPromote quality or set dryRun=false with CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true to promote.'
               : 'Review promoted entries and audit metadata.',
+            dryRun ? 'Dry-run does not call the auto-promotion audit runner.' : 'Candidates rejected by audit remain pending for human review.',
             dryRun ? 'No memory candidates were promoted.' : 'Do not auto-promote preference candidates until occurrence/merge tracking exists.',
           ],
         };

--- a/src/core.js
+++ b/src/core.js
@@ -3492,6 +3492,7 @@ export function createContextForge(options = {}) {
           status: options.status || null,
           provider: options.provider || null,
           limit: options.limit == null ? null : Number(options.limit),
+          order: options.order || 'asc',
         }),
       );
     },

--- a/src/core.js
+++ b/src/core.js
@@ -1231,6 +1231,24 @@ const DISTILL_MODEL_PRESETS = {
       model: 'deepseek-v4-flash',
       responseFormat: 'json_object',
     },
+    deepseekPro: {
+      label: 'DeepSeek V4 Pro',
+      baseUrl: 'https://api.deepseek.com',
+      model: 'deepseek-v4-pro',
+      responseFormat: 'json_object',
+    },
+    deepseekChat: {
+      label: 'DeepSeek Chat',
+      baseUrl: 'https://api.deepseek.com',
+      model: 'deepseek-chat',
+      responseFormat: 'json_object',
+    },
+    deepseekReasoner: {
+      label: 'DeepSeek Reasoner',
+      baseUrl: 'https://api.deepseek.com',
+      model: 'deepseek-reasoner',
+      responseFormat: 'json_object',
+    },
     custom: {
       label: 'Custom OpenAI-compatible',
       baseUrl: '',
@@ -1242,6 +1260,26 @@ const DISTILL_MODEL_PRESETS = {
     configured: {
       label: 'Configured Codex model',
       model: null,
+    },
+    gpt55: {
+      label: 'GPT-5.5',
+      model: 'gpt-5.5',
+      reasoningEffort: 'low',
+    },
+    gpt54: {
+      label: 'GPT-5.4',
+      model: 'gpt-5.4',
+      reasoningEffort: 'low',
+    },
+    gpt54Mini: {
+      label: 'GPT-5.4 Mini',
+      model: 'gpt-5.4-mini',
+      reasoningEffort: 'low',
+    },
+    codex: {
+      label: 'GPT-5.3 Codex',
+      model: 'gpt-5.3-codex',
+      reasoningEffort: 'low',
     },
     manual: {
       label: 'Manual Codex model',
@@ -2498,6 +2536,7 @@ export function createContextForge(options = {}) {
             realPromotionEnabled: config.autoPromote.enabled,
             audit: {
               enabled: Boolean(auditor),
+              executed: !dryRun && Boolean(auditor),
               provider: auditor?.metadata?.provider || 'none',
               model: auditor?.metadata?.model || null,
               reasoningEffort: auditor?.metadata?.reasoningEffort || null,

--- a/src/core.js
+++ b/src/core.js
@@ -1397,8 +1397,11 @@ export function createContextForge(options = {}) {
       return options.autoPromoteAuditor;
     }
     const audit = getEffectiveRuntime(store).autoPromoteAudit;
-    if (!audit.enabled || audit.provider !== 'codex_exec') {
+    if (!audit.enabled) {
       return null;
+    }
+    if (audit.provider !== 'codex_exec') {
+      throw new Error(`Unsupported auto-promotion audit provider "${audit.provider}".`);
     }
     return createCodexExecAutoPromoteAuditor({
       ...audit,

--- a/src/core.js
+++ b/src/core.js
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import { loadConfig } from './config/index.js';
 import { createDistillProvider } from './distill/index.js';
 import { checkCodexExecProvider } from './distill/providers/codex_exec.js';
+import { checkOpenAiCompatibleProvider } from './distill/providers/openai_compatible.js';
 import { validateDistillOutput } from './distill/validate.js';
 import { createEmbeddingProvider } from './embeddings/index.js';
 import { createRemoteContextForge } from './remote/client.js';
@@ -1184,6 +1185,114 @@ function rawTtlCutoffIso(ttlDays, now = new Date()) {
   return new Date(now.getTime() - Number(ttlDays) * 24 * 60 * 60 * 1000).toISOString();
 }
 
+const RUNTIME_SETTING_KEYS = new Set([
+  'distillProvider',
+  'distillPolicy',
+  'codexExec',
+  'openAiCompatible',
+]);
+
+const SECRET_KEYS = {
+  openAiCompatibleApiKey: 'openAiCompatible.apiKey',
+};
+
+const DISTILL_MODEL_PRESETS = {
+  openai_compatible: {
+    deepseek: {
+      label: 'DeepSeek V4 Flash',
+      baseUrl: 'https://api.deepseek.com',
+      model: 'deepseek-v4-flash',
+      responseFormat: 'json_object',
+    },
+    custom: {
+      label: 'Custom OpenAI-compatible',
+      baseUrl: '',
+      model: '',
+      responseFormat: 'json_object',
+    },
+  },
+  codex_exec: {
+    configured: {
+      label: 'Configured Codex model',
+      model: null,
+    },
+    manual: {
+      label: 'Manual Codex model',
+      model: '',
+    },
+  },
+};
+
+function plainSettings(runtimeSettings) {
+  const result = {};
+  for (const [key, entry] of Object.entries(runtimeSettings?.settings || {})) {
+    result[key] = entry.value;
+  }
+  return result;
+}
+
+function effectiveRuntimeConfig(config, runtimeSettings = { settings: {}, secrets: {} }) {
+  const settings = plainSettings(runtimeSettings);
+  const distillPolicy = {
+    ...config.distillPolicy,
+    ...(settings.distillPolicy || {}),
+  };
+  const codexExec = {
+    ...config.codexExec,
+    ...(settings.codexExec || {}),
+  };
+  const openAiCompatible = {
+    ...config.openAiCompatible,
+    ...(settings.openAiCompatible || {}),
+    apiKey: runtimeSettings.secrets?.[SECRET_KEYS.openAiCompatibleApiKey] || config.openAiCompatible.apiKey || null,
+  };
+  return {
+    distillProvider: settings.distillProvider || config.distillProvider,
+    distillPolicy,
+    codexExec,
+    openAiCompatible,
+  };
+}
+
+function sanitizedRuntimeSettings(config, runtimeSettings = { settings: {}, secrets: {} }) {
+  const effective = effectiveRuntimeConfig(config, runtimeSettings);
+  return {
+    effective: {
+      distillProvider: effective.distillProvider,
+      distillPolicy: effective.distillPolicy,
+      codexExec: {
+        ...effective.codexExec,
+        runner: undefined,
+      },
+      openAiCompatible: {
+        ...effective.openAiCompatible,
+        apiKey: undefined,
+        secretPresent: Boolean(effective.openAiCompatible.apiKey),
+      },
+      presets: DISTILL_MODEL_PRESETS,
+    },
+    stored: runtimeSettings.settings,
+  };
+}
+
+function pickKnownSettings(values = {}) {
+  const picked = {};
+  for (const [key, value] of Object.entries(values || {})) {
+    if (RUNTIME_SETTING_KEYS.has(key)) {
+      if (key === 'openAiCompatible' && value && typeof value === 'object' && !Array.isArray(value)) {
+        const { apiKey, ...safeOpenAiCompatible } = value;
+        if (apiKey != null) {
+          throw new Error('openAiCompatible.apiKey must be provided through the write-only secrets channel.');
+        }
+        picked[key] = safeOpenAiCompatible;
+      } else {
+        picked[key] = value;
+      }
+    }
+  }
+  return picked;
+}
+
 export function createContextForge(options = {}) {
   const config = loadConfig(options);
   if (config.storageMode === 'remote') {
@@ -1199,6 +1308,7 @@ export function createContextForge(options = {}) {
     ...config.codexExec,
     runner: options.codexExecRunner,
   };
+  const runtimeFetchImpl = options.fetchImpl;
   const useStore = (fn) => {
     if (sharedStore) {
       return fn(sharedStore);
@@ -1206,6 +1316,10 @@ export function createContextForge(options = {}) {
     return withStore(config, fn);
   };
   let lastRawPruneAt = 0;
+
+  function getEffectiveRuntime(store) {
+    return effectiveRuntimeConfig(config, store.getRuntimeSettings({ includeSecrets: true }));
+  }
 
   function buildDbInfo(store) {
     const storeInfo = store.dbInfo();
@@ -1449,6 +1563,66 @@ export function createContextForge(options = {}) {
       return useStore((store) => buildDbInfo(store));
     },
 
+    getRuntimeSettings() {
+      return useStore((store) => {
+        const redacted = store.getRuntimeSettings();
+        const withSecrets = store.getRuntimeSettings({ includeSecrets: true });
+        return {
+          ...sanitizedRuntimeSettings(config, withSecrets),
+          stored: redacted.settings,
+        };
+      });
+    },
+
+    updateRuntimeSettings(options = {}) {
+      const values = pickKnownSettings(options.values || options.settings || {});
+      const secrets = {};
+      if (options.openAiCompatibleApiKey) {
+        secrets[SECRET_KEYS.openAiCompatibleApiKey] = options.openAiCompatibleApiKey;
+      }
+      if (options.secrets?.openAiCompatibleApiKey) {
+        secrets[SECRET_KEYS.openAiCompatibleApiKey] = options.secrets.openAiCompatibleApiKey;
+      }
+      const clearSecrets = [];
+      if (truthyOption(options.clearOpenAiCompatibleApiKey) || options.clearSecrets?.includes('openAiCompatibleApiKey')) {
+        clearSecrets.push(SECRET_KEYS.openAiCompatibleApiKey);
+      }
+      return useStore((store) => {
+        store.setRuntimeSettings({ values, secrets, clearSecrets });
+        const redacted = store.getRuntimeSettings();
+        const withSecrets = store.getRuntimeSettings({ includeSecrets: true });
+        return {
+          ...sanitizedRuntimeSettings(config, withSecrets),
+          stored: redacted.settings,
+        };
+      });
+    },
+
+    checkDistillProvider(options = {}) {
+      return useStore(async (store) => {
+        const effective = getEffectiveRuntime(store);
+        const providerName = options.provider || effective.distillProvider;
+        if (providerName === 'codex_exec') {
+          return checkCodexExecProvider({
+            ...effective.codexExec,
+            runner: options.codexExecRunner || options.runner || options.codexRunner || codexExec.runner,
+            live: Boolean(options.live),
+          });
+        }
+        if (providerName === 'openai_compatible') {
+          return checkOpenAiCompatibleProvider({
+            ...effective.openAiCompatible,
+            fetchImpl: runtimeFetchImpl,
+            live: Boolean(options.live),
+          });
+        }
+        if (providerName === 'mock') {
+          return { ok: true, provider: 'mock', message: 'mock provider is always available.' };
+        }
+        throw new Error(`Unsupported distill provider "${providerName}".`);
+      });
+    },
+
     async bootstrapContext(options = {}) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.query, 'query');
@@ -1614,9 +1788,13 @@ export function createContextForge(options = {}) {
     },
 
     checkCodexExec(options = {}) {
-      return checkCodexExecProvider({
-        ...codexExec,
-        live: Boolean(options.live),
+      return useStore((store) => {
+        const effective = getEffectiveRuntime(store);
+        return checkCodexExecProvider({
+          ...effective.codexExec,
+          runner: codexExec.runner,
+          live: Boolean(options.live),
+        });
       });
     },
 
@@ -1634,41 +1812,44 @@ export function createContextForge(options = {}) {
     sessionStatus(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.sessionId, 'sessionId');
-      const policy = {
-        minEvents: positiveNumber(
-          options.minEvents == null ? config.distillPolicy.minEvents : Number(options.minEvents),
-          'minEvents',
-        ),
-        minIntervalMs: positiveNumber(
-          options.minIntervalMs == null ? config.distillPolicy.minIntervalMs : Number(options.minIntervalMs),
-          'minIntervalMs',
-        ),
-        charThreshold: positiveNumber(
-          options.charThreshold == null ? config.distillPolicy.charThreshold : Number(options.charThreshold),
-          'charThreshold',
-        ),
-        charMinIntervalMs: positiveNumber(
-          options.charMinIntervalMs == null ? config.distillPolicy.charMinIntervalMs : Number(options.charMinIntervalMs),
-          'charMinIntervalMs',
-        ),
-        maxEvents: positiveNumber(
-          options.maxEvents == null ? config.distillPolicy.maxEvents : Number(options.maxEvents),
-          'maxEvents',
-        ),
-        maxChars: positiveNumber(
-          options.maxChars == null ? config.distillPolicy.maxChars : Number(options.maxChars),
-          'maxChars',
-        ),
-      };
-      return useStore((store) =>
-        buildSessionStatus({
+      return useStore((store) => {
+        const effective = getEffectiveRuntime(store);
+        const policy = {
+          minEvents: positiveNumber(
+            options.minEvents == null ? effective.distillPolicy.minEvents : Number(options.minEvents),
+            'minEvents',
+          ),
+          minIntervalMs: positiveNumber(
+            options.minIntervalMs == null ? effective.distillPolicy.minIntervalMs : Number(options.minIntervalMs),
+            'minIntervalMs',
+          ),
+          charThreshold: positiveNumber(
+            options.charThreshold == null ? effective.distillPolicy.charThreshold : Number(options.charThreshold),
+            'charThreshold',
+          ),
+          charMinIntervalMs: positiveNumber(
+            options.charMinIntervalMs == null
+              ? effective.distillPolicy.charMinIntervalMs
+              : Number(options.charMinIntervalMs),
+            'charMinIntervalMs',
+          ),
+          maxEvents: positiveNumber(
+            options.maxEvents == null ? effective.distillPolicy.maxEvents : Number(options.maxEvents),
+            'maxEvents',
+          ),
+          maxChars: positiveNumber(
+            options.maxChars == null ? effective.distillPolicy.maxChars : Number(options.maxChars),
+            'maxChars',
+          ),
+        };
+        return buildSessionStatus({
           scope,
           sessionId: options.sessionId,
           rawEvents: store.listRawEvents({ ...scope, sessionId: options.sessionId }),
           latestCheckpoint: store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId, level: 0 }),
           policy,
-        }),
-      );
+        });
+      });
     },
 
     remember(options) {
@@ -2652,6 +2833,27 @@ export function createContextForge(options = {}) {
       );
     },
 
+    listMemories(options = {}) {
+      const scope = normalizeScopeOptions(options, config);
+      return useStore((store) =>
+        store.listMemoriesForAdmin({
+          ...scope,
+          status: options.status || 'active',
+          query: options.query || null,
+          limit: options.limit == null ? 100 : Number(options.limit),
+        }),
+      );
+    },
+
+    listScopeKeys(options = {}) {
+      return useStore((store) =>
+        store.listScopeKeys({
+          scopeType: options.scope || options.scopeType || null,
+          limit: options.limit == null ? 200 : Number(options.limit),
+        }),
+      );
+    },
+
     search(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.query, 'query');
@@ -2874,23 +3076,31 @@ export function createContextForge(options = {}) {
     async distillCheckpoint(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.sessionId, 'sessionId');
-      const provider = createDistillProvider(options.provider || config.distillProvider, distillProviders, {
-        codexExec,
-      });
-      const providerMetadata = provider.metadata || {};
 
       return useStore(async (store) => {
+        const effective = getEffectiveRuntime(store);
+        const provider = createDistillProvider(options.provider || effective.distillProvider, distillProviders, {
+          codexExec: {
+            ...effective.codexExec,
+            runner: codexExec.runner,
+          },
+          openAiCompatible: {
+            ...effective.openAiCompatible,
+            fetchImpl: runtimeFetchImpl,
+          },
+        });
+        const providerMetadata = provider.metadata || {};
         const rawEvents = store.listRawEvents({ ...scope, sessionId: options.sessionId });
         const previousCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId, level: 0 });
         const previousWorkingSummary = store.getWorkingSummary({ ...scope, sessionId: options.sessionId });
         const previousSessionWorkingContext = store.getSessionWorkingContext({ ...scope, sessionId: options.sessionId });
         const policy = {
           maxEvents: positiveNumber(
-            options.maxEvents == null ? config.distillPolicy.maxEvents : Number(options.maxEvents),
+            options.maxEvents == null ? effective.distillPolicy.maxEvents : Number(options.maxEvents),
             'maxEvents',
           ),
           maxChars: positiveNumber(
-            options.maxChars == null ? config.distillPolicy.maxChars : Number(options.maxChars),
+            options.maxChars == null ? effective.distillPolicy.maxChars : Number(options.maxChars),
             'maxChars',
           ),
         };
@@ -3148,11 +3358,13 @@ export function createContextForge(options = {}) {
 
     listDistillRuns(options) {
       const scope = normalizeScopeOptions(options, config);
-      requireOption(options.sessionId, 'sessionId');
       return useStore((store) =>
         store.listDistillRuns({
           ...scope,
-          sessionId: options.sessionId,
+          sessionId: options.sessionId || null,
+          status: options.status || null,
+          provider: options.provider || null,
+          limit: options.limit == null ? null : Number(options.limit),
         }),
       );
     },

--- a/src/distill/index.js
+++ b/src/distill/index.js
@@ -1,5 +1,6 @@
 import { distillWithMockProvider } from './providers/mock.js';
 import { createCodexExecProvider } from './providers/codex_exec.js';
+import { createOpenAiCompatibleProvider } from './providers/openai_compatible.js';
 
 export function createDistillProvider(name, overrides = {}, options = {}) {
   if (overrides[name]) {
@@ -25,5 +26,14 @@ export function createDistillProvider(name, overrides = {}, options = {}) {
     };
   }
 
-  throw new Error(`Unsupported distill provider "${name}". Available providers: mock, codex_exec.`);
+  if (name === 'openai_compatible') {
+    const distill = createOpenAiCompatibleProvider(options.openAiCompatible);
+    return {
+      name,
+      distill,
+      metadata: distill.metadata,
+    };
+  }
+
+  throw new Error(`Unsupported distill provider "${name}". Available providers: mock, codex_exec, openai_compatible.`);
 }

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -6,7 +6,7 @@ import path from 'node:path';
 export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v6';
 export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v5';
 
-const OUTPUT_SCHEMA = {
+export const CHECKPOINT_OUTPUT_SCHEMA = {
   $id: CODEX_EXEC_OUTPUT_SCHEMA_VERSION,
   type: 'object',
   additionalProperties: false,
@@ -553,7 +553,7 @@ export function createCodexExecProvider(options = {}) {
     const outputPath = path.join(tempDir, 'checkpoint.json');
     const prompt = buildCodexExecPrompt(input, { maxInputChars });
 
-    await fs.writeFile(schemaPath, `${JSON.stringify(OUTPUT_SCHEMA, null, 2)}\n`, 'utf8');
+    await fs.writeFile(schemaPath, `${JSON.stringify(CHECKPOINT_OUTPUT_SCHEMA, null, 2)}\n`, 'utf8');
 
     const args = [
       'exec',

--- a/src/distill/providers/openai_compatible.js
+++ b/src/distill/providers/openai_compatible.js
@@ -97,7 +97,7 @@ function requestBody({ prompt, model, preset, responseFormatMode, maxTokens }) {
   const format = responseFormat(responseFormatMode);
   if (format) body.response_format = format;
   if (maxTokens) body.max_tokens = maxTokens;
-  if (preset === 'deepseek' || model.startsWith('deepseek-v4-')) {
+  if (preset === 'deepseek' && model === 'deepseek-v4-flash') {
     body.thinking = { type: 'disabled' };
   }
   return body;
@@ -192,6 +192,7 @@ export function createOpenAiCompatibleProvider(options = {}) {
       };
       responseBody = await postJson({ fetchImpl, url, apiKey, body: repairBody, timeoutMs });
       parsed = parseJsonText(completionText(responseBody));
+      validateDistillOutput(parsed.output);
     }
 
     return {

--- a/src/distill/providers/openai_compatible.js
+++ b/src/distill/providers/openai_compatible.js
@@ -1,0 +1,238 @@
+import { buildCodexExecPrompt, CHECKPOINT_OUTPUT_SCHEMA, CODEX_EXEC_OUTPUT_SCHEMA_VERSION } from './codex_exec.js';
+import { validateDistillOutput } from '../validate.js';
+
+export const OPENAI_COMPATIBLE_PROMPT_VERSION = 'openai_compatible.prompt.v1';
+
+const DEFAULT_TIMEOUT_MS = 120000;
+const DEFAULT_BASE_URL = 'https://api.deepseek.com';
+const DEFAULT_MODEL = 'deepseek-v4-flash';
+
+function normalizeBaseUrl(baseUrl) {
+  const url = new URL(baseUrl || DEFAULT_BASE_URL);
+  url.pathname = url.pathname.replace(/\/$/, '');
+  return url.toString().replace(/\/$/, '');
+}
+
+function chatCompletionsUrl(baseUrl) {
+  const normalized = normalizeBaseUrl(baseUrl);
+  return `${normalized}/chat/completions`;
+}
+
+function hostFromBaseUrl(baseUrl) {
+  try {
+    return new URL(normalizeBaseUrl(baseUrl)).host;
+  } catch {
+    return null;
+  }
+}
+
+function stripJsonFence(text) {
+  const trimmed = String(text || '').trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return fenced ? fenced[1].trim() : trimmed;
+}
+
+function parseJsonText(text) {
+  const stripped = stripJsonFence(text);
+  try {
+    return { output: JSON.parse(stripped), jsonRecovery: null };
+  } catch {
+    const start = stripped.indexOf('{');
+    const end = stripped.lastIndexOf('}');
+    if (start !== -1 && end > start) {
+      return { output: JSON.parse(stripped.slice(start, end + 1)), jsonRecovery: 'brace-fallback' };
+    }
+    throw new Error('openai_compatible provider did not return valid JSON.');
+  }
+}
+
+function completionText(responseBody) {
+  const text = responseBody?.choices?.[0]?.message?.content;
+  if (typeof text !== 'string' || !text.trim()) {
+    throw new Error('openai_compatible response did not include choices[0].message.content.');
+  }
+  return text;
+}
+
+function responseFormat(format) {
+  if (format === 'json_schema') {
+    return {
+      type: 'json_schema',
+      json_schema: {
+        name: 'contextforge_checkpoint',
+        strict: true,
+        schema: CHECKPOINT_OUTPUT_SCHEMA,
+      },
+    };
+  }
+  if (format === 'text') {
+    return undefined;
+  }
+  return { type: 'json_object' };
+}
+
+function withOpenAiCompatibleIdentity(prompt) {
+  return prompt.replace(
+    'You are the ContextForge codex_exec distillation provider.',
+    'You are the ContextForge openai_compatible distillation provider.',
+  );
+}
+
+function requestBody({ prompt, model, preset, responseFormatMode, maxTokens }) {
+  const body = {
+    model,
+    messages: [
+      {
+        role: 'system',
+        content:
+          'Return only valid JSON for the ContextForge checkpoint schema. Do not include Markdown or commentary.',
+      },
+      {
+        role: 'user',
+        content: prompt,
+      },
+    ],
+    stream: false,
+  };
+  const format = responseFormat(responseFormatMode);
+  if (format) body.response_format = format;
+  if (maxTokens) body.max_tokens = maxTokens;
+  if (preset === 'deepseek' || model.startsWith('deepseek-v4-')) {
+    body.thinking = { type: 'disabled' };
+  }
+  return body;
+}
+
+async function postJson({ fetchImpl, url, apiKey, body, timeoutMs }) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    const parsed = text ? JSON.parse(text) : {};
+    if (!response.ok) {
+      throw new Error(parsed?.error?.message || `openai_compatible request failed with HTTP ${response.status}.`);
+    }
+    return parsed;
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      throw new Error(`openai_compatible timed out after ${timeoutMs}ms.`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function createOpenAiCompatibleProvider(options = {}) {
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  const preset = options.preset || 'deepseek';
+  const baseUrl = normalizeBaseUrl(options.baseUrl || DEFAULT_BASE_URL);
+  const apiKey = options.apiKey || null;
+  const model = options.model || DEFAULT_MODEL;
+  const responseFormatMode = options.responseFormat || 'json_object';
+  const timeoutMs = options.timeoutMs || DEFAULT_TIMEOUT_MS;
+  const maxInputChars = options.maxInputChars || 12000;
+  const maxTokens = options.maxTokens || null;
+
+  const providerMetadata = {
+    provider: 'openai_compatible',
+    preset,
+    baseUrlHost: hostFromBaseUrl(baseUrl),
+    model,
+    responseFormat: responseFormatMode,
+    promptVersion: OPENAI_COMPATIBLE_PROMPT_VERSION,
+    outputSchemaVersion: CODEX_EXEC_OUTPUT_SCHEMA_VERSION,
+  };
+
+  async function distillWithOpenAiCompatibleProvider(input) {
+    if (typeof fetchImpl !== 'function') {
+      throw new Error('openai_compatible provider requires fetch.');
+    }
+    if (!apiKey) {
+      throw new Error('openai_compatible provider requires an API key.');
+    }
+
+    const startedAt = Date.now();
+    const builtPrompt = buildCodexExecPrompt(input, { maxInputChars });
+    const prompt = withOpenAiCompatibleIdentity(builtPrompt.prompt);
+    const url = chatCompletionsUrl(baseUrl);
+    const body = requestBody({ prompt, model, preset, responseFormatMode, maxTokens });
+    let retryCount = 0;
+    let validationFailure = null;
+    let responseBody = await postJson({ fetchImpl, url, apiKey, body, timeoutMs });
+    let parsed = parseJsonText(completionText(responseBody));
+
+    try {
+      validateDistillOutput(parsed.output);
+    } catch (error) {
+      validationFailure = error.message;
+      retryCount = 1;
+      const repairBody = {
+        ...body,
+        messages: [
+          ...body.messages,
+          {
+            role: 'assistant',
+            content: JSON.stringify(parsed.output),
+          },
+          {
+            role: 'user',
+            content: `The previous JSON failed validation: ${error.message}. Return one corrected JSON object only.`,
+          },
+        ],
+      };
+      responseBody = await postJson({ fetchImpl, url, apiKey, body: repairBody, timeoutMs });
+      parsed = parseJsonText(completionText(responseBody));
+    }
+
+    return {
+      ...parsed.output,
+      provider: parsed.output.provider || 'openai_compatible',
+      sourceEventCount: parsed.output.sourceEventCount ?? (input.rawEvents || []).length,
+      metadata: {
+        ...(parsed.output.metadata || {}),
+        openAiCompatible: {
+          ...providerMetadata,
+          timeoutMs,
+          elapsedMs: Date.now() - startedAt,
+          retryCount,
+          ...(validationFailure ? { validationFailure } : {}),
+          ...(parsed.jsonRecovery ? { jsonRecovery: parsed.jsonRecovery } : {}),
+          usage: responseBody.usage || null,
+          rawEventCount: builtPrompt.metadata.rawEventCount,
+          inputTruncated: builtPrompt.metadata.inputTruncated,
+          maxInputChars,
+        },
+      },
+    };
+  }
+
+  distillWithOpenAiCompatibleProvider.metadata = providerMetadata;
+  return distillWithOpenAiCompatibleProvider;
+}
+
+export async function checkOpenAiCompatibleProvider(options = {}) {
+  const provider = createOpenAiCompatibleProvider(options);
+  return {
+    ok: true,
+    provider: 'openai_compatible',
+    preset: options.preset || 'deepseek',
+    baseUrlHost: hostFromBaseUrl(options.baseUrl || DEFAULT_BASE_URL),
+    model: options.model || DEFAULT_MODEL,
+    responseFormat: options.responseFormat || 'json_object',
+    live: Boolean(options.live),
+    message: options.live
+      ? 'openai_compatible live checks run through distillCheckpoint with raw evidence.'
+      : 'openai_compatible config is syntactically valid.',
+    metadata: provider.metadata,
+  };
+}

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -72,6 +72,22 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
   );
 
   server.registerTool(
+    'get_runtime_settings',
+    {
+      title: 'Get Runtime Settings',
+      description:
+        'Inspect effective ContextForge runtime settings, including distill provider, distill policy, provider model settings, presets, and secret-present flags. Secret values are never returned.',
+      inputSchema: {},
+      annotations: {
+        title: 'Get Runtime Settings',
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+    },
+    async () => jsonResult(await app.getRuntimeSettings()),
+  );
+
+  server.registerTool(
     'bootstrap_context',
     {
       title: 'Bootstrap Context',

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -2,6 +2,10 @@ import { normalizeScopeOptions } from '../scopes/index.js';
 
 const REMOTE_METHODS = [
   'dbInfo',
+  'getRuntimeSettings',
+  'updateRuntimeSettings',
+  'checkDistillProvider',
+  'listScopeKeys',
   'bootstrapContext',
   'syncResumeContext',
   'checkCodexExec',
@@ -24,6 +28,7 @@ const REMOTE_METHODS = [
   'autoPromoteMemoryCandidates',
   'reconcileMemory',
   'getMemory',
+  'listMemories',
   'search',
   'rebuildEmbeddings',
   'processEmbeddingJobs',
@@ -40,7 +45,15 @@ const REMOTE_METHODS = [
   'distillUsage',
 ];
 
-const UNSCOPED_REMOTE_METHODS = new Set(['dbInfo', 'checkCodexExec', 'pruneRawEvents']);
+const UNSCOPED_REMOTE_METHODS = new Set([
+  'dbInfo',
+  'getRuntimeSettings',
+  'updateRuntimeSettings',
+  'checkDistillProvider',
+  'checkCodexExec',
+  'listScopeKeys',
+  'pruneRawEvents',
+]);
 
 function remoteUrl(baseUrl, method) {
   const url = new URL(baseUrl);

--- a/src/server.js
+++ b/src/server.js
@@ -59,6 +59,7 @@ async function sendStaticUi(requestUrl, response) {
     const content = await fs.readFile(filePath);
     response.writeHead(200, {
       'content-type': UI_TYPES[path.extname(filePath)] || 'application/octet-stream',
+      'cache-control': 'no-store',
     });
     response.end(content);
   } catch (error) {
@@ -384,6 +385,7 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
         adminSessions.set(session, { createdAt: Date.now(), expiresAt: Date.now() + adminSessionTtlMs });
         response.writeHead(200, {
           'content-type': 'application/json',
+          'cache-control': 'no-store',
           'set-cookie': makeCookie(ADMIN_COOKIE_NAME, session, {
             maxAge: Math.ceil(adminSessionTtlMs / 1000),
             secure: adminCookieSecure,
@@ -401,6 +403,7 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
       if (session) adminSessions.delete(session);
       response.writeHead(200, {
         'content-type': 'application/json',
+        'cache-control': 'no-store',
         'set-cookie': makeCookie(ADMIN_COOKIE_NAME, '', { maxAge: 0, secure: adminCookieSecure }),
       });
       response.end('{"ok":true}\n');

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
 import http from 'node:http';
-import { pathToFileURL } from 'node:url';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { createContextForge } from './core.js';
 import { createContextForgeMcpServer } from './mcp.js';
@@ -9,6 +11,18 @@ import { REMOTE_METHODS } from './remote/client.js';
 
 const METHOD_SET = new Set(REMOTE_METHODS);
 const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
+const UI_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), 'admin-ui');
+const DEFAULT_ADMIN_SESSION_TTL_MS = 12 * 60 * 60 * 1000;
+const DEFAULT_ADMIN_LOGIN_WINDOW_MS = 15 * 60 * 1000;
+const DEFAULT_ADMIN_LOGIN_MAX_FAILURES = 5;
+const ADMIN_COOKIE_NAME = 'contextforge_admin';
+const UI_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+};
 
 class RequestBodyTooLargeError extends Error {
   constructor() {
@@ -23,6 +37,37 @@ function sendJson(response, statusCode, body) {
     'content-type': 'application/json',
   });
   response.end(`${JSON.stringify(body, null, 2)}\n`);
+}
+
+async function sendStaticUi(requestUrl, response) {
+  const pathname = requestUrl.pathname === '/ui' ? '/ui/' : requestUrl.pathname;
+  let relative;
+  try {
+    relative = pathname === '/ui/' ? 'index.html' : decodeURIComponent(pathname.slice('/ui/'.length));
+  } catch {
+    sendJson(response, 404, { error: { message: 'Not found.' } });
+    return;
+  }
+  const safePath = path.normalize(relative);
+  const filePath = path.join(UI_DIR, safePath);
+  const fileRelative = path.relative(UI_DIR, filePath);
+  if (fileRelative.startsWith('..') || path.isAbsolute(fileRelative)) {
+    sendJson(response, 404, { error: { message: 'Not found.' } });
+    return;
+  }
+  try {
+    const content = await fs.readFile(filePath);
+    response.writeHead(200, {
+      'content-type': UI_TYPES[path.extname(filePath)] || 'application/octet-stream',
+    });
+    response.end(content);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      sendJson(response, 404, { error: { message: 'Not found.' } });
+      return;
+    }
+    sendJson(response, 500, { error: { message: error.message } });
+  }
 }
 
 function parseMaxBodyBytes(env) {
@@ -88,6 +133,107 @@ function timingSafeStringEqual(actual, expected) {
 function isAuthorized(request, token) {
   if (!token) return true;
   return timingSafeStringEqual(request.headers.authorization, `Bearer ${token}`);
+}
+
+function originMatchesHost(request) {
+  const origin = request.headers.origin;
+  if (!origin) return true;
+  try {
+    return new URL(origin).host === request.headers.host;
+  } catch {
+    return false;
+  }
+}
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function makeCookie(name, value, { maxAge = null, secure = true } = {}) {
+  return [
+    `${name}=${encodeURIComponent(value)}`,
+    'HttpOnly',
+    'SameSite=Strict',
+    'Path=/',
+    secure ? 'Secure' : null,
+    maxAge == null ? null : `Max-Age=${maxAge}`,
+  ]
+    .filter(Boolean)
+    .join('; ');
+}
+
+function parseAdminPasswordHash(env) {
+  if (!env.CONTEXTFORGE_ADMIN_USER) {
+    return null;
+  }
+  const pbkdf2 = env.CONTEXTFORGE_ADMIN_PASSWORD_PBKDF2;
+  if (!pbkdf2) {
+    throw new Error('CONTEXTFORGE_ADMIN_PASSWORD_PBKDF2 is required when CONTEXTFORGE_ADMIN_USER is set.');
+  }
+  const [iterationsText, saltHex, hashHex] = String(pbkdf2).split(':');
+  const iterations = Number(iterationsText);
+  if (!Number.isInteger(iterations) || iterations < 100000 || !saltHex || !hashHex) {
+    throw new Error(
+      'CONTEXTFORGE_ADMIN_PASSWORD_PBKDF2 must use format iterations:saltHex:hashHex with at least 100000 iterations.',
+    );
+  }
+  return {
+    iterations,
+    salt: Buffer.from(saltHex, 'hex'),
+    hash: Buffer.from(hashHex, 'hex'),
+  };
+}
+
+function verifyAdminPassword(password, passwordHash) {
+  if (!passwordHash) return false;
+  const derived = crypto.pbkdf2Sync(
+    String(password || ''),
+    passwordHash.salt,
+    passwordHash.iterations,
+    passwordHash.hash.length,
+    'sha256',
+  );
+  return crypto.timingSafeEqual(derived, passwordHash.hash);
+}
+
+function requestIp(request) {
+  return String(request.headers['x-forwarded-for'] || request.socket.remoteAddress || '')
+    .split(',')[0]
+    .trim();
+}
+
+function parseCookies(request) {
+  const cookies = {};
+  for (const item of String(request.headers.cookie || '')
+    .split(';')
+    .map((cookie) => cookie.trim())
+    .filter(Boolean)) {
+    try {
+        const index = item.indexOf('=');
+      const key = index === -1 ? item : item.slice(0, index);
+      const value = index === -1 ? '' : decodeURIComponent(item.slice(index + 1));
+      cookies[key] = value;
+    } catch {
+      // Ignore malformed cookies instead of turning auth checks into 500s.
+    }
+  }
+  return cookies;
+}
+
+function isAdminSessionAuthorized(request, sessions) {
+  const session = parseCookies(request)[ADMIN_COOKIE_NAME];
+  const entry = session ? sessions.get(session) : null;
+  if (!entry) return false;
+  if (Date.now() > entry.expiresAt) {
+    sessions.delete(session);
+    return false;
+  }
+  return true;
+}
+
+function isRequestAuthorized(request, token, sessions) {
+  return isAuthorized(request, token) || (originMatchesHost(request) && isAdminSessionAuthorized(request, sessions));
 }
 
 function connectionServerRole(connection) {
@@ -159,6 +305,50 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
   const serverApp = app || createContextForge({ env: serverStorageEnv(env), reuseStore: true });
   const authToken = env.CONTEXTFORGE_REMOTE_TOKEN || null;
   const maxBodyBytes = parseMaxBodyBytes(env);
+  const adminUser = env.CONTEXTFORGE_ADMIN_USER || null;
+  const adminPasswordHash = parseAdminPasswordHash(env);
+  const adminSessionTtlMs = parsePositiveInteger(env.CONTEXTFORGE_ADMIN_SESSION_TTL_MS, DEFAULT_ADMIN_SESSION_TTL_MS);
+  const adminLoginWindowMs = parsePositiveInteger(
+    env.CONTEXTFORGE_ADMIN_LOGIN_WINDOW_MS,
+    DEFAULT_ADMIN_LOGIN_WINDOW_MS,
+  );
+  const adminLoginMaxFailures = parsePositiveInteger(
+    env.CONTEXTFORGE_ADMIN_LOGIN_MAX_FAILURES,
+    DEFAULT_ADMIN_LOGIN_MAX_FAILURES,
+  );
+  const adminCookieSecure = env.CONTEXTFORGE_ADMIN_COOKIE_SECURE !== 'false';
+  const adminSessions = new Map();
+  const failedAdminLogins = new Map();
+
+  function pruneAdminSessions(now = Date.now()) {
+    for (const [session, entry] of adminSessions.entries()) {
+      if (now > entry.expiresAt) {
+        adminSessions.delete(session);
+      }
+    }
+  }
+
+  function loginAttemptKey(request, username) {
+    return `${requestIp(request)}:${String(username || '')}`;
+  }
+
+  function loginAllowed(key, now = Date.now()) {
+    const entry = failedAdminLogins.get(key);
+    if (!entry || now > entry.resetAt) {
+      failedAdminLogins.delete(key);
+      return true;
+    }
+    return entry.count < adminLoginMaxFailures;
+  }
+
+  function recordFailedLogin(key, now = Date.now()) {
+    const entry = failedAdminLogins.get(key);
+    if (!entry || now > entry.resetAt) {
+      failedAdminLogins.set(key, { count: 1, resetAt: now + adminLoginWindowMs });
+      return;
+    }
+    entry.count += 1;
+  }
 
   const server = http.createServer(async (request, response) => {
     const requestUrl = new URL(request.url, 'http://localhost');
@@ -168,8 +358,62 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
       return;
     }
 
+    if (request.method === 'POST' && requestUrl.pathname === '/ui/login') {
+      try {
+        if (!adminUser || !adminPasswordHash) {
+          sendJson(response, 403, { error: { message: 'Admin login is not configured.' } });
+          return;
+        }
+        const body = await readJsonBody(request, { maxBodyBytes });
+        const attemptKey = loginAttemptKey(request, body.username);
+        if (!loginAllowed(attemptKey)) {
+          sendJson(response, 429, { error: { message: 'Too many failed login attempts.' } });
+          return;
+        }
+        const ok =
+          timingSafeStringEqual(body.username, adminUser) &&
+          verifyAdminPassword(body.password, adminPasswordHash);
+        if (!ok) {
+          recordFailedLogin(attemptKey);
+          sendJson(response, 401, { error: { message: 'Invalid login.' } });
+          return;
+        }
+        failedAdminLogins.delete(attemptKey);
+        pruneAdminSessions();
+        const session = crypto.randomBytes(32).toString('hex');
+        adminSessions.set(session, { createdAt: Date.now(), expiresAt: Date.now() + adminSessionTtlMs });
+        response.writeHead(200, {
+          'content-type': 'application/json',
+          'set-cookie': makeCookie(ADMIN_COOKIE_NAME, session, {
+            maxAge: Math.ceil(adminSessionTtlMs / 1000),
+            secure: adminCookieSecure,
+          }),
+        });
+        response.end(`${JSON.stringify({ ok: true })}\n`);
+      } catch (error) {
+        sendJson(response, error.statusCode || 500, { error: { message: error.message, name: error.name } });
+      }
+      return;
+    }
+
+    if (request.method === 'POST' && requestUrl.pathname === '/ui/logout') {
+      const session = parseCookies(request)[ADMIN_COOKIE_NAME];
+      if (session) adminSessions.delete(session);
+      response.writeHead(200, {
+        'content-type': 'application/json',
+        'set-cookie': makeCookie(ADMIN_COOKIE_NAME, '', { maxAge: 0, secure: adminCookieSecure }),
+      });
+      response.end('{"ok":true}\n');
+      return;
+    }
+
+    if (request.method === 'GET' && (requestUrl.pathname === '/ui' || requestUrl.pathname.startsWith('/ui/'))) {
+      await sendStaticUi(requestUrl, response);
+      return;
+    }
+
     if (requestUrl.pathname === '/mcp') {
-      if (!isAuthorized(request, authToken)) {
+      if (!isRequestAuthorized(request, authToken, adminSessions)) {
         sendJson(response, 401, { error: { message: 'Unauthorized.' } });
         return;
       }
@@ -204,7 +448,7 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
       return;
     }
 
-    if (!isAuthorized(request, authToken)) {
+    if (!isRequestAuthorized(request, authToken, adminSessions)) {
       sendJson(response, 401, { error: { message: 'Unauthorized.' } });
       return;
     }

--- a/src/server.js
+++ b/src/server.js
@@ -222,15 +222,20 @@ function parseCookies(request) {
   return cookies;
 }
 
-function isAdminSessionAuthorized(request, sessions) {
+function getAdminSessionEntry(request, sessions) {
   const session = parseCookies(request)[ADMIN_COOKIE_NAME];
   const entry = session ? sessions.get(session) : null;
   if (!entry) return false;
   if (Date.now() > entry.expiresAt) {
     sessions.delete(session);
-    return false;
+    return null;
   }
-  return true;
+  return entry;
+}
+
+function isAdminSessionAuthorized(request, sessions) {
+  const entry = getAdminSessionEntry(request, sessions);
+  return Boolean(entry);
 }
 
 function isRequestAuthorized(request, token, sessions) {
@@ -356,6 +361,20 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
 
     if (request.method === 'GET' && requestUrl.pathname === '/healthz') {
       sendJson(response, 200, { ok: true });
+      return;
+    }
+
+    if (request.method === 'GET' && requestUrl.pathname === '/ui/session') {
+      const entry = originMatchesHost(request) ? getAdminSessionEntry(request, adminSessions) : null;
+      if (!entry) {
+        sendJson(response, 401, { ok: false });
+        return;
+      }
+      response.writeHead(200, {
+        'content-type': 'application/json',
+        'cache-control': 'no-store',
+      });
+      response.end(`${JSON.stringify({ ok: true, username: adminUser || '관리자' })}\n`);
       return;
     }
 

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -4,7 +4,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import Database from 'better-sqlite3';
 import * as sqliteVec from 'sqlite-vec';
 
-export const SCHEMA_VERSION = 14;
+export const SCHEMA_VERSION = 15;
 
 function nowIso() {
   return new Date().toISOString();
@@ -473,6 +473,14 @@ export class ContextForgeStore {
         completed_at TEXT
       );
 
+      CREATE TABLE IF NOT EXISTS runtime_settings (
+        key TEXT PRIMARY KEY,
+        value_json TEXT NOT NULL,
+        secret INTEGER NOT NULL DEFAULT 0 CHECK (secret IN (0, 1)),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
       CREATE TABLE IF NOT EXISTS working_summaries (
         id TEXT PRIMARY KEY,
         scope_type TEXT NOT NULL CHECK (scope_type IN ('shared', 'repo', 'local')),
@@ -648,6 +656,8 @@ export class ContextForgeStore {
         ON checkpoints(scope_type, scope_key, session_id, created_at);
       CREATE INDEX IF NOT EXISTS idx_distill_runs_session
         ON distill_runs(scope_type, scope_key, session_id, created_at);
+      CREATE INDEX IF NOT EXISTS idx_runtime_settings_secret
+        ON runtime_settings(secret, updated_at);
       CREATE INDEX IF NOT EXISTS idx_working_summaries_scope
         ON working_summaries(scope_type, scope_key, updated_at);
       CREATE INDEX IF NOT EXISTS idx_session_working_context_scope
@@ -725,6 +735,7 @@ export class ContextForgeStore {
         rawEvents: count('raw_events'),
         checkpoints: count('checkpoints'),
         distillRuns: count('distill_runs'),
+        runtimeSettings: count('runtime_settings'),
         workingSummaries: count('working_summaries'),
         sessionWorkingContexts: count('session_working_context'),
         memoryEvents: count('memory_events'),
@@ -1857,6 +1868,30 @@ export class ContextForgeStore {
       .map(hydrateMemory);
   }
 
+  listMemoriesForAdmin({ scopeType, scopeKey, status = 'active', query = null, limit = 100 } = {}) {
+    const filters = ['scope_type = ?', 'scope_key = ?'];
+    const values = [scopeType, scopeKey];
+    if (status && status !== 'all') {
+      filters.push('status = ?');
+      values.push(status);
+    }
+    if (query) {
+      filters.push('(memory_key LIKE ? OR category LIKE ? OR content LIKE ? OR tags_json LIKE ?)');
+      const pattern = `%${query}%`;
+      values.push(pattern, pattern, pattern, pattern);
+    }
+    values.push(Number(limit));
+    return this.db
+      .prepare(`
+        SELECT * FROM memories
+        WHERE ${filters.join(' AND ')}
+        ORDER BY importance DESC, updated_at DESC, memory_key ASC
+        LIMIT ?
+      `)
+      .all(...values)
+      .map(hydrateMemory);
+  }
+
   deactivateMemory({ scopeType, scopeKey, key, reason = null }) {
     const existing = this.getMemory({ scopeType, scopeKey, key });
     if (!existing) {
@@ -2732,14 +2767,138 @@ export class ContextForgeStore {
     return hydrateDistillRun(row);
   }
 
-  listDistillRuns({ scopeType, scopeKey, sessionId }) {
+  listDistillRuns({ scopeType, scopeKey, sessionId = null, status = null, provider = null, limit = null }) {
+    const filters = ['scope_type = ?', 'scope_key = ?'];
+    const values = [scopeType, scopeKey];
+    if (sessionId) {
+      filters.push('session_id = ?');
+      values.push(sessionId);
+    }
+    if (status) {
+      filters.push('status = ?');
+      values.push(status);
+    }
+    if (provider) {
+      filters.push('provider = ?');
+      values.push(provider);
+    }
+    const parsedLimit = limit == null ? null : Number(limit);
+    const limitClause = Number.isInteger(parsedLimit) && parsedLimit > 0 ? 'LIMIT ?' : '';
+    if (limitClause) values.push(parsedLimit);
     return this.db
       .prepare(`
         SELECT * FROM distill_runs
-        WHERE scope_type = ? AND scope_key = ? AND session_id = ?
+        WHERE ${filters.join(' AND ')}
         ORDER BY created_at ASC, id ASC
+        ${limitClause}
       `)
-      .all(scopeType, scopeKey, sessionId)
+      .all(...values)
       .map(hydrateDistillRun);
+  }
+
+  listScopeKeys({ scopeType = null, limit = null } = {}) {
+    const filters = [];
+    const values = [];
+    if (scopeType) {
+      filters.push('scope_type = ?');
+      values.push(scopeType);
+    }
+    const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    const parsedLimit = limit == null ? null : Number(limit);
+    const limitClause = Number.isInteger(parsedLimit) && parsedLimit > 0 ? 'LIMIT ?' : '';
+    if (limitClause) values.push(parsedLimit);
+    return this.db
+      .prepare(`
+        WITH scoped_rows AS (
+          SELECT scope_type, scope_key, 1 AS memories, 0 AS candidates, 0 AS distill_runs, 0 AS raw_events, 0 AS checkpoints, updated_at AS touched_at
+          FROM memories
+          UNION ALL
+          SELECT scope_type, scope_key, 0, 1, 0, 0, 0, created_at
+          FROM memory_candidate_index
+          UNION ALL
+          SELECT scope_type, scope_key, 0, 0, 1, 0, 0, created_at
+          FROM distill_runs
+          UNION ALL
+          SELECT scope_type, scope_key, 0, 0, 0, 1, 0, created_at
+          FROM raw_events
+          UNION ALL
+          SELECT scope_type, scope_key, 0, 0, 0, 0, 1, created_at
+          FROM checkpoints
+        )
+        SELECT
+          scope_type,
+          scope_key,
+          SUM(memories) AS memories,
+          SUM(candidates) AS candidates,
+          SUM(distill_runs) AS distill_runs,
+          SUM(raw_events) AS raw_events,
+          SUM(checkpoints) AS checkpoints,
+          MAX(touched_at) AS last_touched_at
+        FROM scoped_rows
+        ${where}
+        GROUP BY scope_type, scope_key
+        ORDER BY last_touched_at DESC, scope_type ASC, scope_key ASC
+        ${limitClause}
+      `)
+      .all(...values)
+      .map((row) => ({
+        scopeType: row.scope_type,
+        scope: row.scope_type,
+        scopeKey: row.scope_key,
+        memories: Number(row.memories || 0),
+        candidates: Number(row.candidates || 0),
+        distillRuns: Number(row.distill_runs || 0),
+        rawEvents: Number(row.raw_events || 0),
+        checkpoints: Number(row.checkpoints || 0),
+        lastTouchedAt: row.last_touched_at,
+      }));
+  }
+
+  getRuntimeSettings({ includeSecrets = false } = {}) {
+    const rows = this.db.prepare('SELECT * FROM runtime_settings ORDER BY key ASC').all();
+    const settings = {};
+    const secrets = {};
+    for (const row of rows) {
+      const value = parseJson(row.value_json, null);
+      const entry = {
+        value: row.secret && !includeSecrets ? null : value,
+        secret: Boolean(row.secret),
+        secretPresent: Boolean(row.secret && value),
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      };
+      settings[row.key] = entry;
+      if (row.secret && includeSecrets) {
+        secrets[row.key] = value;
+      }
+    }
+    return { settings, secrets };
+  }
+
+  setRuntimeSettings({ values = {}, secrets = {}, clearSecrets = [] } = {}) {
+    const timestamp = nowIso();
+    const setRow = this.db.prepare(`
+      INSERT INTO runtime_settings (key, value_json, secret, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(key) DO UPDATE SET
+        value_json = excluded.value_json,
+        secret = excluded.secret,
+        updated_at = excluded.updated_at
+    `);
+    const deleteRow = this.db.prepare('DELETE FROM runtime_settings WHERE key = ? AND secret = 1');
+    const transaction = this.db.transaction(() => {
+      for (const [key, value] of Object.entries(values || {})) {
+        setRow.run(key, json(value, null), 0, timestamp, timestamp);
+      }
+      for (const [key, value] of Object.entries(secrets || {})) {
+        if (value == null || value === '') continue;
+        setRow.run(key, json(String(value), null), 1, timestamp, timestamp);
+      }
+      for (const key of clearSecrets || []) {
+        deleteRow.run(key);
+      }
+    });
+    transaction();
+    return this.getRuntimeSettings();
   }
 }

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -2767,7 +2767,7 @@ export class ContextForgeStore {
     return hydrateDistillRun(row);
   }
 
-  listDistillRuns({ scopeType, scopeKey, sessionId = null, status = null, provider = null, limit = null }) {
+  listDistillRuns({ scopeType, scopeKey, sessionId = null, status = null, provider = null, limit = null, order = 'asc' }) {
     const filters = ['scope_type = ?', 'scope_key = ?'];
     const values = [scopeType, scopeKey];
     if (sessionId) {
@@ -2785,11 +2785,12 @@ export class ContextForgeStore {
     const parsedLimit = limit == null ? null : Number(limit);
     const limitClause = Number.isInteger(parsedLimit) && parsedLimit > 0 ? 'LIMIT ?' : '';
     if (limitClause) values.push(parsedLimit);
+    const orderDirection = order === 'desc' ? 'DESC' : 'ASC';
     return this.db
       .prepare(`
         SELECT * FROM distill_runs
         WHERE ${filters.join(' AND ')}
-        ORDER BY created_at ASC, id ASC
+        ORDER BY created_at ${orderDirection}, id ${orderDirection}
         ${limitClause}
       `)
       .all(...values)

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -5467,6 +5467,65 @@ test('autoPromoteMemoryCandidates keeps candidates pending when audit runner fai
   assert.equal(app.getMemory({ scope: 'repo', scopeKey: 'audit-fail-repo', key: 'audit-failed-runbook' }), null);
 });
 
+test('autoPromoteMemoryCandidates rejects unsupported audit providers', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'unsupported_audit_provider',
+      CONTEXTFORGE_AUTO_PROMOTE_ENABLED: 'true',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER: 'unknown_audit',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      unsupported_audit_provider: async () => ({
+        summaryShort: 'Unsupported audit provider checkpoint.',
+        summaryText: 'Closeout produced a candidate while audit is misconfigured.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'unsupported-audit-runbook',
+            content: 'The runbook should not promote when audit provider is unsupported.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.96,
+            stability: 0.96,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'unsupported-audit-repo',
+    sessionId: 'unsupported-audit-session',
+    role: 'assistant',
+    content: 'Unsupported audit provider candidate.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'unsupported-audit-repo',
+    sessionId: 'unsupported-audit-session',
+  });
+
+  await assert.rejects(
+    () =>
+      app.autoPromoteMemoryCandidates({
+        scope: 'repo',
+        scopeKey: 'unsupported-audit-repo',
+        sessionId: 'unsupported-audit-session',
+        trigger: 'manual_closeout',
+        dryRun: false,
+      }),
+    /Unsupported auto-promotion audit provider/,
+  );
+  assert.equal(app.getMemory({ scope: 'repo', scopeKey: 'unsupported-audit-repo', key: 'unsupported-audit-runbook' }), null);
+});
+
 test('preference candidates record merged occurrences across checkpoints', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({
@@ -6783,6 +6842,12 @@ test('HTTP server accepts admin UI login sessions', async () => {
     assert.equal(login.headers.get('cache-control'), 'no-store');
     const cookie = login.headers.get('set-cookie');
     assert.match(cookie, /contextforge_admin=/);
+    const session = await fetch(`${remote.url}/ui/session`, {
+      headers: { cookie },
+    });
+    assert.equal(session.status, 200);
+    assert.equal(session.headers.get('cache-control'), 'no-store');
+    assert.deepEqual(await session.json(), { ok: true, username: 'ginishuh' });
     const info = await fetch(`${remote.url}/v0/dbInfo`, {
       method: 'POST',
       headers: {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -2976,6 +2976,48 @@ test('appendRaw and mock distillCheckpoint preserve raw evidence', async () => {
   assert.equal(statusAfter.shouldDistill, false);
 });
 
+test('listDistillRuns can return newest runs first when limited', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'mock',
+    },
+    cwd: process.cwd(),
+  });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'run-order-repo',
+    sessionId: 'older-session',
+    role: 'user',
+    content: 'Create the older run.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'run-order-repo',
+    sessionId: 'older-session',
+  });
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'run-order-repo',
+    sessionId: 'newer-session',
+    role: 'user',
+    content: 'Create the newer run.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'run-order-repo',
+    sessionId: 'newer-session',
+  });
+
+  const oldestFirst = app.listDistillRuns({ scope: 'repo', scopeKey: 'run-order-repo', limit: 1 });
+  assert.equal(oldestFirst[0].sessionId, 'older-session');
+  const newestFirst = app.listDistillRuns({ scope: 'repo', scopeKey: 'run-order-repo', limit: 1, order: 'desc' });
+  assert.equal(newestFirst[0].sessionId, 'newer-session');
+});
+
 test('distillCheckpoint records checkpoint level and coverage metadata', async () => {
   const dataDir = await makeTempDir();
   const store = new ContextForgeStore({ dataDir });

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -5036,6 +5036,17 @@ test('autoPromoteMemoryCandidates promotes only strict safe candidates when enab
     embeddingProviders: {
       openai: embeddingProvider,
     },
+    autoPromoteAuditor: async () => ({
+      approved: true,
+      decision: 'approve',
+      reason: 'Test auditor approved strict safe candidate.',
+      riskCodes: [],
+      metadata: {
+        provider: 'codex_exec',
+        model: 'gpt-5.5',
+        reasoningEffort: 'low',
+      },
+    }),
     distillProviders: {
       auto_enabled_provider: async () => ({
         summaryShort: 'Auto enabled checkpoint.',
@@ -5142,6 +5153,7 @@ test('autoPromoteMemoryCandidates promotes only strict safe candidates when enab
   const promotedCandidates = app.listMemoryCandidates({ scope: 'repo', scopeKey: 'auto-enabled-repo', status: 'promoted' });
   assert.equal(promotedCandidates.length, 2);
   assert.ok(promotedCandidates.every((candidate) => candidate.reviewMetadata.autoPromoted === true));
+  assert.ok(promotedCandidates.every((candidate) => candidate.reviewMetadata.autoPromotionAudit?.metadata?.model === 'gpt-5.5'));
   assert.deepEqual(
     promotedCandidates.map((candidate) => candidate.reviewMetadata.memoryId).sort(),
     result.promoted.map((item) => item.memoryId).sort(),
@@ -5172,6 +5184,82 @@ test('autoPromoteMemoryCandidates promotes only strict safe candidates when enab
   );
   assert.ok(safeApiMemoryResult, 'expected safe-api-contract memory result');
   assert.equal(safeApiMemoryResult.retrieval.vectorModel, 'test-embedding');
+});
+
+test('autoPromoteMemoryCandidates skips candidates rejected by the audit runner', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'audit_reject_provider',
+      CONTEXTFORGE_AUTO_PROMOTE_ENABLED: 'true',
+    },
+    cwd: process.cwd(),
+    autoPromoteAuditor: async () => ({
+      approved: false,
+      decision: 'needs_review',
+      reason: 'Candidate is plausible but needs human review.',
+      riskCodes: ['needs_human_review'],
+      metadata: {
+        provider: 'codex_exec',
+        model: 'gpt-5.5',
+        reasoningEffort: 'low',
+      },
+    }),
+    distillProviders: {
+      audit_reject_provider: async () => ({
+        summaryShort: 'Audit rejected checkpoint.',
+        summaryText: 'Closeout produced a candidate that local checks would otherwise promote.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'audit-gated-runbook',
+            content: 'The runbook requires audit approval before automatic durable promotion.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.96,
+            stability: 0.96,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'audit-reject-repo',
+    sessionId: 'audit-reject-session',
+    role: 'assistant',
+    content: 'Audit-gated candidate.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'audit-reject-repo',
+    sessionId: 'audit-reject-session',
+  });
+
+  const result = await app.autoPromoteMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'audit-reject-repo',
+    sessionId: 'audit-reject-session',
+    trigger: 'manual_closeout',
+    dryRun: false,
+  });
+
+  assert.deepEqual(result.promoted, []);
+  assert.equal(result.skipped.length, 1);
+  assert.equal(result.skipped[0].reason, 'audit_needs_review: needs_human_review');
+  assert.equal(result.skipped[0].audit.metadata.model, 'gpt-5.5');
+  assert.equal(app.getMemory({ scope: 'repo', scopeKey: 'audit-reject-repo', key: 'audit-gated-runbook' }), null);
+  const candidates = app.listMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'audit-reject-repo',
+    status: 'pending',
+  });
+  assert.equal(candidates.length, 1);
 });
 
 test('preference candidates record merged occurrences across checkpoints', async () => {
@@ -6459,7 +6547,7 @@ test('HTTP server serves admin UI assets', async () => {
   try {
     const response = await fetch(`${remote.url}/ui/`);
     assert.equal(response.status, 200);
-    assert.match(await response.text(), /ContextForge Admin/);
+    assert.match(await response.text(), /ContextForge 관리/);
   } finally {
     await remote.close();
   }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -24,6 +25,13 @@ const execFileAsync = promisify(execFile);
 
 async function makeTempDir() {
   return fs.mkdtemp(path.join(os.tmpdir(), 'contextforge-test-'));
+}
+
+function testAdminPasswordHash(password) {
+  const salt = Buffer.from('contextforge-test-admin-salt');
+  const iterations = 100000;
+  const hash = crypto.pbkdf2Sync(password, salt, iterations, 32, 'sha256');
+  return `${iterations}:${salt.toString('hex')}:${hash.toString('hex')}`;
 }
 
 test('interruptible ingest sleep wakes when stopped', async () => {
@@ -4055,6 +4063,236 @@ test('codex_exec doctor reports dry and live smoke readiness through a runner', 
   assert.equal(invocations[2].timeoutMs, 1234);
 });
 
+test('runtime settings are DB-backed, redacted, and hot-apply to session status', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'mock',
+      CONTEXTFORGE_DISTILL_MIN_INTERVAL_MS: '600000',
+    },
+    cwd: process.cwd(),
+  });
+
+  const updated = app.updateRuntimeSettings({
+    values: {
+      distillProvider: 'openai_compatible',
+      openAiCompatible: {
+        preset: 'deepseek',
+        baseUrl: 'https://api.deepseek.com',
+        model: 'deepseek-v4-flash',
+        responseFormat: 'json_object',
+      },
+      distillPolicy: {
+        minEvents: 1,
+        minIntervalMs: 1,
+        charMinIntervalMs: 1,
+        charThreshold: 1,
+        maxEvents: 10,
+        maxChars: 2000,
+      },
+    },
+    secrets: {
+      openAiCompatibleApiKey: 'deepseek-secret',
+    },
+  });
+
+  assert.equal(updated.effective.distillProvider, 'openai_compatible');
+  assert.equal(updated.effective.openAiCompatible.model, 'deepseek-v4-flash');
+  assert.equal(updated.effective.openAiCompatible.secretPresent, true);
+  assert.equal(updated.effective.openAiCompatible.apiKey, undefined);
+  assert.equal(updated.stored['openAiCompatible.apiKey'].value, null);
+  assert.equal(updated.stored['openAiCompatible.apiKey'].secretPresent, true);
+  assert.throws(
+    () =>
+      app.updateRuntimeSettings({
+        values: {
+          openAiCompatible: {
+            apiKey: 'not-through-values',
+          },
+        },
+      }),
+    /write-only secrets channel/,
+  );
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'settings-repo',
+    sessionId: 'settings-session',
+    role: 'user',
+    content: 'Enough content to cross the UI-managed char threshold.',
+  });
+  const status = app.sessionStatus({
+    scope: 'repo',
+    scopeKey: 'settings-repo',
+    sessionId: 'settings-session',
+  });
+  assert.equal(status.thresholds.minIntervalMs, 1);
+  assert.equal(status.thresholds.charThreshold, 1);
+  assert.equal(status.shouldDistill, true);
+});
+
+test('openai_compatible provider distills through a fake DeepSeek-style chat completions endpoint', async () => {
+  const dataDir = await makeTempDir();
+  let requestBody;
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'mock',
+    },
+    cwd: process.cwd(),
+    fetchImpl: async (url, request) => {
+      assert.equal(String(url), 'https://api.deepseek.com/chat/completions');
+      assert.equal(request.headers.authorization, 'Bearer deepseek-secret');
+      requestBody = JSON.parse(request.body);
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: JSON.stringify({
+                    summaryShort: 'OpenAI-compatible checkpoint.',
+                    summaryText: 'The DeepSeek-style provider returned valid JSON.',
+                    workingSummary: 'Current state: openai_compatible provider is under test.',
+                    sessionWorkingContext: {
+                      mode: 'task_execution',
+                      currentTask: 'Test provider',
+                      currentUserIntent: 'Verify DeepSeek-style distill',
+                      targetSubject: null,
+                      sourceSubject: null,
+                      lastUserCorrection: null,
+                      openQuestion: null,
+                      nonGoals: [],
+                      avoidMisreadings: [],
+                      confidence: 0.9,
+                    },
+                    decisions: ['Use OpenAI-compatible Chat Completions for DeepSeek.'],
+                    todos: [],
+                    openQuestions: [],
+                    memoryCandidates: [],
+                    sourceEventCount: 1,
+                    provider: 'openai_compatible',
+                    metadata: {
+                      providerNotes: 'synthetic openai-compatible output',
+                      retrievalHooks: ['deepseek-v4-flash', 'openai_compatible'],
+                    },
+                  }),
+                },
+              },
+            ],
+            usage: {
+              prompt_tokens: 12,
+              completion_tokens: 8,
+              total_tokens: 20,
+            },
+          }),
+      };
+    },
+  });
+
+  app.updateRuntimeSettings({
+    values: {
+      distillProvider: 'openai_compatible',
+      openAiCompatible: {
+        preset: 'deepseek',
+        baseUrl: 'https://api.deepseek.com',
+        model: 'manual-model',
+        responseFormat: 'json_object',
+      },
+    },
+    secrets: {
+      openAiCompatibleApiKey: 'deepseek-secret',
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'openai-compatible-repo',
+    sessionId: 'openai-compatible-session',
+    role: 'user',
+    content: 'Decision: test DeepSeek-compatible distillation.',
+  });
+
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'openai-compatible-repo',
+    sessionId: 'openai-compatible-session',
+  });
+
+  assert.equal(requestBody.model, 'manual-model');
+  assert.deepEqual(requestBody.response_format, { type: 'json_object' });
+  assert.equal(requestBody.thinking.type, 'disabled');
+  assert.equal(checkpoint.provider, 'openai_compatible');
+  assert.equal(checkpoint.metadata.providerMetadata.openAiCompatible.baseUrlHost, 'api.deepseek.com');
+  assert.equal(checkpoint.metadata.providerMetadata.openAiCompatible.model, 'manual-model');
+  assert.equal(checkpoint.metadata.providerMetadata.openAiCompatible.usage.total_tokens, 20);
+});
+
+test('openai_compatible provider preserves raw evidence when provider output is malformed', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+    },
+    cwd: process.cwd(),
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          choices: [{ message: { content: '{"summaryShort":"missing required fields"}' } }],
+        }),
+    }),
+  });
+  app.updateRuntimeSettings({
+    values: {
+      distillProvider: 'openai_compatible',
+      openAiCompatible: {
+        preset: 'deepseek',
+        baseUrl: 'https://api.deepseek.com',
+        model: 'deepseek-v4-flash',
+        responseFormat: 'json_object',
+      },
+    },
+    secrets: {
+      openAiCompatibleApiKey: 'deepseek-secret',
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'bad-openai-compatible-repo',
+    sessionId: 'bad-openai-compatible-session',
+    role: 'user',
+    content: 'Raw evidence should survive malformed provider output.',
+  });
+
+  await assert.rejects(
+    app.distillCheckpoint({
+      scope: 'repo',
+      scopeKey: 'bad-openai-compatible-repo',
+      sessionId: 'bad-openai-compatible-session',
+    }),
+    /Provider output field/,
+  );
+
+  assert.equal(
+    app.listRawEvents({
+      scope: 'repo',
+      scopeKey: 'bad-openai-compatible-repo',
+      sessionId: 'bad-openai-compatible-session',
+    }).length,
+    1,
+  );
+  const runs = app.listDistillRuns({
+    scope: 'repo',
+    scopeKey: 'bad-openai-compatible-repo',
+    sessionId: 'bad-openai-compatible-session',
+  });
+  assert.equal(runs[0].status, 'failed');
+});
+
 test('codex_exec rejects unsupported reasoning effort values', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({
@@ -5509,8 +5747,76 @@ test('reconcileMemory apply_safe rejects matching candidates when no durable mem
   assert.equal(candidates.length, 1);
 });
 
+test('listScopeKeys returns real scopes from memories, candidates, and distill runs', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'scope_keys_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      scope_keys_provider: async () => ({
+        summaryShort: 'Scope key checkpoint.',
+        summaryText: 'A checkpoint that creates a candidate for scope key discovery.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'scope-key-candidate',
+            content: 'Candidate used for scope key discovery.',
+            category: 'note',
+            confidence: 0.9,
+            stability: 0.9,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+
+  app.remember({
+    scope: 'shared',
+    scopeKey: 'team-shared',
+    key: 'scope-key-memory',
+    content: 'Durable memory used for scope key discovery.',
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-scope-keys',
+    sessionId: 'scope-key-session',
+    role: 'user',
+    content: 'Create a checkpoint and candidate.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-scope-keys',
+    sessionId: 'scope-key-session',
+  });
+
+  const allKeys = app.listScopeKeys();
+  const repoKey = allKeys.find((item) => item.scopeType === 'repo' && item.scopeKey === 'repo-scope-keys');
+  assert.equal(repoKey.candidates, 1);
+  assert.equal(repoKey.distillRuns, 1);
+  assert.equal(repoKey.rawEvents, 1);
+  assert.equal(repoKey.checkpoints, 1);
+  const sharedKeys = app.listScopeKeys({ scope: 'shared' });
+  assert.deepEqual(
+    sharedKeys.map((item) => item.scopeKey),
+    ['team-shared'],
+  );
+  assert.equal(sharedKeys[0].memories, 1);
+});
+
 test('REMOTE_METHODS exposes resume, suggestion, auto-promotion, and reconciliation wrappers', () => {
   assert.ok(REMOTE_METHODS.includes('syncResumeContext'));
+  assert.ok(REMOTE_METHODS.includes('getRuntimeSettings'));
+  assert.ok(REMOTE_METHODS.includes('updateRuntimeSettings'));
+  assert.ok(REMOTE_METHODS.includes('checkDistillProvider'));
+  assert.ok(REMOTE_METHODS.includes('listScopeKeys'));
+  assert.ok(REMOTE_METHODS.includes('listMemories'));
   assert.ok(REMOTE_METHODS.includes('suggestMemoryPromotions'));
   assert.ok(REMOTE_METHODS.includes('autoPromoteMemoryCandidates'));
   assert.ok(REMOTE_METHODS.includes('reconcileMemory'));
@@ -5683,6 +5989,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'distill_checkpoint',
       'distill_usage',
       'get_memory',
+      'get_runtime_settings',
       'get_session_working_context',
       'get_working_summary',
       'list_checkpoints',
@@ -6134,6 +6441,120 @@ test('HTTP v0 callers see remote-client connection metadata', async () => {
     assert.equal(resumeBody.result.storage.connection.transport, 'http-api');
     assert.equal(resumeBody.result.storage.connection.serverRole, 'http-server');
     assert.equal(resumeBody.result.storage.connection.server.mode, 'http-server');
+  } finally {
+    await remote.close();
+  }
+});
+
+test('HTTP server serves admin UI assets', async () => {
+  const dataDir = await makeTempDir();
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+    },
+  });
+
+  try {
+    const response = await fetch(`${remote.url}/ui/`);
+    assert.equal(response.status, 200);
+    assert.match(await response.text(), /ContextForge Admin/);
+  } finally {
+    await remote.close();
+  }
+});
+
+test('HTTP server accepts admin UI login sessions', async () => {
+  const dataDir = await makeTempDir();
+  const password = 'hu23bc' + 'CONTEXT!';
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+      CONTEXTFORGE_ADMIN_USER: 'ginishuh',
+      CONTEXTFORGE_ADMIN_PASSWORD_PBKDF2: testAdminPasswordHash(password),
+      CONTEXTFORGE_ADMIN_COOKIE_SECURE: 'false',
+    },
+  });
+
+  try {
+    const login = await fetch(`${remote.url}/ui/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ username: 'ginishuh', password }),
+    });
+    assert.equal(login.status, 200);
+    const cookie = login.headers.get('set-cookie');
+    assert.match(cookie, /contextforge_admin=/);
+    const info = await fetch(`${remote.url}/v0/dbInfo`, {
+      method: 'POST',
+      headers: {
+        cookie,
+        'content-type': 'application/json',
+      },
+      body: '{}',
+    });
+    assert.equal(info.status, 200);
+  } finally {
+    await remote.close();
+  }
+});
+
+test('HTTP server keeps admin UI login disabled unless credentials are configured', async () => {
+  const dataDir = await makeTempDir();
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+    },
+  });
+
+  try {
+    const login = await fetch(`${remote.url}/ui/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ username: 'ginishuh', password: 'anything' }),
+    });
+    assert.equal(login.status, 403);
+  } finally {
+    await remote.close();
+  }
+});
+
+test('HTTP server rate limits repeated admin UI login failures', async () => {
+  const dataDir = await makeTempDir();
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+      CONTEXTFORGE_ADMIN_USER: 'ginishuh',
+      CONTEXTFORGE_ADMIN_PASSWORD_PBKDF2: testAdminPasswordHash('correct-password'),
+      CONTEXTFORGE_ADMIN_COOKIE_SECURE: 'false',
+      CONTEXTFORGE_ADMIN_LOGIN_MAX_FAILURES: '2',
+      CONTEXTFORGE_ADMIN_LOGIN_WINDOW_MS: '60000',
+    },
+  });
+
+  try {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const login = await fetch(`${remote.url}/ui/login`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ username: 'ginishuh', password: 'wrong-password' }),
+      });
+      assert.equal(login.status, 401);
+    }
+
+    const limited = await fetch(`${remote.url}/ui/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ username: 'ginishuh', password: 'wrong-password' }),
+    });
+    assert.equal(limited.status, 429);
   } finally {
     await remote.close();
   }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -4114,6 +4114,12 @@ test('runtime settings are DB-backed, redacted, and hot-apply to session status'
       }),
     /write-only secrets channel/,
   );
+  const cleared = app.updateRuntimeSettings({
+    clearSecrets: ['openAiCompatibleApiKey'],
+  });
+  assert.equal(cleared.effective.openAiCompatible.secretPresent, false);
+  assert.equal(cleared.effective.openAiCompatible.apiKey, undefined);
+  assert.equal(cleared.stored['openAiCompatible.apiKey'], undefined);
 
   app.appendRaw({
     scope: 'repo',
@@ -4223,11 +4229,107 @@ test('openai_compatible provider distills through a fake DeepSeek-style chat com
 
   assert.equal(requestBody.model, 'manual-model');
   assert.deepEqual(requestBody.response_format, { type: 'json_object' });
-  assert.equal(requestBody.thinking.type, 'disabled');
+  assert.equal(requestBody.thinking, undefined);
   assert.equal(checkpoint.provider, 'openai_compatible');
   assert.equal(checkpoint.metadata.providerMetadata.openAiCompatible.baseUrlHost, 'api.deepseek.com');
   assert.equal(checkpoint.metadata.providerMetadata.openAiCompatible.model, 'manual-model');
   assert.equal(checkpoint.metadata.providerMetadata.openAiCompatible.usage.total_tokens, 20);
+});
+
+test('openai_compatible provider repairs invalid JSON output and records retry metadata', async () => {
+  const dataDir = await makeTempDir();
+  const requests = [];
+  const validOutput = {
+    summaryShort: 'Repaired OpenAI-compatible checkpoint.',
+    summaryText: 'The repair retry returned the complete checkpoint schema.',
+    workingSummary: 'Current state: repair retry is under test.',
+    sessionWorkingContext: {
+      mode: 'task_execution',
+      currentTask: 'Test repair retry',
+      currentUserIntent: 'Verify OpenAI-compatible repair validation',
+      targetSubject: null,
+      sourceSubject: null,
+      lastUserCorrection: null,
+      openQuestion: null,
+      nonGoals: [],
+      avoidMisreadings: [],
+      confidence: 0.88,
+    },
+    decisions: ['Re-validate repaired provider output before accepting it.'],
+    todos: [],
+    openQuestions: [],
+    memoryCandidates: [],
+    sourceEventCount: 1,
+    provider: 'openai_compatible',
+    metadata: {
+      retrievalHooks: ['repair-retry'],
+    },
+  };
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+    },
+    cwd: process.cwd(),
+    fetchImpl: async (url, request) => {
+      requests.push(JSON.parse(request.body));
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content:
+                    requests.length === 1
+                      ? '{"summaryShort":"missing required fields"}'
+                      : JSON.stringify(validOutput),
+                },
+              },
+            ],
+            usage: {
+              prompt_tokens: 20,
+              completion_tokens: 10,
+              total_tokens: 30,
+            },
+          }),
+      };
+    },
+  });
+  app.updateRuntimeSettings({
+    values: {
+      distillProvider: 'openai_compatible',
+      openAiCompatible: {
+        preset: 'deepseek',
+        baseUrl: 'https://api.deepseek.com',
+        model: 'deepseek-v4-flash',
+        responseFormat: 'json_object',
+      },
+    },
+    secrets: {
+      openAiCompatibleApiKey: 'deepseek-secret',
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repair-openai-compatible-repo',
+    sessionId: 'repair-openai-compatible-session',
+    role: 'user',
+    content: 'Provider should repair an incomplete checkpoint.',
+  });
+
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repair-openai-compatible-repo',
+    sessionId: 'repair-openai-compatible-session',
+  });
+
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].thinking.type, 'disabled');
+  assert.match(requests[1].messages.at(-1).content, /failed validation/);
+  assert.equal(checkpoint.summaryShort, 'Repaired OpenAI-compatible checkpoint.');
+  assert.equal(checkpoint.metadata.providerMetadata.openAiCompatible.retryCount, 1);
+  assert.match(checkpoint.metadata.providerMetadata.openAiCompatible.validationFailure, /Provider output field/);
 });
 
 test('openai_compatible provider preserves raw evidence when provider output is malformed', async () => {
@@ -5260,6 +5362,67 @@ test('autoPromoteMemoryCandidates skips candidates rejected by the audit runner'
     status: 'pending',
   });
   assert.equal(candidates.length, 1);
+});
+
+test('autoPromoteMemoryCandidates keeps candidates pending when audit runner fails', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'audit_fail_provider',
+      CONTEXTFORGE_AUTO_PROMOTE_ENABLED: 'true',
+    },
+    cwd: process.cwd(),
+    autoPromoteAuditor: async () => {
+      throw new Error('audit runner unavailable');
+    },
+    distillProviders: {
+      audit_fail_provider: async () => ({
+        summaryShort: 'Audit failed checkpoint.',
+        summaryText: 'Closeout produced a candidate that local checks would otherwise promote.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'audit-failed-runbook',
+            content: 'The runbook requires audit success before automatic durable promotion.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.96,
+            stability: 0.96,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'audit-fail-repo',
+    sessionId: 'audit-fail-session',
+    role: 'assistant',
+    content: 'Audit failure candidate.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'audit-fail-repo',
+    sessionId: 'audit-fail-session',
+  });
+
+  const result = await app.autoPromoteMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'audit-fail-repo',
+    sessionId: 'audit-fail-session',
+    trigger: 'manual_closeout',
+    dryRun: false,
+  });
+
+  assert.deepEqual(result.promoted, []);
+  assert.equal(result.skipped[0].reason, 'audit_needs_review: audit_failed');
+  assert.match(result.skipped[0].audit.reason, /audit runner unavailable/);
+  assert.equal(app.getMemory({ scope: 'repo', scopeKey: 'audit-fail-repo', key: 'audit-failed-runbook' }), null);
 });
 
 test('preference candidates record merged occurrences across checkpoints', async () => {
@@ -6547,6 +6710,7 @@ test('HTTP server serves admin UI assets', async () => {
   try {
     const response = await fetch(`${remote.url}/ui/`);
     assert.equal(response.status, 200);
+    assert.equal(response.headers.get('cache-control'), 'no-store');
     assert.match(await response.text(), /ContextForge 관리/);
   } finally {
     await remote.close();
@@ -6574,6 +6738,7 @@ test('HTTP server accepts admin UI login sessions', async () => {
       body: JSON.stringify({ username: 'ginishuh', password }),
     });
     assert.equal(login.status, 200);
+    assert.equal(login.headers.get('cache-control'), 'no-store');
     const cookie = login.headers.get('set-cookie');
     assert.match(cookie, /contextforge_admin=/);
     const info = await fetch(`${remote.url}/v0/dbInfo`, {


### PR DESCRIPTION
## Summary
- Add Korean admin/operator UI under /ui for runtime settings, memory management, candidates, and distill runs
- Add OpenAI-compatible DeepSeek provider while keeping codex_exec selectable
- Add UI-managed runtime settings, provider smoke checks, scope-key dropdowns, login state, and recent run dashboard
- Add conservative auto-promotion audit gate via separate codex_exec auditor

## Validation
- npm test: 117 passed
- git diff --check
- live service restarted and /healthz verified
- Claude review found no merge-blocking issues; medium findings around login/session state and unsupported audit providers were addressed

## Merge Note
Repo AGENTS.md says agents may create/update PRs but must not merge them, so this PR is prepared for human merge.
