### PR TITLE
Add bootstrap latest checkpoint handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 0.4.1 - 2026-05-20
+
+- Added query-independent latest checkpoint handoff to `bootstrapContext` and
+  the MCP `bootstrap_context` tool, returning `handoff.latestCheckpoints` by
+  default so agents see recent work status before durable memory even when
+  checkpoint search ranking loses to stable memories.
+- Added `latestCheckpointLimit` (0-3 per scope) and repo
+  `relatedScopeKeys` options for multi-repo suite/subrepo bootstraps, with CLI
+  and MCP schema support.
+- Updated agent guidance to treat checkpoints as the preferred source for
+  recent handoff state while keeping durable memory for stable contracts,
+  policies, decisions, and runbooks.
+
 ## 0.4.0 - 2026-05-14
 
 - Added a Korean operator UI at `/ui/` for runtime dashboards, provider

--- a/README.md
+++ b/README.md
@@ -903,8 +903,16 @@ receives it together with the new raw-event window so it can update current
 state instead of emitting a delta-only summary. Treat it as current session
 state, not reviewed durable memory.
 
-When a caller knows the session id, `bootstrapContext` can return the working
-summary and a recent raw tail alongside ordinary retrieval results:
+`bootstrapContext` includes recent checkpoint handoff separately from ordinary
+query results. By default it returns the latest level-0 checkpoint for the
+requested scope in `handoff.latestCheckpoints`, even when that checkpoint does
+not win semantic search ranking. Set `--latestCheckpointLimit 0` to disable
+this lane, or a value up to `3` to preload more recent checkpoints per scope.
+For multi-repo work, pass comma-separated repo `--relatedScopeKeys` so a subrepo
+can also receive the suite/root repo's latest handoff.
+
+When a caller knows the session id, `bootstrapContext` can also return the
+working summary and a recent raw tail alongside ordinary retrieval results:
 
 ```bash
 node src/cli.js bootstrapContext \
@@ -912,6 +920,7 @@ node src/cli.js bootstrapContext \
   --scopeKey github.com/example/contextforge \
   --sessionId current-session-id \
   --query "current task handoff" \
+  --relatedScopeKeys github.com/example/suite \
   --rawTailLimit 5
 ```
 
@@ -920,6 +929,10 @@ only when last-mile transcript continuity is needed.
 
 The bootstrap response keeps these channels separate:
 
+- `handoff.latestCheckpoints`: latest recent handoff checkpoints loaded
+  independently of query ranking; read these before durable memory for current
+  work status, recent decisions, open todos, branch/PR/CI flow, and next
+  actions.
 - `results`: durable memories, checkpoints, and memory candidates from search.
 - `workingSummary`: latest rolling handoff state for the requested session.
 - `rawTail`: newest raw events for last-mile continuity.
@@ -1279,11 +1292,14 @@ server's env files, service manager, or local database. When available, use
 as the live access-path check.
 For loose continuation prompts like "yesterday", "continue", "previous work",
 issue/PR follow-up, or cross-agent handoff, agents should call
-`bootstrap_context` or `bootstrapContext` early. The bootstrap response reviews
+`bootstrap_context` or `bootstrapContext` early. The bootstrap response includes
+`handoff.latestCheckpoints` independently of search ranking, then reviews
 repo-scoped `memory`, `checkpoint`, and `memory_candidate` hits as context
 candidates, optionally includes up to three shared-scope hits, then reminds the
 agent to verify current branch, issue/PR, CI, migration, and runtime state
-against live sources before acting.
+against live sources before acting. Agents should read latest checkpoints before
+durable memory for fast-moving work status; durable memory remains the stable
+policy/contract/runbook layer.
 
 When resuming a known session, pass `sessionId` to `bootstrap_context` or
 `bootstrapContext`. ContextForge will include the session's latest

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -65,14 +65,18 @@ At task start, call `bootstrap_context` with `scope: "repo"` and the canonical
 scope key `github.com/example/repo`. Include shared scope only for user-wide
 policy, deployment, credential-location, or cross-repo conventions.
 
