### PR TITLE
Add Codex Python SDK audit provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,27 @@ uses a separate audit runner before the durable memory write. The default audit
 runner is `codex_exec` with `gpt-5.5` and reasoning effort `low`, independent
 from the distillation runner.
 
+For Python-backed services, the audit gate can also use the experimental
+`codex_sdk_python` provider. It calls the Codex Python SDK from a small Python
+runner and points that SDK at an existing Codex binary:
+
+```bash
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER=codex_sdk_python
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_BIN=/home/ubuntu/.local/bin/codex
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHON_COMMAND=python3
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHONPATH=/opt/contextforge/openai-codex-sdk
+```
+
+If the SDK's pinned `openai-codex-cli-bin` wheel is not available for the
+server platform, install only the Python SDK package and its pure Python
+dependency into the configured `PYTHONPATH`, then rely on
+`CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_BIN` for the runtime binary:
+
+```bash
+uv pip install --target /opt/contextforge/openai-codex-sdk --no-deps openai-codex
+uv pip install --target /opt/contextforge/openai-codex-sdk 'pydantic>=2.12'
+```
+
 Use a long random token and store the same value on client machines as
 `CONTEXTFORGE_REMOTE_TOKEN`. Treat this token as an administrator credential:
 it can call every remote API method, including pruning raw evidence and running

--- a/README.md
+++ b/README.md
@@ -317,6 +317,12 @@ uses a separate audit runner before the durable memory write. The default audit
 runner is `codex_exec` with `gpt-5.5` and reasoning effort `low`, independent
 from the distillation runner.
 
+For agent closeout review without writes, use `audit_memory_candidates`. It uses
+the same closeout-scoped safety policy and configured audit provider, returns
+audited `promote`/`review` recommendations, and never promotes durable memory or
+changes candidate status. Keep `auto_promote_memory_candidates dryRun=false` for
+the separate explicit automation path.
+
 For Python-backed services, the audit gate can also use the experimental
 `codex_sdk_python` provider. It calls the Codex Python SDK from a small Python
 runner and points that SDK at an existing Codex binary:
@@ -1249,6 +1255,7 @@ The MCP server exposes a narrow tool surface over the same core API:
 - `list_due_distill_sessions`
 - `process_due_distills`
 - `suggest_memory_promotions`
+- `audit_memory_candidates`
 - `auto_promote_memory_candidates`
 - `reconcile_memory`
 - `promote_memory`

--- a/examples/server.env.example
+++ b/examples/server.env.example
@@ -61,3 +61,11 @@ CONTEXTFORGE_AUTO_PROMOTE_AUDIT_ENABLED=true
 CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER=codex_exec
 CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_MODEL=gpt-5.5
 CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_REASONING_EFFORT=low
+
+# Experimental alternative: run the audit gate through the Codex Python SDK
+# while using an existing local Codex binary instead of the SDK's pinned
+# runtime wheel.
+# CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER=codex_sdk_python
+# CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_BIN=/home/ubuntu/.local/bin/codex
+# CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHON_COMMAND=python3
+# CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHONPATH=/opt/contextforge/openai-codex-sdk

