### PR TITLE
Fix admin dashboard recent distill runs

### DIFF
--- a/src/admin-ui/app.js
+++ b/src/admin-ui/app.js
@@ -16,7 +16,7 @@ function setLoginState(loggedIn, username = '') {
 }
 
 async function refreshDashboardRuns() {
-  await loadRuns('#recentRuns', dashboardRunScope());
+  await loadRecentRuns();
 }
 
 async function restoreLoginSession() {
@@ -231,16 +231,6 @@ function fillScopeKeySelects() {
   fillScopeKeySelect($('#runScopeKey'), $('#runScope').value, $('#runScopeKey').value);
 }
 
-function dashboardRunScope() {
-  const repoWithRuns = state.scopeKeys.find((item) => item.scopeType === 'repo' && item.distillRuns > 0);
-  const anyWithRuns = state.scopeKeys.find((item) => item.distillRuns > 0);
-  const selected = repoWithRuns || anyWithRuns;
-  if (selected) {
-    return { scope: selected.scopeType, scopeKey: selected.scopeKey };
-  }
-  return { scope: 'repo', scopeKey: state.db?.defaultScopeKey || '' };
-}
-
 function formNumber(form, key) {
   const value = Number(form[key].value);
   return Number.isFinite(value) && value > 0 ? value : undefined;
@@ -333,6 +323,24 @@ async function loadRuns(target = '#runsTable', options = {}) {
   const runs = await call('listDistillRuns', { scope, scopeKey, ...(sessionId ? { sessionId } : {}), limit: 25, order: 'desc' });
   $(target).innerHTML = table(runs, [
     { label: '생성 시각', value: (row) => row.createdAt },
+    { label: '스코프', value: (row) => `${row.scopeType}:${row.scopeKey}` },
+    { label: '프로바이더', value: (row) => row.provider },
+    { label: '상태', value: (row) => row.status },
+    { label: '세션', value: (row) => row.sessionId },
+    { label: '이벤트', value: (row) => row.sourceEventCount },
+    { label: '오류', value: (row) => row.errorMessage || '' },
+  ]);
+}
+
+async function loadRecentRuns() {
+  const activeProvider = state.runtime?.effective?.distillProvider || '';
+  const runs = await call('listRecentDistillRuns', { limit: 25 });
+  $('#recentRunsHint').textContent = activeProvider
+    ? `전체 스코프의 최신 디스틸 실행입니다. 현재 활성 프로바이더: ${activeProvider}`
+    : '전체 스코프의 최신 디스틸 실행입니다.';
+  $('#recentRuns').innerHTML = table(runs, [
+    { label: '생성 시각', value: (row) => row.createdAt },
+    { label: '스코프', value: (row) => `${row.scopeType}:${row.scopeKey}` },
     { label: '프로바이더', value: (row) => row.provider },
     { label: '상태', value: (row) => row.status },
     { label: '세션', value: (row) => row.sessionId },

--- a/src/admin-ui/index.html
+++ b/src/admin-ui/index.html
@@ -47,6 +47,7 @@
           </section>
           <section class="panel wide">
             <h2>최근 실행</h2>
+            <p id="recentRunsHint" class="muted">전체 스코프의 최신 디스틸 실행입니다.</p>
             <div id="recentRuns" class="table"></div>
           </section>
         </div>

--- a/src/core.js
+++ b/src/core.js
@@ -3500,6 +3500,19 @@ export function createContextForge(options = {}) {
       );
     },
 
+    listRecentDistillRuns(options = {}) {
+      return useStore((store) =>
+        store.listRecentDistillRuns({
+          scopeType: options.scope || options.scopeType || null,
+          scopeKey: options.scopeKey || null,
+          sessionId: options.sessionId || null,
+          status: options.status || null,
+          provider: options.provider || null,
+          limit: options.limit == null ? 25 : Number(options.limit),
+        }),
+      );
+    },
+
     distillUsage(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.sessionId, 'sessionId');

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -42,6 +42,7 @@ const REMOTE_METHODS = [
   'pruneRawEvents',
   'distillCheckpoint',
   'listDistillRuns',
+  'listRecentDistillRuns',
   'distillUsage',
 ];
 
@@ -52,6 +53,7 @@ const UNSCOPED_REMOTE_METHODS = new Set([
   'checkDistillProvider',
   'checkCodexExec',
   'listScopeKeys',
+  'listRecentDistillRuns',
   'pruneRawEvents',
 ]);
 

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -2797,6 +2797,44 @@ export class ContextForgeStore {
       .map(hydrateDistillRun);
   }
 
+  listRecentDistillRuns({ scopeType = null, scopeKey = null, sessionId = null, status = null, provider = null, limit = 25 } = {}) {
+    const filters = [];
+    const values = [];
+    if (scopeType) {
+      filters.push('scope_type = ?');
+      values.push(scopeType);
+    }
+    if (scopeKey) {
+      filters.push('scope_key = ?');
+      values.push(scopeKey);
+    }
+    if (sessionId) {
+      filters.push('session_id = ?');
+      values.push(sessionId);
+    }
+    if (status) {
+      filters.push('status = ?');
+      values.push(status);
+    }
+    if (provider) {
+      filters.push('provider = ?');
+      values.push(provider);
+    }
+    const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    const parsedLimit = limit == null ? null : Number(limit);
+    const limitClause = Number.isInteger(parsedLimit) && parsedLimit > 0 ? 'LIMIT ?' : '';
+    if (limitClause) values.push(parsedLimit);
+    return this.db
+      .prepare(`
+        SELECT * FROM distill_runs
+        ${where}
+        ORDER BY created_at DESC, id DESC
+        ${limitClause}
+      `)
+      .all(...values)
+      .map(hydrateDistillRun);
+  }
+
   listScopeKeys({ scopeType = null, limit = null } = {}) {
     const filters = [];
     const values = [];

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -27,6 +27,10 @@ async function makeTempDir() {
   return fs.mkdtemp(path.join(os.tmpdir(), 'contextforge-test-'));
 }
 
+async function makeNonGitTempDir() {
+  return fs.mkdtemp(path.join(os.homedir(), 'contextforge-test-'));
+}
+
 function testAdminPasswordHash(password) {
   const salt = Buffer.from('contextforge-test-admin-salt');
   const iterations = 100000;
@@ -371,7 +375,7 @@ test('repo scope key defaults to normalized GitHub origin remote', async () => {
 });
 
 test('repo scope key falls back to a deterministic path key outside git', async () => {
-  const cwd = await makeTempDir();
+  const cwd = await makeNonGitTempDir();
   const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: path.join(cwd, 'data') }, cwd });
 
   assert.match(app.config.defaultScopeKey, /^path:[a-f0-9]{16}:contextforge-test-/);
@@ -418,7 +422,7 @@ test('repoPath and cwd resolve repo scope independently of the app cwd', async (
 });
 
 test('default shared and local scopes get usable default keys', async () => {
-  const cwd = await makeTempDir();
+  const cwd = await makeNonGitTempDir();
   const sharedApp = createContextForge({
     env: {
       CONTEXTFORGE_DATA_DIR: path.join(cwd, 'shared-data'),
@@ -3016,6 +3020,56 @@ test('listDistillRuns can return newest runs first when limited', async () => {
   assert.equal(oldestFirst[0].sessionId, 'older-session');
   const newestFirst = app.listDistillRuns({ scope: 'repo', scopeKey: 'run-order-repo', limit: 1, order: 'desc' });
   assert.equal(newestFirst[0].sessionId, 'newer-session');
+});
+
+test('listRecentDistillRuns returns newest runs across scopes', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'mock',
+    },
+    cwd: process.cwd(),
+  });
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'older-repo',
+    sessionId: 'older-session',
+    role: 'user',
+    content: 'Create the older cross-scope run.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'older-repo',
+    sessionId: 'older-session',
+  });
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'newer-repo',
+    sessionId: 'newer-session',
+    role: 'user',
+    content: 'Create the newer cross-scope run.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'newer-repo',
+    sessionId: 'newer-session',
+  });
+
+  const recent = app.listRecentDistillRuns({ limit: 2 });
+  assert.deepEqual(
+    recent.map((run) => [run.scopeKey, run.sessionId]),
+    [
+      ['newer-repo', 'newer-session'],
+      ['older-repo', 'older-session'],
+    ],
+  );
+
+  const filtered = app.listRecentDistillRuns({ scope: 'repo', scopeKey: 'older-repo', limit: 1 });
+  assert.equal(filtered.length, 1);
+  assert.equal(filtered[0].sessionId, 'older-session');
 });
 
 test('distillCheckpoint records checkpoint level and coverage metadata', async () => {
@@ -6168,6 +6222,7 @@ test('REMOTE_METHODS exposes resume, suggestion, auto-promotion, and reconciliat
   assert.ok(REMOTE_METHODS.includes('updateRuntimeSettings'));
   assert.ok(REMOTE_METHODS.includes('checkDistillProvider'));
   assert.ok(REMOTE_METHODS.includes('listScopeKeys'));
+  assert.ok(REMOTE_METHODS.includes('listRecentDistillRuns'));
   assert.ok(REMOTE_METHODS.includes('listMemories'));
   assert.ok(REMOTE_METHODS.includes('suggestMemoryPromotions'));
   assert.ok(REMOTE_METHODS.includes('autoPromoteMemoryCandidates'));


### PR DESCRIPTION
## Summary
- show dashboard recent runs across all scopes instead of picking one implicit repo scope
- add scope column and active provider hint to make DeepSeek vs historical codex_exec runs clear
- expose listRecentDistillRuns through core and remote APIs
- make path-key tests robust when /tmp is itself inside a git root

## Tests
- npm test

## Live verification
- restarted contextforge-remote.service
- /v0/listRecentDistillRuns now returns newest live rows with provider openai_compatible