-Treat `memory` as reviewed durable state, `checkpoint` as credible recent
-handoff state that still needs live verification, and `memory_candidate` as
-review material.
+Read `handoff.latestCheckpoints` before durable memory for recent work status,
+recent decisions, open todos, branch/PR/CI flow, and next actions. Treat
+`memory` as reviewed durable state for stable contracts, policies, and
+runbooks; treat `checkpoint` as credible recent handoff state that still needs
+live verification; and treat `memory_candidate` as review material.
 
 For loose continuation prompts such as "yesterday", "continue", "previous
-work", issue/PR follow-up, or cross-agent handoff, call
-`sync_resume_context` when available. Use checkpoints for prior intent, recent
-decisions, and unfinished work, then verify current git/GitHub/CI/runtime
+work", issue/PR follow-up, or cross-agent handoff, call `bootstrap_context`
+first. It includes latest checkpoint handoff independently from semantic search
+ranking. Use `sync_resume_context` only when the exact session id is known and
+session working state or raw tail is needed. Use checkpoints for prior intent,
+recent decisions, and unfinished work, then verify current git/GitHub/CI/runtime
 state from live sources.
 
 Use the installed `contextforge-memory` skill for session IDs, distillation,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -268,14 +268,18 @@ Default retrieval should be compact, explainable, scoped, and on demand.
 Recommended order:
 
 1. current repository reality
-2. ContextForge durable memory from `repo + shared`
-3. checkpoints for recent continuity when requested
+2. latest ContextForge checkpoints from `handoff.latestCheckpoints` for recent
+   work status, prior intent, recent decisions, open todos, branch/PR/CI flow,
+   and next actions
+3. ContextForge durable memory from `repo + shared` for stable contracts,
+   policies, decisions, and runbooks
 4. raw conversation evidence only when explicit
 5. built-in agent memory and markdown fallback as supporting context
 
 Avoid:
 
 - auto-loading all checkpoints
+- relying on query ranking alone to surface the latest checkpoint
 - auto-loading raw events
 - dumping giant memory files into prompt context
 - treating vector results as unexplainable truth

--- a/docs/skills/contextforge-memory/SKILL.md
+++ b/docs/skills/contextforge-memory/SKILL.md
@@ -52,10 +52,12 @@ Before relying on results, check connection metadata and storage authority from 
 At the start of non-trivial project work:
 
 1. Call `bootstrap_context` with a task-derived query, `scope: "repo"`, and `repoPath`, `cwd`, or explicit `scopeKey`.
-2. Set `includeShared: true` only for cross-repo/user-wide policy, credentials location, deployment, or recurring preference questions.
-3. Read the storage block and result trust roles.
-4. Use targeted `search` calls only when more detail is needed.
-5. Use `get_memory` only when you already know the exact durable key.
+2. Read `handoff.latestCheckpoints` before durable memory for recent work status, recent decisions, open todos, branch/PR/CI flow, and next actions. This lane is loaded independently from search ranking.
+3. For multi-repo work, pass repo `relatedScopeKeys` for parent/suite/subrepo scopes whose latest handoff may matter. `latestCheckpointLimit` applies per scope.
+4. Set `includeShared: true` only for cross-repo/user-wide policy, credentials location, deployment, or recurring preference questions.
+5. Read the storage block and result trust roles.
+6. Use targeted `search` calls only when more detail is needed.
+7. Use `get_memory` only when you already know the exact durable key.
 
 `bootstrap_context` does not create a session. It retrieves scoped context.
 