--- a/src/admin-ui/app.js
+++ b/src/admin-ui/app.js
@@ -172,6 +172,9 @@ function fillSettingsForm() {
   form.auditEnabled.checked = effective.autoPromoteAudit.enabled !== false;
   form.auditProvider.value = effective.autoPromoteAudit.provider || 'codex_exec';
   form.auditCommand.value = effective.autoPromoteAudit.command || 'codex';
+  form.auditCodexBin.value = effective.autoPromoteAudit.codexBin || effective.autoPromoteAudit.command || 'codex';
+  form.auditPythonCommand.value = effective.autoPromoteAudit.pythonCommand || 'python3';
+  form.auditPythonPath.value = effective.autoPromoteAudit.pythonPath || '';
   form.auditModel.value = effective.autoPromoteAudit.model || 'gpt-5.5';
   form.auditReasoningEffort.value = effective.autoPromoteAudit.reasoningEffort || 'low';
   form.auditTimeoutMs.value = effective.autoPromoteAudit.timeoutMs || 120000;
@@ -253,6 +256,9 @@ $('#settingsForm').addEventListener('submit', async (event) => {
       enabled: form.auditEnabled.checked,
       provider: form.auditProvider.value,
       command: form.auditCommand.value,
+      codexBin: form.auditCodexBin.value || form.auditCommand.value,
+      pythonCommand: form.auditPythonCommand.value || 'python3',
+      pythonPath: form.auditPythonPath.value || null,
       model: form.auditModel.value || 'gpt-5.5',
       reasoningEffort: form.auditReasoningEffort.value || 'low',
       timeoutMs: formNumber(form, 'auditTimeoutMs') || 120000,

--- a/src/admin-ui/index.html
+++ b/src/admin-ui/index.html
@@ -131,14 +131,20 @@
               <label>감사 프로바이더
                 <select name="auditProvider">
                   <option value="codex_exec">codex_exec</option>
+                  <option value="codex_sdk_python">codex_sdk_python</option>
                 </select>
               </label>
             </div>
             <div class="row">
               <label>감사 Codex 명령 <input name="auditCommand" /></label>
+              <label>감사 Codex 바이너리 <input name="auditCodexBin" placeholder="/home/ubuntu/.local/bin/codex" /></label>
               <label>감사 모델 <input name="auditModel" list="codexModelPresets" placeholder="gpt-5.5" /></label>
               <label>감사 추론 강도 <input name="auditReasoningEffort" placeholder="low" /></label>
               <label>감사 제한 시간(ms) <input name="auditTimeoutMs" type="number" min="1" /></label>
+            </div>
+            <div class="row">
+              <label>Python 명령 <input name="auditPythonCommand" placeholder="python3" /></label>
+              <label>Python 경로 <input name="auditPythonPath" placeholder="/path/to/openai-codex-sdk" /></label>
             </div>
           </fieldset>
           <fieldset>

--- a/src/audit/codex_exec.js
+++ b/src/audit/codex_exec.js
@@ -6,7 +6,7 @@ import { parseCodexExecJson, runCodexExecCommand } from '../distill/providers/co
 export const AUTO_PROMOTE_AUDIT_PROMPT_VERSION = 'auto_promote_audit.codex_exec.v1';
 export const AUTO_PROMOTE_AUDIT_SCHEMA_VERSION = 'contextforge.auto_promote_audit.v1';
 
-const AUDIT_OUTPUT_SCHEMA = {
+export const AUDIT_OUTPUT_SCHEMA = {
   $id: AUTO_PROMOTE_AUDIT_SCHEMA_VERSION,
   type: 'object',
   additionalProperties: false,
@@ -36,7 +36,7 @@ function truncate(value, maxChars = 2000) {
   return text.length > maxChars ? `${text.slice(0, maxChars)}\n[truncated]` : text;
 }
 
-function buildAuditPrompt(input, metadata) {
+export function buildAuditPrompt(input, metadata) {
   const candidate = input.candidate?.candidate || {};
   const payload = {
     task: 'Audit whether one ContextForge memory candidate is safe for automatic durable-memory promotion.',

--- a/src/audit/codex_sdk_python.js
+++ b/src/audit/codex_sdk_python.js
@@ -1,0 +1,178 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseCodexExecJson } from '../distill/providers/codex_exec.js';
+import {
+  AUDIT_OUTPUT_SCHEMA,
+  AUTO_PROMOTE_AUDIT_SCHEMA_VERSION,
+  buildAuditPrompt,
+} from './codex_exec.js';
+
+export const AUTO_PROMOTE_AUDIT_PYTHON_SDK_PROMPT_VERSION = 'auto_promote_audit.codex_sdk_python.v1';
+
+const RUNNER_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), 'codex_sdk_python_runner.py');
+const REASONING_EFFORTS = new Set(['minimal', 'low', 'medium', 'high']);
+const SANDBOX_PRESETS = new Set(['read-only', 'workspace-write', 'full-access']);
+const KILL_GRACE_MS = 5000;
+
+function validateReasoningEffort(reasoningEffort) {
+  if (!reasoningEffort) return;
+  if (!REASONING_EFFORTS.has(reasoningEffort)) {
+    throw new Error(
+      `Invalid auto-promote audit reasoning effort "${reasoningEffort}". Expected one of: minimal, low, medium, high.`,
+    );
+  }
+}
+
+function validateSandbox(sandbox) {
+  if (!SANDBOX_PRESETS.has(sandbox)) {
+    throw new Error(
+      `Invalid Codex Python SDK audit sandbox "${sandbox}". Expected one of: read-only, workspace-write, full-access.`,
+    );
+  }
+}
+
+export function runCodexSdkPythonCommand({
+  pythonCommand,
+  pythonPath,
+  scriptPath,
+  codexBin,
+  model,
+  reasoningEffort,
+  sandbox,
+  prompt,
+  timeoutMs,
+  cwd,
+  env = process.env,
+}) {
+  return new Promise((resolve, reject) => {
+    const args = [
+      scriptPath || RUNNER_PATH,
+      '--codex-bin',
+      codexBin,
+      '--model',
+      model,
+      '--sandbox',
+      sandbox,
+      '--cwd',
+      cwd,
+    ];
+    if (reasoningEffort) {
+      args.push('--reasoning-effort', reasoningEffort);
+    }
+    const childEnv = { ...env };
+    if (pythonPath) {
+      childEnv.PYTHONPATH = childEnv.PYTHONPATH ? `${pythonPath}${path.delimiter}${childEnv.PYTHONPATH}` : pythonPath;
+    }
+
+    const child = spawn(pythonCommand, args, {
+      cwd,
+      env: childEnv,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill('SIGTERM');
+      setTimeout(() => {
+        if (child.exitCode == null) {
+          child.kill('SIGKILL');
+        }
+      }, KILL_GRACE_MS).unref();
+      reject(new Error(`Codex Python SDK audit timed out after ${timeoutMs}ms.`));
+    }, timeoutMs);
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (code !== 0) {
+        reject(new Error(`Codex Python SDK audit failed with exit code ${code}: ${stderr || stdout}`));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+
+    child.stdin.end(`${JSON.stringify({ prompt, requestedOutputSchema: AUDIT_OUTPUT_SCHEMA })}\n`);
+  });
+}
+
+export function createCodexSdkPythonAutoPromoteAuditor(options = {}) {
+  const runner = options.runner || runCodexSdkPythonCommand;
+  const pythonCommand = options.pythonCommand || 'python3';
+  const pythonPath = options.pythonPath || null;
+  const scriptPath = options.scriptPath || RUNNER_PATH;
+  const codexBin = options.codexBin || options.command || 'codex';
+  const model = options.model || 'gpt-5.5';
+  const reasoningEffort = options.reasoningEffort || 'low';
+  const sandbox = options.sandbox || 'read-only';
+  const cwd = options.cwd || process.cwd();
+  const timeoutMs = options.timeoutMs || 120000;
+
+  validateReasoningEffort(reasoningEffort);
+  validateSandbox(sandbox);
+
+  const metadata = {
+    provider: 'codex_sdk_python',
+    promptVersion: AUTO_PROMOTE_AUDIT_PYTHON_SDK_PROMPT_VERSION,
+    outputSchemaVersion: AUTO_PROMOTE_AUDIT_SCHEMA_VERSION,
+    pythonCommand,
+    pythonPath,
+    scriptPath,
+    codexBin,
+    model,
+    reasoningEffort,
+    sandbox,
+    timeoutMs,
+  };
+
+  async function audit(input) {
+    const startedAt = Date.now();
+    const result = await runner({
+      pythonCommand,
+      pythonPath,
+      scriptPath,
+      codexBin,
+      model,
+      reasoningEffort,
+      sandbox,
+      prompt: buildAuditPrompt(input, metadata),
+      timeoutMs,
+      cwd,
+      env: process.env,
+    });
+    const runnerOutput = parseCodexExecJson(result.stdout || '');
+    const output = parseCodexExecJson(runnerOutput.final_response || result.stdout || '');
+    const approved = output.approved === true && output.decision === 'approve';
+    return {
+      approved,
+      decision: output.decision || (approved ? 'approve' : 'needs_review'),
+      reason: output.reason || '',
+      riskCodes: Array.isArray(output.riskCodes) ? output.riskCodes : [],
+      metadata: {
+        ...metadata,
+        elapsedMs: Date.now() - startedAt,
+        runnerElapsedMs: runnerOutput.elapsed_ms || null,
+      },
+    };
+  }
+
+  audit.metadata = metadata;
+  return audit;
+}

--- a/src/audit/codex_sdk_python.js
+++ b/src/audit/codex_sdk_python.js
@@ -98,6 +98,12 @@ export function runCodexSdkPythonCommand({
       clearTimeout(timeout);
       reject(error);
     });
+    child.stdin.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
     child.on('close', (code) => {
       if (settled) return;
       settled = true;
@@ -158,7 +164,20 @@ export function createCodexSdkPythonAutoPromoteAuditor(options = {}) {
       env: process.env,
     });
     const runnerOutput = parseCodexExecJson(result.stdout || '');
-    const output = parseCodexExecJson(runnerOutput.final_response || result.stdout || '');
+    if (typeof runnerOutput.final_response !== 'string' || runnerOutput.final_response.trim() === '') {
+      return {
+        approved: false,
+        decision: 'needs_review',
+        reason: 'Codex Python SDK audit returned an empty final_response.',
+        riskCodes: ['empty_final_response'],
+        metadata: {
+          ...metadata,
+          elapsedMs: Date.now() - startedAt,
+          runnerElapsedMs: runnerOutput.elapsed_ms || null,
+        },
+      };
+    }
+    const output = parseCodexExecJson(runnerOutput.final_response);
     const approved = output.approved === true && output.decision === 'approve';
     return {
       approved,

--- a/src/audit/codex_sdk_python_runner.py
+++ b/src/audit/codex_sdk_python_runner.py
@@ -13,6 +13,7 @@ SANDBOX_BY_VALUE = {
     Sandbox.workspace_write.value: Sandbox.workspace_write,
     Sandbox.full_access.value: Sandbox.full_access,
 }
+REASONING_EFFORTS = {"minimal", "low", "medium", "high"}
 
 
 def parse_args():
@@ -27,11 +28,20 @@ def parse_args():
 
 def main():
     args = parse_args()
-    payload = json.load(sys.stdin)
-    prompt = payload["prompt"]
+    try:
+        payload = json.load(sys.stdin)
+        prompt = payload["prompt"]
+    except (json.JSONDecodeError, KeyError, TypeError) as error:
+        print(json.dumps({"error": f"Invalid audit payload: {error}"}), file=sys.stderr)
+        sys.exit(1)
     sandbox = SANDBOX_BY_VALUE.get(args.sandbox)
     if sandbox is None:
         raise ValueError(f"Unsupported sandbox preset: {args.sandbox}")
+    if args.reasoning_effort and args.reasoning_effort not in REASONING_EFFORTS:
+        raise ValueError(
+            f"Unsupported reasoning effort: {args.reasoning_effort}. "
+            f"Expected one of: {', '.join(sorted(REASONING_EFFORTS))}"
+        )
 
     config_overrides = ()
     if args.reasoning_effort:

--- a/src/audit/codex_sdk_python_runner.py
+++ b/src/audit/codex_sdk_python_runner.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import sys
+import time
+
+from openai_codex import Codex, CodexConfig, Sandbox
+
+
+SANDBOX_BY_VALUE = {
+    Sandbox.read_only.value: Sandbox.read_only,
+    Sandbox.workspace_write.value: Sandbox.workspace_write,
+    Sandbox.full_access.value: Sandbox.full_access,
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run a ContextForge auto-promotion audit with the Codex Python SDK.")
+    parser.add_argument("--codex-bin", required=True)
+    parser.add_argument("--model", default="gpt-5.5")
+    parser.add_argument("--reasoning-effort", default="low")
+    parser.add_argument("--sandbox", default=Sandbox.read_only.value)
+    parser.add_argument("--cwd", default=os.getcwd())
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    payload = json.load(sys.stdin)
+    prompt = payload["prompt"]
+    sandbox = SANDBOX_BY_VALUE.get(args.sandbox)
+    if sandbox is None:
+        raise ValueError(f"Unsupported sandbox preset: {args.sandbox}")
+
+    config_overrides = ()
+    if args.reasoning_effort:
+        config_overrides = (f'model_reasoning_effort="{args.reasoning_effort}"',)
+
+    started_at = time.time()
+    config = CodexConfig(
+        codex_bin=args.codex_bin,
+        cwd=args.cwd,
+        config_overrides=config_overrides,
+        client_name="contextforge_python_sdk_audit",
+        client_title="ContextForge Python SDK Audit",
+    )
+
+    with Codex(config) as codex:
+        thread = codex.thread_start(
+            model=args.model or None,
+            sandbox=sandbox,
+            cwd=args.cwd,
+            ephemeral=True,
+        )
+        result = thread.run(prompt, sandbox=sandbox)
+
+    print(
+        json.dumps(
+            {
+                "final_response": result.final_response,
+                "elapsed_ms": round((time.time() - started_at) * 1000),
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cli.js
+++ b/src/cli.js
@@ -217,6 +217,7 @@ async function main() {
     applyMemoryUpdateCandidate: (app, coreOptions) => app.applyMemoryUpdateCandidate(coreOptions),
     rejectMemoryUpdateCandidate: (app, coreOptions) => app.rejectMemoryUpdateCandidate(coreOptions),
     skipMemoryUpdateCandidate: (app, coreOptions) => app.skipMemoryUpdateCandidate(coreOptions),
+    auditMemoryCandidates: (app, coreOptions) => app.auditMemoryCandidates(coreOptions),
     autoPromoteMemoryCandidates: (app, coreOptions) => app.autoPromoteMemoryCandidates(coreOptions),
     search: (app, coreOptions) => app.search(coreOptions),
     rebuildEmbeddings: (app, coreOptions) => app.rebuildEmbeddings(coreOptions),

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -236,6 +236,13 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
         enabled: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_ENABLED !== 'false',
         provider: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER || 'codex_exec',
         command: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_COMMAND || env.CONTEXTFORGE_CODEX_EXEC_COMMAND || 'codex',
+        codexBin:
+          env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_BIN ||
+          env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_COMMAND ||
+          env.CONTEXTFORGE_CODEX_EXEC_COMMAND ||
+          'codex',
+        pythonCommand: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHON_COMMAND || 'python3',
+        pythonPath: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHONPATH || null,
         model: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_MODEL || 'gpt-5.5',
         reasoningEffort: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_REASONING_EFFORT || 'low',
         sandbox: env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_SANDBOX || 'read-only',

--- a/src/core.js
+++ b/src/core.js
@@ -1007,6 +1007,17 @@ function autoPromotionWouldPromote(indexedCandidate, warnings, rank) {
   };
 }
 
+function auditedPromotionProposal(indexedCandidate, warnings, audit, rank) {
+  const proposal = promotionProposal(indexedCandidate, warnings, rank);
+  const approved = audit?.approved === true;
+  return {
+    ...proposal,
+    audit,
+    auditReason: audit?.reason || null,
+    recommendedAction: approved ? 'promote' : 'review',
+  };
+}
+
 function promoteCandidateToMemory(
   store,
   scope,
@@ -2681,6 +2692,205 @@ export function createContextForge(options = {}) {
           nextActions: [
             'Ask the user to choose: promote, edit then promote, skip, or reject.',
             'Do not promote automatically.',
+          ],
+        };
+      });
+    },
+
+    async auditMemoryCandidates(options = {}) {
+      const scope = normalizeScopeOptions(options, config);
+      const trigger = options.trigger;
+      if (!CLOSEOUT_TRIGGERS.has(trigger)) {
+        throw new Error('trigger must be a closeout trigger.');
+      }
+      const requestedLimit = positiveNumber(options.limit == null ? 3 : Number(options.limit), 'limit');
+      const limit = Math.min(3, requestedLimit);
+      const requestWarnings =
+        requestedLimit > 3
+          ? [
+              {
+                code: 'limit_capped',
+                message: 'audit_memory_candidates returns at most 3 proposals.',
+                requestedLimit,
+                effectiveLimit: limit,
+              },
+            ]
+          : [];
+      const minConfidence = Number(options.minConfidence ?? 0.85);
+      const minStability = Number(options.minStability ?? 0.85);
+      if (!Number.isFinite(minConfidence) || minConfidence < 0 || minConfidence > 1) {
+        throw new Error('minConfidence must be between 0 and 1.');
+      }
+      if (!Number.isFinite(minStability) || minStability < 0 || minStability > 1) {
+        throw new Error('minStability must be between 0 and 1.');
+      }
+      const categoryPolicy = normalizeAllowedCategories(options.allowedCategories);
+      const allowedCategories = categoryPolicy.allowedCategories;
+      if (categoryPolicy.strippedPreference) {
+        requestWarnings.push({
+          code: 'preference_input_stripped',
+          message: 'Preference candidates cannot be audited for automatic-style promotion until occurrence/merge tracking exists.',
+        });
+      }
+      const scanLimit = positiveNumber(options.scanLimit == null ? 10 : Number(options.scanLimit), 'scanLimit');
+      const promotionRecommendation = options.promotionRecommendation || 'promote';
+      if (!options.sessionId && !options.checkpointId) {
+        return {
+          kind: 'memory_candidate_audit_suggestions',
+          trigger,
+          source: {
+            sessionId: null,
+            checkpointId: null,
+            mode: 'none',
+          },
+          policy: {
+            minConfidence,
+            minStability,
+            allowedCategories: Array.from(allowedCategories),
+            scopeFallback: false,
+            mutates: false,
+            audit: {
+              enabled: false,
+              executed: false,
+              provider: 'none',
+              model: null,
+              reasoningEffort: null,
+            },
+          },
+          proposals: [],
+          skipped: [],
+          requestWarnings: [
+            ...requestWarnings,
+            {
+              ...missingCloseoutSourceWarning('audit_memory_candidates'),
+              detail:
+                'Audited suggestions never use scope fallback. Pass the checkpointId returned by distill_checkpoint or the current sessionId.',
+            },
+          ],
+          nextActions: [
+            'No current-session closeout candidates were reviewed because sessionId/checkpointId was missing.',
+            'Provide sessionId or checkpointId; audited suggestions never scan the scope backlog.',
+            'No memory candidates were promoted.',
+          ],
+        };
+      }
+
+      return useStore(async (store) => {
+        let checkpointId = options.checkpointId || null;
+        let sourceMode = null;
+        if (checkpointId) {
+          sourceMode = 'checkpoint';
+        } else {
+          const latestCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId, level: 0 });
+          checkpointId = latestCheckpoint?.id || null;
+          sourceMode = 'latest_checkpoint';
+        }
+        const auditor = checkpointId ? getAutoPromoteAuditor(store) : null;
+        const auditPolicy = {
+          enabled: Boolean(auditor),
+          executed: false,
+          provider: auditor?.metadata?.provider || 'none',
+          model: auditor?.metadata?.model || null,
+          reasoningEffort: auditor?.metadata?.reasoningEffort || null,
+        };
+        if (options.sessionId && !checkpointId) {
+          return {
+            kind: 'memory_candidate_audit_suggestions',
+            trigger,
+            source: {
+              sessionId: options.sessionId,
+              checkpointId: null,
+              mode: sourceMode,
+            },
+            policy: {
+              minConfidence,
+              minStability,
+              allowedCategories: Array.from(allowedCategories),
+              scopeFallback: false,
+              mutates: false,
+              audit: auditPolicy,
+            },
+            proposals: [],
+            skipped: [],
+            requestWarnings,
+            nextActions: [
+              'No latest checkpoint was found for this session; distill a checkpoint before auditing candidates.',
+              'No memory candidates were promoted.',
+            ],
+          };
+        }
+
+        const policy = { minConfidence, minStability, allowedCategories };
+        const candidates = store.listMemoryCandidates({
+          ...scope,
+          sessionId: options.sessionId || null,
+          checkpointId,
+          status: 'pending',
+          promotionRecommendation,
+          sort: 'recommendation',
+          limit: scanLimit,
+        });
+        const assessed = candidates.map((candidate) => {
+          const warnings = autoPromotionWarnings(store, scope, candidate, policy);
+          const score = scorePromotionCandidate(candidate, warnings, AUTO_PROMOTE_SKIP_WARNING_CODES);
+          return { candidate, warnings, score };
+        });
+        const selected = assessed
+          .filter((item) => item.score > 0)
+          .sort((a, b) => b.score - a.score)
+          .slice(0, limit);
+        const audited = [];
+        for (const item of selected) {
+          try {
+            const audit = await auditAutoPromotionCandidate({ auditor, store, scope, item });
+            audited.push({ ...item, audit });
+          } catch (error) {
+            audited.push({
+              ...item,
+              audit: {
+                approved: false,
+                decision: 'needs_review',
+                reason: `Memory candidate audit failed: ${error.message}`,
+                riskCodes: ['audit_failed'],
+                metadata: { errorName: error.name },
+              },
+            });
+          }
+        }
+
+        return {
+          kind: 'memory_candidate_audit_suggestions',
+          trigger,
+          source: {
+            sessionId: options.sessionId || null,
+            checkpointId,
+            mode: sourceMode,
+          },
+          policy: {
+            minConfidence,
+            minStability,
+            allowedCategories: Array.from(allowedCategories),
+            scopeFallback: false,
+            mutates: false,
+            audit: {
+              ...auditPolicy,
+              executed: audited.length > 0,
+            },
+          },
+          proposals: audited.map((item, index) =>
+            auditedPromotionProposal(item.candidate, item.warnings, item.audit, index + 1),
+          ),
+          skipped: assessed
+            .filter((item) => item.score <= 0)
+            .map((item) => ({
+              candidateId: item.candidate.id,
+              reason: candidateWarningReason(item.warnings) || 'low_score',
+            })),
+          requestWarnings,
+          nextActions: [
+            'Ask the user to choose: promote, edit then promote, skip, or reject.',
+            'Use promote_memory_candidate only after reviewed approval; rejected audit candidates remain pending until explicitly rejected or skipped.',
+            'No memory candidates were promoted.',
           ],
         };
       });

--- a/src/core.js
+++ b/src/core.js
@@ -1007,9 +1007,9 @@ function autoPromotionWouldPromote(indexedCandidate, warnings, rank) {
   };
 }
 
-function auditedPromotionProposal(indexedCandidate, warnings, audit, rank) {
+function auditedPromotionProposal(indexedCandidate, warnings, audit, rank, { auditEnabled = true } = {}) {
   const proposal = promotionProposal(indexedCandidate, warnings, rank);
-  const approved = audit?.approved === true;
+  const approved = auditEnabled && audit?.approved === true;
   return {
     ...proposal,
     audit,
@@ -2874,11 +2874,13 @@ export function createContextForge(options = {}) {
             mutates: false,
             audit: {
               ...auditPolicy,
-              executed: audited.length > 0,
+              executed: Boolean(auditor) && audited.length > 0,
             },
           },
           proposals: audited.map((item, index) =>
-            auditedPromotionProposal(item.candidate, item.warnings, item.audit, index + 1),
+            auditedPromotionProposal(item.candidate, item.warnings, item.audit, index + 1, {
+              auditEnabled: Boolean(auditor),
+            }),
           ),
           skipped: assessed
             .filter((item) => item.score <= 0)

--- a/src/core.js
+++ b/src/core.js
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { createCodexExecAutoPromoteAuditor } from './audit/codex_exec.js';
+import { createCodexSdkPythonAutoPromoteAuditor } from './audit/codex_sdk_python.js';
 import { loadConfig } from './config/index.js';
 import { createDistillProvider } from './distill/index.js';
 import { checkCodexExecProvider } from './distill/providers/codex_exec.js';
@@ -1513,13 +1514,19 @@ export function createContextForge(options = {}) {
     if (!audit.enabled) {
       return null;
     }
-    if (audit.provider !== 'codex_exec') {
-      throw new Error(`Unsupported auto-promotion audit provider "${audit.provider}".`);
+    if (audit.provider === 'codex_exec') {
+      return createCodexExecAutoPromoteAuditor({
+        ...audit,
+        runner: options.autoPromoteAuditRunner,
+      });
     }
-    return createCodexExecAutoPromoteAuditor({
-      ...audit,
-      runner: options.autoPromoteAuditRunner,
-    });
+    if (audit.provider === 'codex_sdk_python') {
+      return createCodexSdkPythonAutoPromoteAuditor({
+        ...audit,
+        runner: options.autoPromoteAuditRunner,
+      });
+    }
+    throw new Error(`Unsupported auto-promotion audit provider "${audit.provider}".`);
   }
 
   function buildDbInfo(store) {

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -31,6 +31,7 @@ const MCP_INSTRUCTIONS = [
   'Search result types have different trust roles: memory is reviewed durable fact or decision; checkpoint is credible recent handoff state for continuity, planning, prior intent, recent decisions, and unfinished work, but mutable live-state claims must be verified with git/GitHub/CI/runtime/migrations before acting; memory_candidate is unreviewed promotion material and not durable truth.',
   'For task start or loose continuation prompts such as "지난 환경 작업과 동기화", "어제 하던 거 이어서", "previous work", or "continue", call bootstrap_context first; it includes latest checkpoint handoff independent of search ranking. Use sync_resume_context only when you know the exact sessionId and need session working state or raw tail.',
   'For closeout triggers only, call suggest_memory_promotions with the current sessionId or the checkpointId returned by distill_checkpoint: after this agent merges a PR, after the user says they merged and the agent syncs main/cleans branches, or when the user explicitly says today\'s work is done. Suggest at most 1-3 durable memory promotions and never promote automatically.',
+  'When an agent needs audited closeout recommendations without writes, call audit_memory_candidates with sessionId or checkpointId. It runs the configured audit provider and returns proposals for promote/edit/skip/reject, but never mutates durable memory or candidate status.',
   'For strict closeout-scoped safe automatic promotion, call auto_promote_memory_candidates only when the user wants automatic promotion and always include sessionId or checkpointId. By default use dryRun=true. Use dryRun=false only when CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true is intentionally configured; never use scope-wide backlog fallback and never auto-promote preference candidates.',
   'Preference-like candidates are tracked as merged occurrences; use list_preference_occurrences to review repeated evidence and weakened corrections, but do not treat occurrence evidence alone as durable preference truth.',
   'For user corrections such as "너 잘못 알고 있잖아", "그거 아니야", "그건 X가 아니라 Y야", or "기억 수정해", call reconcile_memory. Show the basis for prior knowledge, assess conflicts, and only apply safe corrections when the user explicitly asks to fix memory.',
@@ -760,6 +761,38 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
       },
     },
     async (args) => jsonResult(await app.autoPromoteMemoryCandidates(args)),
+  );
+
+  server.registerTool(
+    'audit_memory_candidates',
+    {
+      title: 'Audit Memory Candidates',
+      description:
+        'Run the configured audit provider on closeout-scoped pending memory candidates and return read-only audited recommendations for the agent/user to choose from. Requires sessionId or checkpointId, never scans scope fallback, and never promotes or changes candidate status.',
+      inputSchema: {
+        ...scopedSchema,
+        sessionId: z.string().optional(),
+        checkpointId: z.string().optional(),
+        trigger: z.enum([
+          'agent_merged_pr',
+          'user_merged_then_synced',
+          'user_declared_work_done',
+          'manual_closeout',
+        ]),
+        limit: z.number().int().positive().optional(),
+        scanLimit: z.number().int().positive().optional(),
+        minConfidence: z.number().optional(),
+        minStability: z.number().optional(),
+        allowedCategories: z.array(z.string()).optional(),
+        promotionRecommendation: z.string().optional(),
+      },
+      annotations: {
+        title: 'Audit Memory Candidates',
+        readOnlyHint: true,
+        idempotentHint: false,
+      },
+    },
+    async (args) => jsonResult(await app.auditMemoryCandidates(args)),
   );
 
   server.registerTool(

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -27,6 +27,7 @@ const REMOTE_METHODS = [
   'rejectMemoryUpdateCandidate',
   'skipMemoryUpdateCandidate',
   'suggestMemoryPromotions',
+  'auditMemoryCandidates',
   'autoPromoteMemoryCandidates',
   'reconcileMemory',
   'getMemory',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -5858,6 +5858,93 @@ test('autoPromoteMemoryCandidates keeps candidates pending when audit runner fai
   assert.equal(app.getMemory({ scope: 'repo', scopeKey: 'audit-fail-repo', key: 'audit-failed-runbook' }), null);
 });
 
+test('autoPromoteMemoryCandidates can audit through the Codex Python SDK provider', async () => {
+  const dataDir = await makeTempDir();
+  const auditInvocations = [];
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'python_sdk_audit_provider',
+      CONTEXTFORGE_AUTO_PROMOTE_ENABLED: 'true',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER: 'codex_sdk_python',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_BIN: '/home/ubuntu/.local/bin/codex',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHON_COMMAND: 'python3',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHONPATH: '/tmp/contextforge-codex-sdk',
+    },
+    cwd: process.cwd(),
+    autoPromoteAuditRunner: async (invocation) => {
+      auditInvocations.push(invocation);
+      return {
+        stdout: JSON.stringify({
+          final_response: JSON.stringify({
+            approved: true,
+            decision: 'approve',
+            reason: 'The candidate is stable and supported by checkpoint evidence.',
+            riskCodes: [],
+          }),
+          elapsed_ms: 12,
+        }),
+        stderr: '',
+      };
+    },
+    distillProviders: {
+      python_sdk_audit_provider: async () => ({
+        summaryShort: 'Python SDK audit checkpoint.',
+        summaryText: 'Closeout produced a candidate that should be audited through the Python SDK provider.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'python-sdk-audit-runbook',
+            content: 'The runbook is stable and safe enough for automatic durable promotion after audit.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.96,
+            stability: 0.96,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'python-sdk-audit-repo',
+    sessionId: 'python-sdk-audit-session',
+    role: 'assistant',
+    content: 'Python SDK audit candidate.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'python-sdk-audit-repo',
+    sessionId: 'python-sdk-audit-session',
+  });
+
+  const result = await app.autoPromoteMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'python-sdk-audit-repo',
+    sessionId: 'python-sdk-audit-session',
+    trigger: 'manual_closeout',
+    dryRun: false,
+  });
+
+  assert.equal(result.policy.audit.provider, 'codex_sdk_python');
+  assert.equal(result.promoted.length, 1);
+  assert.equal(result.promoted[0].audit.metadata.provider, 'codex_sdk_python');
+  assert.equal(result.promoted[0].audit.metadata.codexBin, '/home/ubuntu/.local/bin/codex');
+  assert.equal(result.promoted[0].audit.metadata.pythonPath, '/tmp/contextforge-codex-sdk');
+  assert.equal(auditInvocations.length, 1);
+  assert.equal(auditInvocations[0].codexBin, '/home/ubuntu/.local/bin/codex');
+  assert.equal(auditInvocations[0].pythonCommand, 'python3');
+  assert.equal(auditInvocations[0].pythonPath, '/tmp/contextforge-codex-sdk');
+  assert.match(auditInvocations[0].prompt, /ContextForge automatic memory promotion auditor/);
+  assert.ok(
+    app.getMemory({ scope: 'repo', scopeKey: 'python-sdk-audit-repo', key: 'python-sdk-audit-runbook' }),
+  );
+});
+
 test('autoPromoteMemoryCandidates rejects unsupported audit providers', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -5502,6 +5502,104 @@ test('autoPromoteMemoryCandidates requires closeout scope and defaults to dry-ru
   );
 });
 
+test('auditMemoryCandidates returns audited read-only recommendations', async () => {
+  const dataDir = await makeTempDir();
+  const auditInvocations = [];
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'audit_suggestions_provider',
+    },
+    cwd: process.cwd(),
+    autoPromoteAuditor: async ({ candidate, warnings, checkpoint }) => {
+      auditInvocations.push({ candidate, warnings, checkpoint });
+      return {
+        approved: true,
+        decision: 'approve',
+        reason: 'Candidate is stable enough to offer as a closeout recommendation.',
+        riskCodes: [],
+        metadata: {
+          provider: 'codex_exec',
+          model: 'gpt-5.5',
+          reasoningEffort: 'low',
+        },
+      };
+    },
+    distillProviders: {
+      audit_suggestions_provider: async () => ({
+        summaryShort: 'Audit suggestions checkpoint.',
+        summaryText: 'Closeout produced a candidate that should be audited without mutation.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'audited-readonly-runbook',
+            content: 'Agents should audit closeout memory candidates before suggesting promotion.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.96,
+            stability: 0.96,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'audit-suggestions-repo',
+    sessionId: 'audit-suggestions-session',
+    role: 'assistant',
+    content: 'Read-only audited candidate.',
+  });
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'audit-suggestions-repo',
+    sessionId: 'audit-suggestions-session',
+  });
+
+  const noSource = await app.auditMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'audit-suggestions-repo',
+    trigger: 'manual_closeout',
+  });
+  assert.equal(noSource.kind, 'memory_candidate_audit_suggestions');
+  assert.deepEqual(noSource.proposals, []);
+  assert.equal(noSource.source.mode, 'none');
+  assert.ok(noSource.requestWarnings.some((warning) => warning.code === 'missing_closeout_source'));
+
+  const result = await app.auditMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'audit-suggestions-repo',
+    checkpointId: checkpoint.id,
+    trigger: 'user_declared_work_done',
+    limit: 5,
+  });
+
+  assert.equal(result.kind, 'memory_candidate_audit_suggestions');
+  assert.equal(result.policy.mutates, false);
+  assert.equal(result.policy.audit.executed, true);
+  assert.equal(result.policy.audit.provider, 'none');
+  assert.equal(result.source.mode, 'checkpoint');
+  assert.equal(result.proposals.length, 1);
+  assert.equal(result.proposals[0].key, 'audited-readonly-runbook');
+  assert.equal(result.proposals[0].recommendedAction, 'promote');
+  assert.equal(result.proposals[0].audit.metadata.model, 'gpt-5.5');
+  assert.ok(result.requestWarnings.some((warning) => warning.code === 'limit_capped'));
+  assert.equal(auditInvocations.length, 1);
+  assert.equal(auditInvocations[0].checkpoint.id, checkpoint.id);
+  assert.equal(app.getMemory({ scope: 'repo', scopeKey: 'audit-suggestions-repo', key: 'audited-readonly-runbook' }), null);
+  const pendingCandidates = app.listMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'audit-suggestions-repo',
+    status: 'pending',
+  });
+  assert.equal(pendingCandidates.length, 1);
+  assert.equal(pendingCandidates[0].candidate.key, 'audited-readonly-runbook');
+});
+
 test('autoPromoteMemoryCandidates returns stable empty arrays and preference input warnings', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({
@@ -5943,6 +6041,100 @@ test('autoPromoteMemoryCandidates can audit through the Codex Python SDK provide
   assert.ok(
     app.getMemory({ scope: 'repo', scopeKey: 'python-sdk-audit-repo', key: 'python-sdk-audit-runbook' }),
   );
+});
+
+test('auditMemoryCandidates can use the Codex Python SDK provider without enabling auto-promotion', async () => {
+  const dataDir = await makeTempDir();
+  const auditInvocations = [];
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'python_sdk_audit_suggestions_provider',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER: 'codex_sdk_python',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_BIN: '/home/ubuntu/.local/bin/codex',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHON_COMMAND: 'python3',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHONPATH: '/tmp/contextforge-codex-sdk',
+    },
+    cwd: process.cwd(),
+    autoPromoteAuditRunner: async (invocation) => {
+      auditInvocations.push(invocation);
+      return {
+        stdout: JSON.stringify({
+          final_response: JSON.stringify({
+            approved: false,
+            decision: 'needs_review',
+            reason: 'The agent should review this candidate before promotion.',
+            riskCodes: ['needs_human_review'],
+          }),
+          elapsed_ms: 21,
+        }),
+        stderr: '',
+      };
+    },
+    distillProviders: {
+      python_sdk_audit_suggestions_provider: async () => ({
+        summaryShort: 'Python SDK audit suggestions checkpoint.',
+        summaryText: 'Closeout produced a candidate that should be audited without auto-promotion.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'python-sdk-readonly-audit',
+            content: 'The Python SDK audit provider can produce read-only closeout recommendations.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.96,
+            stability: 0.96,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'python-sdk-audit-suggestions-repo',
+    sessionId: 'python-sdk-audit-suggestions-session',
+    role: 'assistant',
+    content: 'Python SDK read-only audited candidate.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'python-sdk-audit-suggestions-repo',
+    sessionId: 'python-sdk-audit-suggestions-session',
+  });
+
+  const result = await app.auditMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'python-sdk-audit-suggestions-repo',
+    sessionId: 'python-sdk-audit-suggestions-session',
+    trigger: 'manual_closeout',
+  });
+
+  assert.equal(result.policy.audit.provider, 'codex_sdk_python');
+  assert.equal(result.policy.audit.executed, true);
+  assert.equal(result.proposals.length, 1);
+  assert.equal(result.proposals[0].recommendedAction, 'review');
+  assert.equal(result.proposals[0].audit.metadata.provider, 'codex_sdk_python');
+  assert.equal(result.proposals[0].audit.metadata.codexBin, '/home/ubuntu/.local/bin/codex');
+  assert.equal(auditInvocations.length, 1);
+  assert.equal(auditInvocations[0].pythonCommand, 'python3');
+  assert.equal(
+    app.getMemory({
+      scope: 'repo',
+      scopeKey: 'python-sdk-audit-suggestions-repo',
+      key: 'python-sdk-readonly-audit',
+    }),
+    null,
+  );
+  const pendingCandidates = app.listMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'python-sdk-audit-suggestions-repo',
+    status: 'pending',
+  });
+  assert.equal(pendingCandidates.length, 1);
 });
 
 test('autoPromoteMemoryCandidates rejects unsupported audit providers', async () => {
@@ -6651,6 +6843,7 @@ test('REMOTE_METHODS exposes resume, suggestion, auto-promotion, and reconciliat
   assert.ok(REMOTE_METHODS.includes('processDueDistills'));
   assert.ok(REMOTE_METHODS.includes('listMemories'));
   assert.ok(REMOTE_METHODS.includes('suggestMemoryPromotions'));
+  assert.ok(REMOTE_METHODS.includes('auditMemoryCandidates'));
   assert.ok(REMOTE_METHODS.includes('autoPromoteMemoryCandidates'));
   assert.ok(REMOTE_METHODS.includes('reconcileMemory'));
   assert.ok(REMOTE_METHODS.includes('listPreferenceOccurrences'));
@@ -6813,6 +7006,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     assert.deepEqual(toolNames, [
       'append_raw',
       'apply_memory_update_candidate',
+      'audit_memory_candidates',
       'auto_promote_memory_candidates',
       'begin_session',
       'bootstrap_context',
@@ -6913,6 +7107,10 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     assert.ok(autoPromoteTool.inputSchema.properties.minConfidence);
     assert.ok(autoPromoteTool.inputSchema.properties.allowedCategories);
     assert.ok(autoPromoteTool.description.includes('missing_closeout_source'));
+    const auditCandidatesTool = toolList.tools.find((tool) => tool.name === 'audit_memory_candidates');
+    assert.ok(auditCandidatesTool.inputSchema.properties.minConfidence);
+    assert.ok(auditCandidatesTool.inputSchema.properties.promotionRecommendation);
+    assert.ok(auditCandidatesTool.description.includes('never promotes'));
     const promoteTool = toolList.tools.find((tool) => tool.name === 'promote_memory');
     assert.ok(promoteTool.description.includes('sourceCheckpointId'));
     const promoteCandidateTool = toolList.tools.find((tool) => tool.name === 'promote_memory_candidate');

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -10,6 +10,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import Database from 'better-sqlite3';
+import { createCodexSdkPythonAutoPromoteAuditor } from '../src/audit/codex_sdk_python.js';
 import { createContextForge } from '../src/core.js';
 import { validateDistillOutput } from '../src/distill/validate.js';
 import { createOpenAiEmbeddingProvider } from '../src/embeddings/index.js';
@@ -5600,6 +5601,66 @@ test('auditMemoryCandidates returns audited read-only recommendations', async ()
   assert.equal(pendingCandidates[0].candidate.key, 'audited-readonly-runbook');
 });
 
+test('auditMemoryCandidates keeps recommendations conservative when audit is disabled', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'audit_disabled_provider',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_ENABLED: 'false',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      audit_disabled_provider: async () => ({
+        summaryShort: 'Audit disabled checkpoint.',
+        summaryText: 'Closeout produced a candidate while the audit provider is disabled.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'audit-disabled-runbook',
+            content: 'Read-only audit suggestions should not recommend promotion when audit is disabled.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.96,
+            stability: 0.96,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'audit-disabled-repo',
+    sessionId: 'audit-disabled-session',
+    role: 'assistant',
+    content: 'Audit disabled read-only candidate.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'audit-disabled-repo',
+    sessionId: 'audit-disabled-session',
+  });
+
+  const result = await app.auditMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'audit-disabled-repo',
+    sessionId: 'audit-disabled-session',
+    trigger: 'manual_closeout',
+  });
+
+  assert.equal(result.policy.audit.enabled, false);
+  assert.equal(result.policy.audit.executed, false);
+  assert.equal(result.proposals.length, 1);
+  assert.equal(result.proposals[0].recommendedAction, 'review');
+  assert.equal(result.proposals[0].audit.approved, true);
+  assert.equal(result.proposals[0].audit.metadata.provider, 'none');
+  assert.equal(app.getMemory({ scope: 'repo', scopeKey: 'audit-disabled-repo', key: 'audit-disabled-runbook' }), null);
+});
+
 test('autoPromoteMemoryCandidates returns stable empty arrays and preference input warnings', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({
@@ -6135,6 +6196,37 @@ test('auditMemoryCandidates can use the Codex Python SDK provider without enabli
     status: 'pending',
   });
   assert.equal(pendingCandidates.length, 1);
+});
+
+test('Codex Python SDK auditor treats empty final_response as needs_review', async () => {
+  const auditor = createCodexSdkPythonAutoPromoteAuditor({
+    codexBin: '/home/ubuntu/.local/bin/codex',
+    pythonCommand: 'python3',
+    runner: async () => ({
+      stdout: JSON.stringify({
+        final_response: null,
+        elapsed_ms: 7,
+      }),
+      stderr: '',
+    }),
+  });
+
+  const result = await auditor({
+    candidate: {
+      candidate: {
+        key: 'empty-final-response',
+        content: 'The audit runner returned no final response.',
+        category: 'runbook',
+      },
+    },
+    warnings: [],
+    checkpoint: null,
+  });
+
+  assert.equal(result.approved, false);
+  assert.equal(result.decision, 'needs_review');
+  assert.deepEqual(result.riskCodes, ['empty_final_response']);
+  assert.equal(result.metadata.runnerElapsedMs, 7);
 });
 
 test('autoPromoteMemoryCandidates rejects unsupported audit providers', async () => {


### PR DESCRIPTION
## Summary
- add experimental auto-promotion audit provider `codex_sdk_python`
- run audits through a small Python SDK runner while pointing at an existing local Codex binary
- expose Python SDK audit settings in the admin UI and env example
- document the `--no-deps openai-codex` + `pydantic` setup for platforms without the pinned CLI wheel

## Verification
- `git diff --check`
- `npm test`
- live smoke: Codex Python SDK with `CodexConfig(codex_bin='/home/ubuntu/.local/bin/codex')`
- live smoke: Node `codex_sdk_python` auditor wrapper returned a structured audit result
