### PR TITLE
[codex] add bounded distill catch-up scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 0.4.2 - 2026-05-31
+
+- Added bounded distillation catch-up commands:
+  `listDueDistillSessions` and `processDueDistills` in core, CLI, remote API,
+  and MCP as `list_due_distill_sessions` / `process_due_distills`.
+- Made catch-up scanning continue from checkpoint `sourceRawEventIds`, respect
+  normal distillation thresholds, skip active sessions through an idle window,
+  and preserve small default processing batches for low-resource operation.
+- Added `distillUsage` prompt-cache observability for providers that report
+  prompt cache hit/miss tokens, including aggregate cache hit ratio.
+- Fixed HOME-dependent non-git temp test setup so the full suite is stable when
+  `/home/ubuntu` is itself inside a git worktree.
+
 ## 0.4.1 - 2026-05-20
 
 - Added query-independent latest checkpoint handoff to `bootstrapContext` and

--- a/README.md
+++ b/README.md
@@ -882,6 +882,23 @@ If a session has a large backlog, oldest-first draining may require several
 checkpoint. This is intentional: ContextForge favors gap-free checkpoint
 chains over jumping straight to the newest tail.
 
+Watch-mode ingestion is file-change driven, so a small raw tail can remain
+after a checkpoint if the native transcript receives final events and then goes
+quiet. Use `listDueDistillSessions` to inspect those catch-up candidates without
+calling a provider, and `processDueDistills` to run a bounded batch:
+
+```sh
+node src/cli.js listDueDistillSessions --limit 20
+node src/cli.js processDueDistills --dryRun true --limit 5
+node src/cli.js processDueDistills --limit 5
+```
+
+The catch-up scanner is deliberately conservative: it uses checkpoint
+`sourceRawEventIds` to continue after the last covered raw event, defaults to a
+10 minute `idleMs` window to avoid active sessions, skips fresh `started`
+distill runs, and only processes sessions that still satisfy the normal
+distillation thresholds.
+
 Tool output is evidence, not conversation memory. Long logs, DB dumps, and
 shell output should remain in the native transcript or an explicit artifact;
 checkpoints should preserve the assistant's interpreted verification facts,
@@ -1067,11 +1084,23 @@ node src/cli.js distillUsage \
 
 `distillUsage` reports run counts, success/failure counts, selected raw-event
 characters, estimated input tokens, elapsed time, and actual provider token
-usage when a provider records it. When actual provider usage is unavailable,
-`estimatedInputTokens` uses `selectedCharCount / 4` by default. Override the
-estimation ratio with `--charsPerToken`. Older runs that do not have
-`sourceEventWindow` metadata may report `selectedCharCount` and
-`estimatedInputTokens` as `0`.
+usage when a provider records it. For providers that expose prompt-cache
+details, it also reports prompt cache hit/miss tokens and an aggregate cache
+hit ratio. When actual provider usage is unavailable, `estimatedInputTokens`
+uses `selectedCharCount / 4` by default. Override the estimation ratio with
+`--charsPerToken`. Older runs that do not have `sourceEventWindow` metadata may
+report `selectedCharCount` and `estimatedInputTokens` as `0`.
+
+Inspect or process bounded distillation catch-up work:
+
+```bash
+node src/cli.js listDueDistillSessions --limit 20
+node src/cli.js processDueDistills --dryRun true --limit 5
+```
+
+`listDueDistillSessions` is read-only. `processDueDistills` runs a small
+oldest-first batch, defaults to `--limit 5`, and respects the same normal
+distillation thresholds plus the default idle window.
 
 CLI output is JSON so adapters and scripts can consume it directly.
 
@@ -1196,6 +1225,8 @@ The MCP server exposes a narrow tool surface over the same core API:
 - `prune_raw_events`
 - `distill_checkpoint`
 - `distill_usage`
+- `list_due_distill_sessions`
+- `process_due_distills`
 - `suggest_memory_promotions`
 - `auto_promote_memory_candidates`
 - `reconcile_memory`
@@ -1410,6 +1441,7 @@ durable memories, raw event capture, rolling working summaries, checkpoint
 distillation with `mock`, `codex_exec`, and `openai_compatible` providers,
 remote HTTP mode for server-backed canonical memory, an operator UI, stdio and
 Streamable HTTP MCP, explainable hybrid retrieval, embedding job processing,