@@ -75,11 +77,12 @@ When resuming a known session, pass that `sessionId` to `bootstrap_context`, `sy
 
 For "continue", "yesterday", prior issue/PR follow-up, or cross-agent handoff:
 
-1. Prefer `sync_resume_context`.
-2. Treat checkpoints as credible recent handoff notes.
-3. Treat memory candidates as review material only.
-4. Verify live mutable state before editing or reporting final status.
-5. Do not propose memory promotions during start/resume sync.
+1. Call `bootstrap_context` first; its latest checkpoint handoff is not dependent on semantic search ranking.
+2. Use `sync_resume_context` only when the exact `sessionId` is known and session working state or raw tail is needed.
+3. Treat checkpoints as credible recent handoff notes and prefer them over durable memory for fast-moving work status.
+4. Treat memory candidates as review material only.
+5. Verify live mutable state before editing or reporting final status.
+6. Do not propose memory promotions during start/resume sync.
 
 ## Evidence Capture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contextforge",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contextforge",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contextforge",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Self-hosted memory and distillation runtime for coding agents.",
   "type": "module",
   "bin": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -135,6 +135,13 @@ function toCoreOptions(options) {
     iterations: options.iterations == null ? undefined : Number(options.iterations),
     charsPerToken: options.charsPerToken == null ? undefined : Number(options.charsPerToken),
     rawTailLimit: options.rawTailLimit == null ? undefined : Number(options.rawTailLimit),
+    latestCheckpointLimit: options.latestCheckpointLimit == null ? undefined : Number(options.latestCheckpointLimit),
+    relatedScopeKeys: options.relatedScopeKeys
+      ? String(options.relatedScopeKeys)
+          .split(',')
+          .map((item) => item.trim())
+          .filter(Boolean)
+      : undefined,
     settings: options.settings ? JSON.parse(options.settings) : undefined,
     values: options.values ? JSON.parse(options.values) : undefined,
     secrets: options.secrets ? JSON.parse(options.secrets) : undefined,

--- a/src/core.js
+++ b/src/core.js
@@ -110,6 +110,14 @@ function nonnegativeNumber(value, name) {
   return value;
 }
 
+function boundedInteger(value, name, { min = 0, max = 3 } = {}) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}.`);
+  }
+  return parsed;
+}
+
 function withStore(config, fn) {
   const store = new ContextForgeStore({ dataDir: config.dataDir });
   try {
@@ -428,6 +436,52 @@ function bootstrapRawTailEvent(event) {
     metadata: event.metadata,
     createdAt: event.createdAt,
   };
+}
+
+function checkpointHandoffCompact(checkpoint, scope) {
+  const sourceEventWindow = checkpoint.metadata?.sourceEventWindow || null;
+  return {
+    type: 'checkpoint',
+    trust: 'credible_recent_handoff',
+    verificationRequired: true,
+    whyUse:
+      'Preferred source for recent work status, handoff, recent decisions, open todos, and next actions; verify mutable claims against live sources before final action.',
+    useFor: ['recent_status', 'handoff', 'next_actions', 'recent_decisions'],
+    scope: {
+      scopeType: scope.scopeType,
+      scopeKey: scope.scopeKey,
+    },
+    id: checkpoint.id,
+    sessionId: checkpoint.sessionId,
+    conversationId: checkpoint.conversationId,
+    level: checkpoint.level,
+    createdAt: checkpoint.createdAt,
+    summaryShort: checkpoint.summaryShort,
+    summaryText: truncateText(checkpoint.summaryText, 1600),
+    decisions: checkpoint.decisions || [],
+    todos: checkpoint.todos || [],
+    openQuestions: checkpoint.openQuestions || [],
+    sourceEventCount: checkpoint.sourceEventCount,
+    provider: checkpoint.provider,
+    ...(sourceEventWindow
+      ? {
+          sourceEventWindow: {
+            mode: sourceEventWindow.mode || null,
+            selectedEventCount: sourceEventWindow.selectedEventCount ?? null,
+            selectedCharCount: sourceEventWindow.selectedCharCount ?? null,
+            truncated: Boolean(sourceEventWindow.truncated),
+          },
+        }
+      : {}),
+  };
+}
+
+function normalizeRelatedScopeKeys(value) {
+  if (value == null) {
+    return [];
+  }
+  const items = Array.isArray(value) ? value : String(value).split(',');
+  return [...new Set(items.map((item) => String(item).trim()).filter(Boolean))];
 }
 
 function bootstrapResult(result, group) {
@@ -1718,6 +1772,14 @@ export function createContextForge(options = {}) {
       const sharedLimit = Math.min(3, limit);
       const includeShared = truthyOption(options.includeShared);
       const sessionId = options.sessionId || null;
+      const latestCheckpointLimit = boundedInteger(
+        options.latestCheckpointLimit == null ? 1 : Number(options.latestCheckpointLimit),
+        'latestCheckpointLimit',
+        { min: 0, max: 3 },
+      );
+      const relatedScopeKeys = normalizeRelatedScopeKeys(options.relatedScopeKeys).filter(
+        (scopeKey) => scopeKey !== scope.scopeKey,
+      );
       const rawTailLimit = sessionId
         ? nonnegativeNumber(options.rawTailLimit == null ? 0 : Number(options.rawTailLimit), 'rawTailLimit')
         : null;
@@ -1761,6 +1823,25 @@ export function createContextForge(options = {}) {
           ...repoResults.map((result) => bootstrapResult(result, 'primary')),
           ...sharedResults.map((result) => bootstrapResult(result, 'shared')),
         ];
+        const handoffScopes = [
+          scope,
+          ...relatedScopeKeys.map((scopeKey) => ({
+            scopeType: 'repo',
+            scopeKey,
+          })),
+        ];
+        const latestCheckpoints =
+          latestCheckpointLimit > 0
+            ? handoffScopes.flatMap((handoffScope) =>
+                store
+                  .listRecentCheckpoints({
+                    ...handoffScope,
+                    level: 0,
+                    limit: latestCheckpointLimit,
+                  })
+                  .map((checkpoint) => checkpointHandoffCompact(checkpoint, handoffScope)),
+              )
+            : [];
         const workingSummary = sessionId
           ? bootstrapWorkingSummary(store.getWorkingSummary({ ...scope, sessionId }))
           : null;
@@ -1778,6 +1859,14 @@ export function createContextForge(options = {}) {
           query: options.query,
           includeShared,
           sharedLimit: includeShared ? sharedLimit : null,
+          handoff: {
+            latestCheckpoints,
+            latestCheckpointLimit,
+            relatedScopeKeys,
+            trustOrder: ['live_source', 'recent_checkpoint', 'durable_memory', 'memory_candidate'],
+            useHint:
+              'Read latestCheckpoints before durable memory for fast-moving work status; verify mutable claims against GitHub/git/CI/runtime before acting.',
+          },
           ...(sessionId ? { sessionId, workingSummary, structuredWorkingContext, rawTail, rawTailLimit } : {}),
           ...(sharedSkippedReason ? { sharedSkippedReason } : {}),
           summary: bootstrapSummary(results),

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -24,11 +24,12 @@ function jsonResult(result) {
 
 const MCP_INSTRUCTIONS = [
   'Use ContextForge for scoped memory retrieval on demand.',
-  'At the start of non-trivial project work, call bootstrap_context with repoPath, cwd, or an explicit scopeKey. It summarizes storage authority, vector readiness, repo semantic retrieval results, and trust hints in one response.',
+  'At the start of non-trivial project work, call bootstrap_context with repoPath, cwd, or an explicit scopeKey. It summarizes storage authority, vector readiness, query retrieval results, trust hints, and query-independent latest checkpoint handoff in one response.',
   'bootstrap_context does not create a session. In Codex or Claude Code auto-ingest environments, preserve or recover the adapter session id such as codex:<native-session-id> or claude_code:<native-session-id> before session_status, distill_checkpoint, or closeout promotion. Use begin_session only for manual ContextForge evidence streams where the agent will call append_raw itself; do not create a fresh cf_... session at closeout to review candidates from an existing Codex/Claude session.',
   'Use db_info connection metadata for access path: prefer connection.summary, then connection.accessMode/accessPath and connection.serverRole. connection.mode is kept for compatibility. Top-level storageMode describes the responding ContextForge process; connection.server may describe the server-owned store behind a remote call.',
+  'Read bootstrap_context.handoff.latestCheckpoints before durable memory for recent work status, recent decisions, open todos, branch/PR/CI flow, and next actions. Durable memory is for reviewed stable facts, contracts, policies, and runbooks. Verify mutable checkpoint claims with git/GitHub/CI/runtime/migrations before final action.',
   'Search result types have different trust roles: memory is reviewed durable fact or decision; checkpoint is credible recent handoff state for continuity, planning, prior intent, recent decisions, and unfinished work, but mutable live-state claims must be verified with git/GitHub/CI/runtime/migrations before acting; memory_candidate is unreviewed promotion material and not durable truth.',
-  'For start/resume requests such as "지난 환경 작업과 동기화", "어제 하던 거 이어서", "previous work", or "continue", call sync_resume_context. Use checkpoints actively as handoff notes, then verify mutable state with git/GitHub/CI/runtime/migrations. Do not propose memory promotions during resume sync.',
+  'For task start or loose continuation prompts such as "지난 환경 작업과 동기화", "어제 하던 거 이어서", "previous work", or "continue", call bootstrap_context first; it includes latest checkpoint handoff independent of search ranking. Use sync_resume_context only when you know the exact sessionId and need session working state or raw tail.',
   'For closeout triggers only, call suggest_memory_promotions with the current sessionId or the checkpointId returned by distill_checkpoint: after this agent merges a PR, after the user says they merged and the agent syncs main/cleans branches, or when the user explicitly says today\'s work is done. Suggest at most 1-3 durable memory promotions and never promote automatically.',
   'For strict closeout-scoped safe automatic promotion, call auto_promote_memory_candidates only when the user wants automatic promotion and always include sessionId or checkpointId. By default use dryRun=true. Use dryRun=false only when CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true is intentionally configured; never use scope-wide backlog fallback and never auto-promote preference candidates.',
   'Preference-like candidates are tracked as merged occurrences; use list_preference_occurrences to review repeated evidence and weakened corrections, but do not treat occurrence evidence alone as durable preference truth.',
@@ -92,12 +93,14 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Bootstrap Context',
       description:
-        'Resolve scoped ContextForge memory for a task in one call. Searches repo scope semantically across memory, checkpoint, and memory_candidate results, optionally includes up to 3 shared-scope results, and annotates trust and verification hints for agents. Does not create a session; pass a known Codex/Claude/ContextForge sessionId to load session working state. rawTailLimit defaults to 0; set a positive value to include raw tail.',
+        'Resolve scoped ContextForge memory for a task in one call. Includes query-independent latest checkpoint handoff (default 1, max 3) before search results, searches repo scope semantically across memory, checkpoint, and memory_candidate results, optionally includes up to 3 shared-scope results, and annotates trust and verification hints for agents. Does not create a session; pass a known Codex/Claude/ContextForge sessionId to load session working state. rawTailLimit defaults to 0; set a positive value to include raw tail.',
       inputSchema: {
         ...scopedSchema,
         query: z.string(),
         sessionId: z.string().optional(),
         rawTailLimit: z.number().int().nonnegative().optional(),
+        latestCheckpointLimit: z.number().int().min(0).max(3).optional(),
+        relatedScopeKeys: z.array(z.string()).optional(),
         includeShared: z.boolean().optional(),
         limit: z.number().int().positive().optional(),
         sharedScopeKey: z.string().optional(),

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -2056,6 +2056,30 @@ export class ContextForgeStore {
     return rows.map(hydrateCheckpoint);
   }
 
+  listRecentCheckpoints({ scopeType, scopeKey, level = null, limit = 1 }) {
+    const parsedLimit = Number(limit);
+    if (!Number.isInteger(parsedLimit) || parsedLimit <= 0) {
+      return [];
+    }
+    const filters = ['scope_type = ?', 'scope_key = ?'];
+    const values = [scopeType, scopeKey];
+    if (level != null) {
+      filters.push('level = ?');
+      values.push(Number(level));
+    }
+    values.push(parsedLimit);
+    const rows = this.db
+      .prepare(`
+        SELECT * FROM checkpoints
+        WHERE ${filters.join(' AND ')}
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?
+      `)
+      .all(...values);
+
+    return rows.map(hydrateCheckpoint);
+  }
+
   getWorkingSummary({ scopeType, scopeKey, sessionId }) {
     const row = this.db
       .prepare(`

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -3310,6 +3310,133 @@ test('bootstrapContext includes working summary and recent raw tail separately f
   assert.match(bootstrap.rawTail[0].content, /Bootstrap wiring/);
 });
 
+test('bootstrapContext includes latest checkpoints independently from search results', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'handoff_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      handoff_provider: async (input) => ({
+        summaryShort: 'Latest handoff.',
+        summaryText: `Recent checkpoint: ${input.rawEvents.at(-1).content}`,
+        decisions: ['Recent decision.'],
+        todos: ['Recent todo.'],
+        openQuestions: [],
+        memoryCandidates: [],
+        sourceEventCount: input.rawEvents.length,
+        metadata: { synthetic: true },
+      }),
+    },
+  });
+
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'repo-handoff',
+    key: 'durable-bootstrap-hit',
+    content: 'Durable bootstrap memory should win ordinary search ranking.',
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-handoff',
+    sessionId: 'handoff-session',
+    role: 'assistant',
+    content: 'PR #123 merged after all CI passed.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-handoff',
+    sessionId: 'handoff-session',
+  });
+
+  const bootstrap = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-handoff',
+    query: 'durable bootstrap memory',
+  });
+
+  assert.equal(bootstrap.results.some((item) => item.type === 'memory' && item.key === 'durable-bootstrap-hit'), true);
+  assert.equal(bootstrap.handoff.latestCheckpointLimit, 1);
+  assert.deepEqual(bootstrap.handoff.relatedScopeKeys, []);
+  assert.equal(bootstrap.handoff.latestCheckpoints.length, 1);
+  assert.equal(bootstrap.handoff.latestCheckpoints[0].trust, 'credible_recent_handoff');
+  assert.equal(bootstrap.handoff.latestCheckpoints[0].scope.scopeKey, 'repo-handoff');
+  assert.match(bootstrap.handoff.latestCheckpoints[0].summaryText, /PR #123 merged/);
+  assert.ok(bootstrap.handoff.latestCheckpoints[0].useFor.includes('recent_status'));
+
+  const disabled = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-handoff',
+    query: 'durable bootstrap memory',
+    latestCheckpointLimit: 0,
+  });
+  assert.deepEqual(disabled.handoff.latestCheckpoints, []);
+});
+
+test('bootstrapContext can include latest checkpoints from related repo scopes', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'related_handoff_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      related_handoff_provider: async (input) => ({
+        summaryShort: 'Latest related handoff.',
+        summaryText: `Recent related checkpoint: ${input.rawEvents.at(-1).content}`,
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [],
+        sourceEventCount: input.rawEvents.length,
+        metadata: {},
+      }),
+    },
+  });
+
+  for (const scopeKey of ['repo-child', 'repo-suite']) {
+    app.appendRaw({
+      scope: 'repo',
+      scopeKey,
+      sessionId: `${scopeKey}-session`,
+      role: 'assistant',
+      content: `Checkpoint evidence for ${scopeKey}.`,
+    });
+    await app.distillCheckpoint({
+      scope: 'repo',
+      scopeKey,
+      sessionId: `${scopeKey}-session`,
+    });
+  }
+
+  const bootstrap = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-child',
+    relatedScopeKeys: ['repo-suite', 'repo-suite', 'repo-child'],
+    query: 'unrelated query still needs latest handoff',
+  });
+
+  assert.deepEqual(
+    bootstrap.handoff.latestCheckpoints.map((checkpoint) => checkpoint.scope.scopeKey).sort(),
+    ['repo-child', 'repo-suite'],
+  );
+  assert.deepEqual(bootstrap.handoff.relatedScopeKeys, ['repo-suite']);
+
+  await assert.rejects(
+    () =>
+      app.bootstrapContext({
+        scope: 'repo',
+        scopeKey: 'repo-child',
+        query: 'invalid handoff limit',
+        latestCheckpointLimit: 4,
+      }),
+    /latestCheckpointLimit must be an integer between 0 and 3/,
+  );
+});
+
 test('distillCheckpoint passes previous working summary to provider for rolling updates', async () => {
   const dataDir = await makeTempDir();
   const seenPreviousWorkingSummaries = [];
@@ -6487,7 +6614,10 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     const bootstrapTool = toolList.tools.find((tool) => tool.name === 'bootstrap_context');
     assert.ok(bootstrapTool.inputSchema.properties.sessionId);
     assert.ok(bootstrapTool.inputSchema.properties.rawTailLimit);
+    assert.ok(bootstrapTool.inputSchema.properties.latestCheckpointLimit);
+    assert.ok(bootstrapTool.inputSchema.properties.relatedScopeKeys);
     assert.ok(bootstrapTool.description.includes('Does not create a session'));
+    assert.ok(bootstrapTool.description.includes('latest checkpoint handoff'));
     const syncResumeTool = toolList.tools.find((tool) => tool.name === 'sync_resume_context');
     assert.ok(syncResumeTool.inputSchema.properties.sessionId);
     const sessionWorkingContextTool = toolList.tools.find((tool) => tool.name === 'upsert_session_working_context');


### PR DESCRIPTION
## Summary
- Add query-independent latest checkpoint handoff to bootstrap_context and MCP responses
- Add latestCheckpointLimit and relatedScopeKeys controls for repo/suite handoff continuity
- Update agent docs, ContextForge memory skill guidance, changelog, and version to 0.4.1

## Validation
- npm test: 122 pass, 0 fail
- git diff --check
- CLI bootstrapContext smoke confirmed handoff.latestCheckpoints is present
- Claude review findings incorporated