-closeout promotion review, audited strict safe auto-promotion controls, and
-memory reconciliation for user corrections. Further provider adapters and
-large-store performance hardening remain future work.
+bounded distillation catch-up, closeout promotion review, audited strict safe
+auto-promotion controls, and memory reconciliation for user corrections.
+Further provider adapters and large-store performance hardening remain future
+work.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contextforge",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contextforge",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contextforge",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Self-hosted memory and distillation runtime for coding agents.",
   "type": "module",
   "bin": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -133,6 +133,8 @@ function toCoreOptions(options) {
     watchStateDir: options.watchStateDir || process.env.CONTEXTFORGE_WATCH_STATE_DIR,
     intervalMs: options.intervalMs == null ? undefined : Number(options.intervalMs),
     iterations: options.iterations == null ? undefined : Number(options.iterations),
+    idleMs: options.idleMs == null ? undefined : Number(options.idleMs),
+    activeRunMaxAgeMs: options.activeRunMaxAgeMs == null ? undefined : Number(options.activeRunMaxAgeMs),
     charsPerToken: options.charsPerToken == null ? undefined : Number(options.charsPerToken),
     rawTailLimit: options.rawTailLimit == null ? undefined : Number(options.rawTailLimit),
     latestCheckpointLimit: options.latestCheckpointLimit == null ? undefined : Number(options.latestCheckpointLimit),
@@ -179,6 +181,14 @@ function printJson(value) {
   console.log(JSON.stringify(value, null, 2));
 }
 
+function preserveCoreLimitDefault(coreOptions, rawOptions) {
+  if (rawOptions.limit != null) {
+    return coreOptions;
+  }
+  const { limit, ...withoutLimit } = coreOptions;
+  return withoutLimit;
+}
+
 async function main() {
   const { command, options } = parseArgs(process.argv);
   const commands = {
@@ -190,6 +200,10 @@ async function main() {
     doctorCodexExec: (app, coreOptions) => app.checkCodexExec(coreOptions),
     beginSession: (app, coreOptions) => app.beginSession(coreOptions),
     sessionStatus: (app, coreOptions) => app.sessionStatus(coreOptions),
+    listDueDistillSessions: (app, coreOptions, rawOptions) =>
+      app.listDueDistillSessions(preserveCoreLimitDefault(coreOptions, rawOptions)),
+    processDueDistills: (app, coreOptions, rawOptions) =>
+      app.processDueDistills(preserveCoreLimitDefault(coreOptions, rawOptions)),
     remember: (app, coreOptions) => app.remember(coreOptions),
     promoteMemory: (app, coreOptions) => app.promoteMemory(coreOptions),
     promoteMemoryCandidate: (app, coreOptions) => app.promoteMemoryCandidate(coreOptions),
@@ -282,7 +296,7 @@ async function main() {
   if (!handler) {
     throw new Error(`Unknown command: ${command}`);
   }
-  printJson(await handler(app, coreOptions));
+  printJson(await handler(app, coreOptions, options));
 }
 
 main().catch((error) => {

--- a/src/core.js
+++ b/src/core.js
@@ -171,6 +171,20 @@ function usageNumberFrom(metadata, keys) {
   return null;
 }
 
+function usageNestedNumberFrom(metadata, path) {
+  if (!metadata || typeof metadata !== 'object') {
+    return null;
+  }
+  let current = metadata;
+  for (const key of path) {
+    if (!current || typeof current !== 'object') {
+      return null;
+    }
+    current = current[key];
+  }
+  return finiteNumber(current);
+}
+
 function extractUsageMetadata(run) {
   const providerMetadata = run.outputMetadata?.providerMetadata || {};
   const candidates = [
@@ -190,10 +204,28 @@ function extractUsageMetadata(run) {
     ]);
     const totalTokens = usageNumberFrom(candidate, ['totalTokens', 'total_tokens']);
     if (inputTokens != null || outputTokens != null || totalTokens != null) {
+      const promptCacheHitTokens =
+        usageNumberFrom(candidate, [
+          'promptCacheHitTokens',
+          'prompt_cache_hit_tokens',
+          'cacheHitInputTokens',
+          'input_cache_hit_tokens',
+        ]) ?? usageNestedNumberFrom(candidate, ['prompt_tokens_details', 'cached_tokens']);
+      const explicitPromptCacheMissTokens = usageNumberFrom(candidate, [
+        'promptCacheMissTokens',
+        'prompt_cache_miss_tokens',
+        'cacheMissInputTokens',
+        'input_cache_miss_tokens',
+      ]);
+      const promptCacheMissTokens =
+        explicitPromptCacheMissTokens ??
+        (inputTokens != null && promptCacheHitTokens != null ? Math.max(0, inputTokens - promptCacheHitTokens) : null);
       return {
         inputTokens,
         outputTokens,
         totalTokens: totalTokens ?? (inputTokens != null && outputTokens != null ? inputTokens + outputTokens : null),
+        promptCacheHitTokens,
+        promptCacheMissTokens,
       };
     }
   }
@@ -242,7 +274,15 @@ function summarizeDistillUsage({ scope, sessionId, runs, charsPerToken = 4 }) {
     inputTokens: actualUsageRuns.reduce((total, run) => total + (run.usage.inputTokens || 0), 0),
     outputTokens: actualUsageRuns.reduce((total, run) => total + (run.usage.outputTokens || 0), 0),
     totalTokens: actualUsageRuns.reduce((total, run) => total + (run.usage.totalTokens || 0), 0),
+    promptCacheRuns: actualUsageRuns.filter(
+      (run) => run.usage.promptCacheHitTokens != null || run.usage.promptCacheMissTokens != null,
+    ).length,
+    promptCacheHitTokens: actualUsageRuns.reduce((total, run) => total + (run.usage.promptCacheHitTokens || 0), 0),
+    promptCacheMissTokens: actualUsageRuns.reduce((total, run) => total + (run.usage.promptCacheMissTokens || 0), 0),
   };
+  actualUsage.promptCacheHitRatio = actualUsage.inputTokens
+    ? actualUsage.promptCacheHitTokens / actualUsage.inputTokens
+    : null;
 
   return {
     scopeType: scope.scopeType,
@@ -1244,6 +1284,25 @@ function buildSessionStatus({ scope, sessionId, rawEvents, latestCheckpoint, pol
   };
 }
 
+function dueDistillSessionSummary(candidate, status, idleElapsedMs) {
+  return {
+    scopeType: candidate.scopeType,
+    scopeKey: candidate.scopeKey,
+    sessionId: candidate.sessionId,
+    latestCheckpointAt: candidate.latestCheckpointAt || null,
+    firstRawAfterCheckpointAt: candidate.firstRawAfterCheckpointAt || null,
+    latestRawAt: candidate.latestRawAt || null,
+    idleElapsedMs,
+    latestRunStatus: candidate.latestRunStatus || null,
+    latestRunAt: candidate.latestRunAt || null,
+    latestRunCompletedAt: candidate.latestRunCompletedAt || null,
+    eventsSinceLastCheckpoint: status.eventsSinceLastCheckpoint,
+    charsSinceLastCheckpoint: status.charsSinceLastCheckpoint,
+    distillWindow: status.distillWindow,
+    reasons: status.reasons,
+  };
+}
+
 function commonMetadataValue(rawEvents, key) {
   const values = new Set(rawEvents.map((event) => event.metadata?.[key]).filter(Boolean));
   return values.size === 1 ? [...values][0] : null;
@@ -2027,6 +2086,180 @@ export function createContextForge(options = {}) {
           policy,
         });
       });
+    },
+
+    listDueDistillSessions(options = {}) {
+      const shouldNarrowScope = Boolean(options.scope || options.scopeType || options.scopeKey || options.cwd || options.repoPath);
+      const scope = shouldNarrowScope ? normalizeScopeOptions(options, config) : null;
+      const limit = positiveNumber(options.limit == null ? 20 : Number(options.limit), 'limit');
+      const scanLimit = positiveNumber(
+        options.scanLimit == null ? Math.max(50, limit * 5) : Number(options.scanLimit),
+        'scanLimit',
+      );
+      const idleMs = nonnegativeNumber(options.idleMs == null ? 600000 : Number(options.idleMs), 'idleMs');
+      const activeRunMaxAgeMs = nonnegativeNumber(
+        options.activeRunMaxAgeMs == null ? 300000 : Number(options.activeRunMaxAgeMs),
+        'activeRunMaxAgeMs',
+      );
+      const order = options.order === 'desc' ? 'desc' : 'asc';
+
+      return useStore((store) => {
+        const effective = getEffectiveRuntime(store);
+        const policy = {
+          minEvents: positiveNumber(
+            options.minEvents == null ? effective.distillPolicy.minEvents : Number(options.minEvents),
+            'minEvents',
+          ),
+          minIntervalMs: positiveNumber(
+            options.minIntervalMs == null ? effective.distillPolicy.minIntervalMs : Number(options.minIntervalMs),
+            'minIntervalMs',
+          ),
+          charThreshold: positiveNumber(
+            options.charThreshold == null ? effective.distillPolicy.charThreshold : Number(options.charThreshold),
+            'charThreshold',
+          ),
+          charMinIntervalMs: positiveNumber(
+            options.charMinIntervalMs == null
+              ? effective.distillPolicy.charMinIntervalMs
+              : Number(options.charMinIntervalMs),
+            'charMinIntervalMs',
+          ),
+          maxEvents: positiveNumber(
+            options.maxEvents == null ? effective.distillPolicy.maxEvents : Number(options.maxEvents),
+            'maxEvents',
+          ),
+          maxChars: positiveNumber(
+            options.maxChars == null ? effective.distillPolicy.maxChars : Number(options.maxChars),
+            'maxChars',
+          ),
+        };
+        const now = new Date();
+        const candidates = store.listSessionsWithRawAfterCheckpoint({
+          scopeType: scope?.scopeType || null,
+          scopeKey: scope?.scopeKey || null,
+          limit: scanLimit,
+          order,
+          minEvents: policy.minEvents,
+          charThreshold: policy.charThreshold,
+        });
+        const due = [];
+        const skipped = [];
+        for (const candidate of candidates) {
+          const latestRawTime = Date.parse(candidate.latestRawAt || '');
+          const idleElapsedMs = Number.isFinite(latestRawTime) ? Math.max(0, now.getTime() - latestRawTime) : null;
+          if (idleElapsedMs != null && idleElapsedMs < idleMs) {
+            skipped.push({ ...candidate, reason: 'idle_window' });
+            continue;
+          }
+          const latestRunTime = Date.parse(candidate.latestRunAt || '');
+          if (
+            candidate.latestRunStatus === 'started' &&
+            Number.isFinite(latestRunTime) &&
+            now.getTime() - latestRunTime < activeRunMaxAgeMs
+          ) {
+            skipped.push({ ...candidate, reason: 'active_started_run' });
+            continue;
+          }
+          const candidateScope = { scopeType: candidate.scopeType, scopeKey: candidate.scopeKey };
+          const rawEvents = store.listRawEvents({ ...candidateScope, sessionId: candidate.sessionId });
+          const latestCheckpoint = store.getLatestCheckpoint({
+            ...candidateScope,
+            sessionId: candidate.sessionId,
+            level: 0,
+          });
+          const status = buildSessionStatus({
+            scope: candidateScope,
+            sessionId: candidate.sessionId,
+            rawEvents,
+            latestCheckpoint,
+            policy,
+            now,
+          });
+          if (!status.shouldDistill) {
+            skipped.push({ ...candidate, reason: 'below_threshold' });
+            continue;
+          }
+          due.push(dueDistillSessionSummary(candidate, status, idleElapsedMs));
+          if (due.length >= limit) {
+            break;
+          }
+        }
+        return {
+          scope: scope ? { scopeType: scope.scopeType, scopeKey: scope.scopeKey } : null,
+          limit,
+          scanLimit,
+          idleMs,
+          activeRunMaxAgeMs,
+          order,
+          scanned: candidates.length,
+          dueCount: due.length,
+          skippedCount: skipped.length,
+          skipReasonCounts: skipped.reduce((counts, item) => {
+            counts[item.reason] = (counts[item.reason] || 0) + 1;
+            return counts;
+          }, {}),
+          sessions: due,
+        };
+      });
+    },
+
+    async processDueDistills(options = {}) {
+      const limit = positiveNumber(options.limit == null ? 5 : Number(options.limit), 'limit');
+      const dryRun = options.dryRun === true || options.dryRun === 'true';
+      const due = await this.listDueDistillSessions({
+        ...options,
+        limit,
+      });
+      const result = {
+        dryRun,
+        limit,
+        scanLimit: due.scanLimit,
+        idleMs: due.idleMs,
+        activeRunMaxAgeMs: due.activeRunMaxAgeMs,
+        scanned: due.scanned,
+        dueCount: due.dueCount,
+        skippedCount: due.skippedCount,
+        skipReasonCounts: due.skipReasonCounts,
+        processed: 0,
+        failed: 0,
+        sessions: due.sessions,
+        results: [],
+      };
+      if (dryRun) {
+        return result;
+      }
+      for (const session of due.sessions) {
+        try {
+          const checkpoint = await this.distillCheckpoint({
+            scope: session.scopeType,
+            scopeKey: session.scopeKey,
+            sessionId: session.sessionId,
+            provider: options.provider,
+            maxEvents: options.maxEvents,
+            maxChars: options.maxChars,
+          });
+          result.processed += 1;
+          result.results.push({
+            scopeType: session.scopeType,
+            scopeKey: session.scopeKey,
+            sessionId: session.sessionId,
+            status: 'succeeded',
+            checkpointId: checkpoint.id,
+            sourceEventCount: checkpoint.sourceEventCount,
+            createdAt: checkpoint.createdAt,
+          });
+        } catch (error) {
+          result.failed += 1;
+          result.results.push({
+            scopeType: session.scopeType,
+            scopeKey: session.scopeKey,
+            sessionId: session.sessionId,
+            status: 'failed',
+            error: errorSummary(error),
+          });
+        }
+      }
+      return result;
     },
 
     remember(options) {

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -184,6 +184,66 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
   );
 
   server.registerTool(
+    'list_due_distill_sessions',
+    {
+      title: 'List Due Distill Sessions',
+      description:
+        'Scan for sessions with raw evidence after the latest checkpoint coverage that are due for distillation. This is read-only and bounded by limit/scanLimit; idleMs avoids active sessions.',
+      inputSchema: {
+        ...scopedSchema,
+        limit: z.number().int().positive().optional(),
+        scanLimit: z.number().int().positive().optional(),
+        idleMs: z.number().int().nonnegative().optional(),
+        activeRunMaxAgeMs: z.number().int().nonnegative().optional(),
+        order: z.enum(['asc', 'desc']).optional(),
+        minEvents: z.number().int().positive().optional(),
+        minIntervalMs: z.number().int().positive().optional(),
+        charMinIntervalMs: z.number().int().positive().optional(),
+        charThreshold: z.number().int().positive().optional(),
+        maxEvents: z.number().int().positive().optional(),
+        maxChars: z.number().int().positive().optional(),
+      },
+      annotations: {
+        title: 'List Due Distill Sessions',
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.listDueDistillSessions(args)),
+  );
+
+  server.registerTool(
+    'process_due_distills',
+    {
+      title: 'Process Due Distills',
+      description:
+        'Run a small catch-up batch of due session distillations. Use dryRun=true to inspect first; limit defaults to 5 and idleMs avoids active sessions.',
+      inputSchema: {
+        ...scopedSchema,
+        limit: z.number().int().positive().optional(),
+        scanLimit: z.number().int().positive().optional(),
+        idleMs: z.number().int().nonnegative().optional(),
+        activeRunMaxAgeMs: z.number().int().nonnegative().optional(),
+        order: z.enum(['asc', 'desc']).optional(),
+        provider: z.string().optional(),
+        dryRun: z.boolean().optional(),
+        minEvents: z.number().int().positive().optional(),
+        minIntervalMs: z.number().int().positive().optional(),
+        charMinIntervalMs: z.number().int().positive().optional(),
+        charThreshold: z.number().int().positive().optional(),
+        maxEvents: z.number().int().positive().optional(),
+        maxChars: z.number().int().positive().optional(),
+      },
+      annotations: {
+        title: 'Process Due Distills',
+        readOnlyHint: false,
+        idempotentHint: false,
+      },
+    },
+    async (args) => jsonResult(await app.processDueDistills(args)),
+  );
+
+  server.registerTool(
     'search',
     {
       title: 'Search Memory',

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -11,6 +11,8 @@ const REMOTE_METHODS = [
   'checkCodexExec',
   'beginSession',
   'sessionStatus',
+  'listDueDistillSessions',
+  'processDueDistills',
   'remember',
   'promoteMemory',
   'promoteMemoryCandidate',
@@ -57,10 +59,16 @@ const UNSCOPED_REMOTE_METHODS = new Set([
   'pruneRawEvents',
 ]);
 
+const OPTIONALLY_SCOPED_REMOTE_METHODS = new Set(['listDueDistillSessions', 'processDueDistills']);
+
 function remoteUrl(baseUrl, method) {
   const url = new URL(baseUrl);
   url.pathname = `${url.pathname.replace(/\/$/, '')}/v0/${method}`;
   return url;
+}
+
+function hasScopeHints(options = {}) {
+  return Boolean(options.scope || options.scopeType || options.scopeKey || options.cwd || options.repoPath);
 }
 
 function makeRemoteError(method, status, body) {
@@ -207,6 +215,9 @@ export function createRemoteContextForge(config, options = {}) {
       continue;
     }
     api[method] = (callOptions = {}) => {
+      if (OPTIONALLY_SCOPED_REMOTE_METHODS.has(method) && !hasScopeHints(callOptions)) {
+        return client.call(method, callOptions);
+      }
       if (UNSCOPED_REMOTE_METHODS.has(method)) {
         return client.call(method, callOptions);
       }

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -2859,6 +2859,152 @@ export class ContextForgeStore {
       .map(hydrateDistillRun);
   }
 
+  listSessionsWithRawAfterCheckpoint({
+    scopeType = null,
+    scopeKey = null,
+    limit = 100,
+    order = 'asc',
+    minEvents = null,
+    charThreshold = null,
+  } = {}) {
+    const filters = [];
+    const values = [];
+    if (scopeType) {
+      filters.push('r.scope_type = ?');
+      values.push(scopeType);
+    }
+    if (scopeKey) {
+      filters.push('r.scope_key = ?');
+      values.push(scopeKey);
+    }
+    const where = filters.length ? `AND ${filters.join(' AND ')}` : '';
+    const havingFilters = [];
+    const havingValues = [];
+    const parsedMinEvents = minEvents == null ? null : Number(minEvents);
+    if (Number.isInteger(parsedMinEvents) && parsedMinEvents > 0) {
+      havingFilters.push('COUNT(*) >= ?');
+      havingValues.push(parsedMinEvents);
+    }
+    const parsedCharThreshold = charThreshold == null ? null : Number(charThreshold);
+    if (Number.isFinite(parsedCharThreshold) && parsedCharThreshold > 0) {
+      havingFilters.push('SUM(LENGTH(r.content)) >= ?');
+      havingValues.push(parsedCharThreshold);
+    }
+    const havingClause = havingFilters.length ? `HAVING (${havingFilters.join(' OR ')})` : '';
+    const parsedLimit = limit == null ? null : Number(limit);
+    const limitClause = Number.isInteger(parsedLimit) && parsedLimit > 0 ? 'LIMIT ?' : '';
+    const queryValues = [...values, ...havingValues];
+    if (limitClause) queryValues.push(parsedLimit);
+    const orderDirection = order === 'desc' ? 'DESC' : 'ASC';
+    return this.db
+      .prepare(`
+        WITH latest_checkpoint_key AS (
+          SELECT scope_type, scope_key, session_id, MAX(created_at) AS latest_checkpoint_at
+          FROM checkpoints
+          WHERE level = 0
+          GROUP BY scope_type, scope_key, session_id
+        ),
+        latest_checkpoint AS (
+          SELECT
+            c.scope_type,
+            c.scope_key,
+            c.session_id,
+            c.created_at AS latest_checkpoint_at,
+            json_extract(c.metadata_json, '$.sourceRawEventIds[#-1]') AS last_source_raw_event_id
+          FROM checkpoints c
+          INNER JOIN latest_checkpoint_key k
+            ON k.scope_type = c.scope_type
+           AND k.scope_key = c.scope_key
+           AND k.session_id = c.session_id
+           AND k.latest_checkpoint_at = c.created_at
+          WHERE c.level = 0
+        ),
+        last_source_raw_event AS (
+          SELECT r.scope_type, r.scope_key, r.session_id, r.id, r.created_at
+          FROM raw_events r
+          INNER JOIN latest_checkpoint c
+            ON c.scope_type = r.scope_type
+           AND c.scope_key = r.scope_key
+           AND c.session_id = r.session_id
+           AND c.last_source_raw_event_id = r.id
+        ),
+        latest_run_key AS (
+          SELECT scope_type, scope_key, session_id, MAX(created_at) AS latest_run_at
+          FROM distill_runs
+          GROUP BY scope_type, scope_key, session_id
+        ),
+        latest_run AS (
+          SELECT d.scope_type, d.scope_key, d.session_id, d.status, d.created_at, d.completed_at
+          FROM distill_runs d
+          INNER JOIN latest_run_key k
+            ON k.scope_type = d.scope_type
+           AND k.scope_key = d.scope_key
+           AND k.session_id = d.session_id
+           AND k.latest_run_at = d.created_at
+        )
+        SELECT
+          r.scope_type,
+          r.scope_key,
+          r.session_id,
+          COUNT(*) AS events_since_checkpoint,
+          SUM(LENGTH(r.content)) AS chars_since_checkpoint,
+          MIN(r.created_at) AS first_raw_after_checkpoint_at,
+          MAX(r.created_at) AS latest_raw_at,
+          c.latest_checkpoint_at,
+          latest_run.status AS latest_run_status,
+          latest_run.created_at AS latest_run_at,
+          latest_run.completed_at AS latest_run_completed_at
+        FROM raw_events r
+        LEFT JOIN latest_checkpoint c
+          ON c.scope_type = r.scope_type
+         AND c.scope_key = r.scope_key
+         AND c.session_id = r.session_id
+        LEFT JOIN last_source_raw_event last_source
+          ON last_source.scope_type = r.scope_type
+         AND last_source.scope_key = r.scope_key
+         AND last_source.session_id = r.session_id
+        LEFT JOIN latest_run
+          ON latest_run.scope_type = r.scope_type
+         AND latest_run.scope_key = r.scope_key
+         AND latest_run.session_id = r.session_id
+        WHERE r.role IN ('user', 'assistant')
+          AND (
+            c.latest_checkpoint_at IS NULL
+            OR (
+              c.last_source_raw_event_id IS NOT NULL
+              AND last_source.id IS NOT NULL
+              AND (
+                r.created_at > last_source.created_at
+                OR (r.created_at = last_source.created_at AND r.id > last_source.id)
+              )
+            )
+            OR (
+              (c.last_source_raw_event_id IS NULL OR last_source.id IS NULL)
+              AND r.created_at > c.latest_checkpoint_at
+            )
+        )
+        ${where}
+        GROUP BY r.scope_type, r.scope_key, r.session_id
+        ${havingClause}
+        ORDER BY latest_raw_at ${orderDirection}, r.scope_type ${orderDirection}, r.scope_key ${orderDirection}, r.session_id ${orderDirection}
+        ${limitClause}
+      `)
+      .all(...queryValues)
+      .map((row) => ({
+        scopeType: row.scope_type,
+        scopeKey: row.scope_key,
+        sessionId: row.session_id,
+        eventsSinceCheckpoint: Number(row.events_since_checkpoint || 0),
+        charsSinceCheckpoint: Number(row.chars_since_checkpoint || 0),
+        firstRawAfterCheckpointAt: row.first_raw_after_checkpoint_at,
+        latestRawAt: row.latest_raw_at,
+        latestCheckpointAt: row.latest_checkpoint_at,
+        latestRunStatus: row.latest_run_status || null,
+        latestRunAt: row.latest_run_at || null,
+        latestRunCompletedAt: row.latest_run_completed_at || null,
+      }));
+  }
+
   listScopeKeys({ scopeType = null, limit = null } = {}) {
     const filters = [];
     const values = [];

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -28,7 +28,7 @@ async function makeTempDir() {
 }
 
 async function makeNonGitTempDir() {
-  return fs.mkdtemp(path.join(os.homedir(), 'contextforge-test-'));
+  return makeTempDir();
 }
 
 function testAdminPasswordHash(password) {
@@ -3775,6 +3775,166 @@ test('sessionStatus continues after the last raw event covered by a checkpoint',
   assert.equal(status.distillWindow.firstRawEventId !== checkpoint.metadata.sourceRawEventIds[0], true);
 });
 
+test('listDueDistillSessions finds raw evidence after checkpoint coverage', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'mock',
+    },
+    cwd: process.cwd(),
+  });
+  const scope = {
+    scope: 'repo',
+    scopeKey: 'repo-catch-up',
+    sessionId: 'catch-up-session',
+  };
+
+  app.appendRaw({
+    ...scope,
+    role: 'user',
+    content: 'covered raw event',
+  });
+  const coveredRaw = app.listRawEvents(scope)[0];
+  const db = new Database(path.join(dataDir, 'contextforge.db'));
+  try {
+    db.prepare('UPDATE raw_events SET created_at = ? WHERE id = ?').run(
+      '2026-01-01T00:00:00.000Z',
+      coveredRaw.id,
+    );
+  } finally {
+    db.close();
+  }
+
+  const checkpoint = await app.distillCheckpoint(scope);
+  app.appendRaw({
+    ...scope,
+    role: 'assistant',
+    content: 'tail raw appended after the checkpoint run',
+  });
+  const tailRaw = app.listRawEvents(scope).find((event) => event.content.includes('tail raw appended'));
+  const dbAfterTail = new Database(path.join(dataDir, 'contextforge.db'));
+  try {
+    dbAfterTail.prepare('UPDATE raw_events SET created_at = ? WHERE id = ?').run(
+      '2026-01-01T00:01:00.000Z',
+      tailRaw.id,
+    );
+    dbAfterTail.prepare('UPDATE checkpoints SET created_at = ? WHERE id = ?').run(
+      '2026-01-01T00:02:00.000Z',
+      checkpoint.id,
+    );
+  } finally {
+    dbAfterTail.close();
+  }
+
+  const due = app.listDueDistillSessions({
+    scope: 'repo',
+    scopeKey: 'repo-catch-up',
+    limit: 5,
+    minEvents: 1,
+    minIntervalMs: 1,
+    charThreshold: 1,
+    charMinIntervalMs: 1,
+  });
+
+  assert.equal(due.dueCount, 1);
+  assert.equal(due.skippedCount, 0);
+  assert.deepEqual(due.skipReasonCounts, {});
+  assert.equal(due.sessions[0].sessionId, 'catch-up-session');
+  assert.equal(due.sessions[0].eventsSinceLastCheckpoint, 1);
+  assert.equal(due.sessions[0].charsSinceLastCheckpoint, tailRaw.content.length);
+  assert.equal(due.sessions[0].latestCheckpointAt, '2026-01-01T00:02:00.000Z');
+
+  const dryRun = await app.processDueDistills({
+    scope: 'repo',
+    scopeKey: 'repo-catch-up',
+    limit: 1,
+    dryRun: true,
+    minEvents: 1,
+    minIntervalMs: 1,
+    charThreshold: 1,
+    charMinIntervalMs: 1,
+  });
+  assert.equal(dryRun.dryRun, true);
+  assert.equal(dryRun.processed, 0);
+  assert.equal(dryRun.dueCount, 1);
+
+  const processed = await app.processDueDistills({
+    scope: 'repo',
+    scopeKey: 'repo-catch-up',
+    limit: 1,
+    minEvents: 1,
+    minIntervalMs: 1,
+    charThreshold: 1,
+    charMinIntervalMs: 1,
+  });
+  assert.equal(processed.processed, 1);
+  assert.equal(processed.failed, 0);
+  assert.equal(processed.results[0].status, 'succeeded');
+  assert.equal(processed.results[0].sourceEventCount, 1);
+
+  const after = app.listDueDistillSessions({
+    scope: 'repo',
+    scopeKey: 'repo-catch-up',
+    limit: 5,
+    minEvents: 1,
+    minIntervalMs: 1,
+    charThreshold: 1,
+    charMinIntervalMs: 1,
+    idleMs: 0,
+  });
+  assert.equal(after.dueCount, 0);
+});
+
+test('listDueDistillSessions skips sessions inside the idle window', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'mock',
+    },
+    cwd: process.cwd(),
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-idle-catch-up',
+    sessionId: 'idle-session',
+    role: 'user',
+    content: 'fresh raw event that should wait for the idle window',
+  });
+
+  const due = app.listDueDistillSessions({
+    scope: 'repo',
+    scopeKey: 'repo-idle-catch-up',
+    limit: 5,
+    minEvents: 1,
+    charThreshold: 1,
+    idleMs: 600000,
+  });
+  assert.equal(due.dueCount, 0);
+  assert.equal(due.skippedCount, 1);
+  assert.deepEqual(due.skipReasonCounts, { idle_window: 1 });
+});
+
+test('CLI due distill commands preserve core default limits', async () => {
+  const dataDir = await makeTempDir();
+  const env = {
+    ...process.env,
+    CONTEXTFORGE_DATA_DIR: dataDir,
+  };
+
+  const listed = await execFileAsync('node', ['src/cli.js', 'listDueDistillSessions'], { env });
+  assert.equal(JSON.parse(listed.stdout).limit, 20);
+
+  const dryRun = await execFileAsync('node', ['src/cli.js', 'processDueDistills', '--dryRun', 'true'], { env });
+  assert.equal(JSON.parse(dryRun.stdout).limit, 5);
+
+  const explicit = await execFileAsync('node', ['src/cli.js', 'processDueDistills', '--dryRun', 'true', '--limit', '2'], {
+    env,
+  });
+  assert.equal(JSON.parse(explicit.stdout).limit, 2);
+});
+
 test('distillCheckpoint drains bounded conversation windows oldest first', async () => {
   const dataDir = await makeTempDir();
   const seen = [];
@@ -3935,6 +4095,8 @@ test('distillUsage summarizes estimated and actual provider usage', async () => 
             inputTokens: 42,
             outputTokens: 8,
             totalTokens: 50,
+            prompt_cache_hit_tokens: 10,
+            prompt_cache_miss_tokens: 32,
           },
         },
       }),
@@ -3970,8 +4132,13 @@ test('distillUsage summarizes estimated and actual provider usage', async () => 
     inputTokens: 42,
     outputTokens: 8,
     totalTokens: 50,
+    promptCacheRuns: 1,
+    promptCacheHitTokens: 10,
+    promptCacheMissTokens: 32,
+    promptCacheHitRatio: 10 / 42,
   });
   assert.equal(usage.runs[0].usage.totalTokens, 50);
+  assert.equal(usage.runs[0].usage.promptCacheHitTokens, 10);
 });
 
 test('distillUsage averages elapsed time across completed runs only', async () => {
@@ -6393,6 +6560,8 @@ test('REMOTE_METHODS exposes resume, suggestion, auto-promotion, and reconciliat
   assert.ok(REMOTE_METHODS.includes('checkDistillProvider'));
   assert.ok(REMOTE_METHODS.includes('listScopeKeys'));
   assert.ok(REMOTE_METHODS.includes('listRecentDistillRuns'));
+  assert.ok(REMOTE_METHODS.includes('listDueDistillSessions'));
+  assert.ok(REMOTE_METHODS.includes('processDueDistills'));
   assert.ok(REMOTE_METHODS.includes('listMemories'));
   assert.ok(REMOTE_METHODS.includes('suggestMemoryPromotions'));
   assert.ok(REMOTE_METHODS.includes('autoPromoteMemoryCandidates'));
@@ -6570,11 +6739,13 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'get_session_working_context',
       'get_working_summary',
       'list_checkpoints',
+      'list_due_distill_sessions',
       'list_embedding_jobs',
       'list_memory_candidates',
       'list_memory_events',
       'list_memory_update_candidates',
       'list_preference_occurrences',
+      'process_due_distills',
       'process_embedding_jobs',
       'promote_memory',
       'promote_memory_candidate',
@@ -6598,6 +6769,14 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     assert.ok(sessionStatusTool.inputSchema.properties.maxEvents);
     assert.ok(sessionStatusTool.inputSchema.properties.maxChars);
     assert.ok(sessionStatusTool.description.includes('latestCheckpointMemoryCandidateCount'));
+    const listDueDistillsTool = toolList.tools.find((tool) => tool.name === 'list_due_distill_sessions');
+    assert.ok(listDueDistillsTool.inputSchema.properties.scanLimit);
+    assert.ok(listDueDistillsTool.inputSchema.properties.idleMs);
+    assert.ok(listDueDistillsTool.description.includes('idleMs'));
+    const processDueDistillsTool = toolList.tools.find((tool) => tool.name === 'process_due_distills');
+    assert.ok(processDueDistillsTool.inputSchema.properties.dryRun);
+    assert.ok(processDueDistillsTool.inputSchema.properties.limit);
+    assert.ok(processDueDistillsTool.description.includes('catch-up batch'));
     const distillTool = toolList.tools.find((tool) => tool.name === 'distill_checkpoint');
     assert.ok(distillTool.inputSchema.properties.maxEvents);
     assert.ok(distillTool.inputSchema.properties.maxChars);
@@ -7319,7 +7498,7 @@ test('remote storage mode resolves repoPath before sending scoped calls', async 
 test('remote storage mode strips local path hints after resolving scope', async () => {
   const appCwd = await makeTempDir();
   const repoPath = await makeGitRepo('https://github.com/example/remote-strip-repo.git');
-  let postedBody = null;
+  const postedBodies = [];
   const app = createContextForge({
     env: {
       CONTEXTFORGE_STORAGE_MODE: 'remote',
@@ -7327,8 +7506,9 @@ test('remote storage mode strips local path hints after resolving scope', async 
       CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
     },
     cwd: appCwd,
-    fetchImpl: async (_url, request) => {
-      postedBody = JSON.parse(request.body);
+    fetchImpl: async (url, request) => {
+      const postedBody = JSON.parse(request.body);
+      postedBodies.push({ method: new URL(url).pathname.split('/').at(-1), body: postedBody });
       return {
         ok: true,
         text: async () =>
@@ -7352,9 +7532,26 @@ test('remote storage mode strips local path hints after resolving scope', async 
   });
 
   assert.equal(memory.scopeKey, 'github.com/example/remote-strip-repo');
-  assert.equal(postedBody.scopeKey, 'github.com/example/remote-strip-repo');
-  assert.equal(postedBody.repoPath, undefined);
-  assert.equal(postedBody.cwd, undefined);
+  assert.equal(postedBodies[0].body.scopeKey, 'github.com/example/remote-strip-repo');
+  assert.equal(postedBodies[0].body.repoPath, undefined);
+  assert.equal(postedBodies[0].body.cwd, undefined);
+
+  await app.listDueDistillSessions({
+    scope: 'repo',
+    repoPath,
+    cwd: appCwd,
+    limit: 1,
+  });
+  assert.equal(postedBodies[1].method, 'listDueDistillSessions');
+  assert.equal(postedBodies[1].body.scopeKey, 'github.com/example/remote-strip-repo');
+  assert.equal(postedBodies[1].body.repoPath, undefined);
+  assert.equal(postedBodies[1].body.cwd, undefined);
+
+  await app.listDueDistillSessions({ limit: 2 });
+  assert.equal(postedBodies[2].method, 'listDueDistillSessions');
+  assert.equal(postedBodies[2].body.scopeKey, undefined);
+  assert.equal(postedBodies[2].body.scope, undefined);
+  assert.equal(postedBodies[2].body.limit, 2);
 });
 
 test('remote storage mode preserves structured error names and warnings', async () => {


### PR DESCRIPTION
## Summary
- add bounded distillation catch-up scanning and processing across core, CLI, remote API, and MCP
- continue from checkpoint `sourceRawEventIds`, respect normal distillation thresholds, and protect active sessions with idle/run guards
- expose prompt cache hit/miss observability in `distillUsage`
- bump package version to `0.4.2` and update README/CHANGELOG

## Validation
- `npm test` (125 pass)
- `git diff --check`
- local CLI smoke: `listDueDistillSessions` default limit 20 and `processDueDistills --dryRun true` default limit 5

## Operational Notes
- `processDueDistills` defaults to small sequential batches to avoid surprising provider usage
- remote clients can call the due commands globally, or scoped when `scope`/`scopeKey`/`repoPath` is provided