### PR TITLE
Add structured checkpoint handoff payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.5.0 - 2026-06-03
+
 - Added optional structured checkpoint handoff payloads for agent resume state,
   including mutable live-state verification hints.
 - Preserved memory candidate v2 review fields in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Added optional structured checkpoint handoff payloads for agent resume state,
+  including mutable live-state verification hints.
+- Preserved memory candidate v2 review fields in
+  `memory_candidate_index.candidate_json`.
+- Exposed deterministic latest checkpoint handoff in bootstrap/resume context.
+
 ## 0.4.2 - 2026-05-31
 
 - Added bounded distillation catch-up commands:

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,391 @@
+# ContextForge
+
+코딩 에이전트를 위한 셀프호스트 메모리와 디스틸 런타임.
+
+[English README](README.md)
+
+ContextForge는 단순한 메모리 파일이 아니다. Codex, Claude Code, OpenClaw
+같은 에이전트가 프로젝트별 기억을 안전하게 공유하고, 대화 증거를 보존하며,
+LLM으로 최근 작업 상태를 checkpoint로 압축해 다음 에이전트가 이어받을 수
+있게 만드는 사이드카 런타임이다.
+
+![ContextForge 설명 만화](docs/assets/contextforge-explainer-comic-ko.jpg)
+
+## 핵심 개념
+
+- `memory`: 검토 후 승격된 durable memory. 안정적인 정책, 계약, runbook,
+  결정, 반복되는 선호를 저장한다.
+- `checkpoint`: raw evidence를 LLM이 압축한 최근 handoff 상태. 신뢰할 수
+  있는 최근 메모지만, branch, PR, CI 같은 live state는 다시 확인해야 한다.
+- `memory_candidate`: checkpoint에서 나온 승격 후보. 검토 자료일 뿐 자동으로
+  durable memory가 되지 않는다.
+- `raw evidence`: user/assistant 대화 증거. 디스틸 실패가 나도 삭제하지 않는다.
+- `working summary/context`: 현재 세션의 mutable resume state. durable
+  memory가 아니다.
+
+행동할 때의 신뢰 순서는 다음과 같다.
+
+```text
+live source > durable memory > checkpoint handoff > memory_candidate
+```
+
+## 0.5.0에서 좋아진 점
+
+- checkpoint가 사람용 요약뿐 아니라 구조화된 handoff payload를 저장할 수 있다.
+- `bootstrapContext`와 `syncResumeContext`가 검색 결과와 별개로
+  `handoff.latestHandoff`를 제공한다.
+- `structured.liveState`에는 repo, branch, PR, head commit, CI, worktree
+  같은 mutable state와 재검증 힌트를 담을 수 있다.
+- memory candidate v2 필드인 `durabilityReason`, `riskReason`,
+  `evidenceRefs`, `suggestedAction`을 보존한다.
+- 자동승격 감사는 distill 모델과 분리된다. `codex_exec` 또는
+  `codex_sdk_python` 감사 provider를 사용할 수 있다.
+
+## 권장 구조
+
+여러 머신이나 여러 에이전트가 같은 기억을 공유해야 한다면 remote mode를
+권장한다.
+
+```text
+Codex / Claude Code / OpenClaw
+          |
+      MCP tools / CLI
+          |
+   ContextForge Server
+          |
+ shared / repo / local scoped memory
+          |
+ SQLite + raw evidence + checkpoints + durable memory
+```
+
+단일 머신에서만 쓸 때는 `project-local` 또는 `local` storage로 충분하다.
+
+## 빠른 시작
+
+요구사항:
+
+- Node.js 20 이상
+
+설치:
+
+```bash
+npm install
+```
+
+테스트:
+
+```bash
+npm test
+```
+
+로컬 DB 확인:
+
+```bash
+node src/cli.js dbInfo
+```
+
+기본값은 현재 checkout 아래 `.contextforge/contextforge.db`에 저장하는
+`project-local` 모드다. 이 디렉터리와 SQLite sidecar 파일은 git에 넣지 않는다.
+
+## 저장 모드
+
+- `project-local`: checkout-local SQLite. 기본값이며 실험에 좋다.
+- `local`: 사용자 홈 디렉터리 아래 단일 머신 SQLite.
+- `remote`: HTTP 서버가 canonical DB를 소유하고, 여러 머신이 MCP/CLI로 접근한다.
+
+remote client 예시:
+
+```bash
+CONTEXTFORGE_STORAGE_MODE=remote \
+CONTEXTFORGE_REMOTE_URL=https://memory.example.com \
+CONTEXTFORGE_REMOTE_TOKEN=change-me \
+node src/cli.js dbInfo
+```
+
+## HTTP 서버
+
+서버 실행:
+
+```bash
+CONTEXTFORGE_REMOTE_TOKEN=change-me \
+node src/cli.js serve --host 127.0.0.1 --port 8765
+```
+
+서버는 `/mcp`, `/v0/*`, `/healthz`, `/ui/`를 제공한다. token이 설정되어 있으면
+remote API 호출에는 `CONTEXTFORGE_REMOTE_TOKEN`이 필요하다.
+
+운영 UI는 `/ui/`에서 사용할 수 있다. UI에서는 runtime 설정, distill provider,
+모델, threshold, memory candidates, durable memory correction 등을 확인하고
+수정할 수 있다. API key는 write-only로 저장되며 응답에 노출되지 않는다.
+
+## 모델 분리
+
+ContextForge는 distill과 audit을 분리하는 구성을 권장한다.
+
+```text
+distill:
+  codex_exec / gpt-5.4-mini / low
+
+audit:
+  codex_sdk_python 또는 codex_exec / gpt-5.5 / low
+
+embedding:
+  text-embedding-3-small / 1536 dimensions
+```
+
+distill은 raw evidence를 checkpoint와 memory candidate로 압축한다. audit은 이미
+만들어진 candidate를 durable memory로 자동 승격해도 되는지 별도로 판단한다.
+이렇게 하면 비용이 큰 모델을 모든 distill에 쓰지 않고, 중요한 승격 판단에만
+더 강한 모델을 사용할 수 있다.
+
+## Distillation
+
+지원 provider:
+
+- `mock`
+- `codex_exec`
+- `openai_compatible`
+
+`codex_exec`는 Codex CLI를 실행해 JSON-only checkpoint output을 받고,
+로컬 schema validation을 통과한 결과만 저장한다.
+
+예시:
+
+```bash
+CONTEXTFORGE_DISTILL_PROVIDER=codex_exec \
+CONTEXTFORGE_CODEX_EXEC_MODEL=gpt-5.4-mini \
+CONTEXTFORGE_CODEX_EXEC_REASONING_EFFORT=low \
+node src/cli.js distillCheckpoint \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --sessionId demo-session
+```
+
+DeepSeek 같은 Chat Completions 호환 provider는 `openai_compatible`로 사용할 수
+있다.
+
+```bash
+CONTEXTFORGE_DISTILL_PROVIDER=openai_compatible \
+CONTEXTFORGE_OPENAI_COMPATIBLE_PRESET=deepseek \
+CONTEXTFORGE_OPENAI_COMPATIBLE_BASE_URL=https://api.deepseek.com \
+CONTEXTFORGE_OPENAI_COMPATIBLE_MODEL=deepseek-v4-flash \
+CONTEXTFORGE_OPENAI_COMPATIBLE_RESPONSE_FORMAT=json_object \
+CONTEXTFORGE_OPENAI_COMPATIBLE_API_KEY=sk-... \
+node src/cli.js distillCheckpoint \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --sessionId demo-session
+```
+
+## 구조화 checkpoint
+
+checkpoint provider는 선택적으로 `structured` payload를 반환할 수 있다.
+
+```json
+{
+  "structured": {
+    "schemaVersion": "contextforge.structured_checkpoint.v1",
+    "work": {
+      "intent": "사용자가 원한 것",
+      "status": "in_progress | implemented | verified | blocked | abandoned",
+      "outcome": "실제로 끝난 상태"
+    },
+    "liveState": {
+      "repo": "github.com/example/contextforge",
+      "branch": "feature/example",
+      "headCommit": "abcdef0",
+      "ciStatus": "pass | fail | pending | unknown",
+      "observedAt": "2026-06-03T00:00:00Z",
+      "verificationRequired": true,
+      "staleReasons": ["branch, commit, CI는 변할 수 있는 live state"],
+      "verifyHints": ["git status --short --branch", "gh pr view 123 --json statusCheckRollup"]
+    },
+    "changes": [],
+    "verification": [],
+    "risks": [],
+    "nextActions": []
+  }
+}
+```
+
+이 payload는 `checkpoint.metadata.structured`에 저장되고,
+`checkpoint.structured`로도 노출된다. durable memory가 아니라 handoff object다.
+따라서 branch, PR, commit, CI, runtime 상태는 반드시 live source에서 재확인해야
+한다.
+
+## Bootstrap과 Resume
+
+작업 시작 시 에이전트는 먼저 `bootstrap_context` 또는 `bootstrapContext`를
+호출한다.
+
+```bash
+node src/cli.js bootstrapContext \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --query "current task handoff"
+```
+
+응답의 주요 채널:
+
+- `handoff.latestHandoff`: 최신 checkpoint handoff. 검색 결과와 분리되어
+  deterministic하게 제공된다.
+- `handoff.latestCheckpoints`: 최근 checkpoint 목록.
+- `results`: durable memory, checkpoint, memory candidate 검색 결과.
+- `workingSummary`: sessionId를 알 때 가져오는 현재 세션 resume state.
+- `rawTail`: 필요한 경우에만 요청하는 최근 raw event 꼬리.
+
+에이전트는 `handoff.latestHandoff`를 먼저 읽고, `liveState.verifyHints`로
+branch/PR/CI/worktree를 재검증한 뒤 durable memory와 검색 결과를 참고해야 한다.
+
+## Memory Candidate와 감사
+
+distill은 durable memory를 직접 쓰지 않는다. 대신 후보를 만든다.
+
+candidate는 다음과 같은 review field를 가질 수 있다.
+
+- `durabilityReason`
+- `riskReason`
+- `evidenceRefs`
+- `suggestedAction`
+
+provider의 `suggestedAction`은 자동 승인으로 취급하지 않는다. 제안은
+`providerSuggestedAction`으로 노출되고, 실제 승격은 사용자의 선택 또는 별도 audit
+gate를 통과해야 한다.
+
+read-only 후보 검토:
+
+```bash
+node src/cli.js suggestMemoryPromotions \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --checkpointId checkpoint-id \
+  --trigger manual_closeout
+```
+
+자동승격 dry-run:
+
+```bash
+node src/cli.js autoPromoteMemoryCandidates \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --checkpointId checkpoint-id \
+  --trigger manual_closeout \
+  --dryRun true
+```
+
+`dryRun=false`는 `CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true`인 trusted deployment에서만
+사용해야 한다.
+
+## Python SDK 감사 provider
+
+Python 백엔드나 Python 서비스와의 연결을 실험할 때는 `codex_sdk_python` 감사
+provider를 사용할 수 있다. 이 provider는 Codex Python SDK runner를 통해 Codex
+thread를 열고, 기존 Codex binary를 runtime으로 사용한다.
+
+환경 변수 예시:
+
+```bash
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER=codex_sdk_python
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_BIN=/home/ubuntu/.local/bin/codex
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHON_COMMAND=python3
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHONPATH=/opt/contextforge/openai-codex-sdk
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_MODEL=gpt-5.5
+CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_REASONING_EFFORT=low
+```
+
+SDK target 설치 예시:
+
+```bash
+uv pip install --python /path/to/python3 \
+  --target /opt/contextforge/openai-codex-sdk \
+  --no-deps openai-codex
+
+uv pip install --python /path/to/python3 \
+  --target /opt/contextforge/openai-codex-sdk \
+  'pydantic>=2.12'
+```
+
+중요: target 디렉터리는 서버가 실제로 실행할 Python interpreter 기준으로 만들어야
+한다. 예를 들어 서버 runner가 `/usr/bin/python3` 3.12를 쓰는데 `uv` 기본 Python
+3.11로 target을 만들면 `pydantic-core` 같은 native wheel import가 실패할 수
+있다.
+
+## MCP 사용 원칙
+
+ContextForge MCP는 repo/shared/local scope를 명시적으로 다룬다.
+
+작업 시작:
+
+1. `bootstrap_context`를 repo scope로 호출한다.
+2. `handoff.latestHandoff`와 `handoff.latestCheckpoints`를 먼저 읽는다.
+3. live state는 source에서 재검증한다.
+4. durable memory와 search results를 그 다음 참고한다.
+
+작업 종료:
+
+1. 필요하면 `session_status`로 distill 필요성을 확인한다.
+2. `distill_checkpoint`로 checkpoint를 만든다.
+3. `suggest_memory_promotions` 또는 `list_memory_candidates`로 후보를 검토한다.
+4. stable하고 비밀이 아닌 사실만 `promote_memory_candidate`로 승격한다.
+
+`bootstrap_context`는 세션을 만들지 않는다. Codex/Claude adapter가 ingest한
+세션을 닫을 때는 새 `cf_...` 세션을 만들지 말고 기존 `codex:<id>` 또는
+`claude_code:<id>`를 사용해야 한다.
+
+## Embeddings
+
+retrieval 품질을 위해 embedding index를 권장한다.
+
+기본 권장 모델:
+
+```text
+provider: openai
+model: text-embedding-3-small
+dimensions: 1536
+```
+
+embedding job은 checkpoint/memory write와 분리되어 있어서 실패해도 durable
+memory나 checkpoint가 사라지지 않는다. 실패하거나 멈춘 job은
+`processEmbeddingJobs`로 재시도할 수 있다.
+
+## 안전 원칙
+
+- `.db`, `.db-wal`, `.db-shm`, raw log, `.env` 파일을 git에 넣지 않는다.
+- raw evidence는 보존하되, 긴 tool output dump를 checkpoint 본문으로 복사하지
+  않는다.
+- checkpoint는 최근 handoff state이고 durable truth가 아니다.
+- secrets, tokens, credentials, customer data, PII는 memory로 승격하지 않는다.
+- mutable live state는 항상 source에서 다시 확인한다.
+
+## 개발
+
+테스트:
+
+```bash
+npm test
+```
+
+서버:
+
+```bash
+node src/server.js
+```
+
+MCP:
+
+```bash
+node src/mcp.js
+```
+
+스토리지 확인:
+
+```bash
+node src/cli.js dbInfo
+```
+
+## 더 보기
+
+- [Architecture](docs/architecture.md)
+- [Runtime modes](docs/runtime-modes.md)
+- [Roadmap](docs/roadmap.md)
+- [Changelog](CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -947,6 +947,43 @@ receives it together with the new raw-event window so it can update current
 state instead of emitting a delta-only summary. Treat it as current session
 state, not reviewed durable memory.
 
+Checkpoint providers may also return an optional structured handoff payload:
+
+```json
+{
+  "structured": {
+    "schemaVersion": "contextforge.structured_checkpoint.v1",
+    "work": {
+      "intent": "What the user wanted",
+      "status": "in_progress | implemented | verified | blocked | abandoned",
+      "outcome": "What actually happened"
+    },
+    "liveState": {
+      "repo": "github.com/example/contextforge",
+      "branch": "feature/example",
+      "headCommit": "abcdef0",
+      "ciStatus": "pass | fail | pending | unknown",
+      "observedAt": "2026-06-03T00:00:00Z",
+      "verificationRequired": true,
+      "staleReasons": ["branch, commit, and CI are mutable live state"],
+      "verifyHints": ["git status --short --branch", "gh pr view 123 --json statusCheckRollup"]
+    },
+    "changes": [],
+    "verification": [],
+    "risks": [],
+    "nextActions": []
+  }
+}
+```
+
+The structured payload is stored as `checkpoint.metadata.structured` and exposed
+as `checkpoint.structured`. It is a handoff object, not durable memory. Mutable
+branch, PR, commit, CI, worktree, runtime, and deployment state may appear in
+`liveState`, but agents must treat it as observed state and recheck it before
+acting. Memory candidates can include optional review fields such as
+`durabilityReason`, `riskReason`, `evidenceRefs`, and `suggestedAction`; these
+fields are preserved in the candidate index for suggestion and audit surfaces.
+
 `bootstrapContext` includes recent checkpoint handoff separately from ordinary
 query results. By default it returns the latest level-0 checkpoint for the
 requested scope in `handoff.latestCheckpoints`, even when that checkpoint does
@@ -977,6 +1014,9 @@ The bootstrap response keeps these channels separate:
   independently of query ranking; read these before durable memory for current
   work status, recent decisions, open todos, branch/PR/CI flow, and next
   actions.
+- `handoff.latestHandoff`: the first latest checkpoint in deterministic handoff
+  order, including structured handoff payload and live-state stale warnings when
+  available.
 - `results`: durable memories, checkpoints, and memory candidates from search.
 - `workingSummary`: latest rolling handoff state for the requested session.
 - `rawTail`: newest raw events for last-mile continuity.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Self-hosted memory and distillation runtime for coding agents.
 
+[한국어 README](README.ko.md)
+
 This is not another memory file. ContextForge is a scoped memory runtime for
 coding agents.
 
@@ -17,12 +19,28 @@ ContextForge is a sidecar memory runtime. It complements existing agent memory
 systems by providing canonical project/repo memory, evidence retention, and
 LLM-backed distillation.
 
-Current 0.4.x builds add a server-hosted operator UI, DB-backed runtime
-settings, OpenAI-compatible distillation for DeepSeek-style Chat Completions
-APIs, separate auto-promotion audit runners, remote-first MCP workflows,
-start/resume handoff tools, correction reconciliation, hybrid retrieval, and an
-embedding job queue so vector indexing can recover independently from memory or
-checkpoint writes.
+Current 0.5.0 builds add structured checkpoint handoff payloads, deterministic
+`handoff.latestHandoff` bootstrap state, preserved memory-candidate review
+fields, a server-hosted operator UI, DB-backed runtime settings,
+OpenAI-compatible distillation for DeepSeek-style Chat Completions APIs,
+separate auto-promotion audit runners including the experimental
+`codex_sdk_python` audit provider, remote-first MCP workflows, correction
+reconciliation, hybrid retrieval, and an embedding job queue so vector indexing
+can recover independently from memory or checkpoint writes.
+
+## What's New In 0.5.0
+
+- Checkpoints can include an optional structured handoff object with work
+  status, observed live state, verification, risks, and next actions.
+- `bootstrapContext` and `syncResumeContext` expose
+  `handoff.latestHandoff` separately from ordinary search results, so agents can
+  read recent continuation state even when the query is narrow or unrelated.
+- Memory candidates preserve v2 review fields such as `durabilityReason`,
+  `riskReason`, `evidenceRefs`, and `suggestedAction` for audit and closeout
+  review surfaces.
+- Auto-promotion audit can run through either `codex_exec` or the experimental
+  `codex_sdk_python` provider. This keeps cheap distillation and stricter audit
+  decisions on separate model/runtime paths.
 
 ## Goals
 
@@ -86,6 +104,17 @@ and records provider run metadata, including prompt and output schema versions.
 The OpenAI-compatible provider calls Chat Completions APIs such as DeepSeek at
 `{baseUrl}/chat/completions`, validates the same checkpoint contract locally,
 and records provider metadata without returning API keys.
+
+Checkpoint output is intentionally split into three lanes:
+
+- human-readable summaries for quick inspection
+- structured handoff payloads for the next agent
+- memory candidates for reviewed durable-memory promotion
+
+For cost and quality separation, a common deployment uses a smaller model for
+distillation, for example `codex_exec` with `gpt-5.4-mini` and reasoning effort
+`low`, while using a stronger audit runner such as `gpt-5.5` with reasoning
+effort `low` before any automatic durable-memory promotion.
 
 ## Quick Start
 
@@ -301,6 +330,11 @@ CONTEXTFORGE_AUTO_PROMOTE_AUDIT_ENABLED=true
 CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER=codex_exec
 CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_MODEL=gpt-5.5
 CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_REASONING_EFFORT=low
+# For Python-backed audit deployments, use codex_sdk_python instead:
+# CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER=codex_sdk_python
+# CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_BIN=/home/ubuntu/.local/bin/codex
+# CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHON_COMMAND=python3
+# CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHONPATH=/opt/contextforge/openai-codex-sdk
 ```
 
 The default and recommended embedding model is `text-embedding-3-small`.
@@ -340,9 +374,18 @@ dependency into the configured `PYTHONPATH`, then rely on
 `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_BIN` for the runtime binary:
 
 ```bash
-uv pip install --target /opt/contextforge/openai-codex-sdk --no-deps openai-codex
-uv pip install --target /opt/contextforge/openai-codex-sdk 'pydantic>=2.12'
+uv pip install --python /path/to/python3 \
+  --target /opt/contextforge/openai-codex-sdk \
+  --no-deps openai-codex
+uv pip install --python /path/to/python3 \
+  --target /opt/contextforge/openai-codex-sdk \
+  'pydantic>=2.12'
 ```
+
+Use the same Python interpreter that the ContextForge server will run through
+`CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHON_COMMAND`. If the target directory is
+built with a different Python version, native wheels such as `pydantic-core`
+may fail to import at audit time.
 
 Use a long random token and store the same value on client machines as
 `CONTEXTFORGE_REMOTE_TOKEN`. Treat this token as an administrator credential:
@@ -1452,9 +1495,16 @@ distillation runner:
 
 - `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_ENABLED`: set to `false` to disable the
   audit gate and rely only on local strict checks. Default: enabled.
-- `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER`: currently `codex_exec`.
+- `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PROVIDER`: `codex_exec` or
+  `codex_sdk_python`.
 - `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_COMMAND`: Codex executable for the
   audit runner. Defaults to `CONTEXTFORGE_CODEX_EXEC_COMMAND` or `codex`.
+- `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_BIN`: Codex binary used by the
+  `codex_sdk_python` provider. Defaults to the audit command.
+- `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHON_COMMAND`: Python executable for the
+  `codex_sdk_python` runner. Default: `python3`.
+- `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_PYTHONPATH`: optional target directory
+  containing the Codex Python SDK and dependencies.
 - `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_MODEL`: audit model. Default:
   `gpt-5.5`.
 - `CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_REASONING_EFFORT`: audit reasoning

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,6 +212,8 @@ Provider outputs should include:
 - `decisions`
 - `todos`
 - `openQuestions`
+- optional `structured` handoff state with
+  `schemaVersion: "contextforge.structured_checkpoint.v1"`
 - `memoryCandidates`
 - `sourceEventCount`
 - `provider`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contextforge",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contextforge",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contextforge",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Self-hosted memory and distillation runtime for coding agents.",
   "type": "module",
   "bin": {
@@ -14,6 +14,7 @@
     "examples",
     "docs",
     "README.md",
+    "README.ko.md",
     "LICENSE"
   ],
   "engines": {

--- a/src/core.js
+++ b/src/core.js
@@ -5,7 +5,7 @@ import { loadConfig } from './config/index.js';
 import { createDistillProvider } from './distill/index.js';
 import { checkCodexExecProvider } from './distill/providers/codex_exec.js';
 import { checkOpenAiCompatibleProvider } from './distill/providers/openai_compatible.js';
-import { validateDistillOutput } from './distill/validate.js';
+import { STRUCTURED_CHECKPOINT_SCHEMA_VERSION, validateDistillOutput } from './distill/validate.js';
 import { createEmbeddingProvider } from './embeddings/index.js';
 import { createRemoteContextForge } from './remote/client.js';
 import { searchMemories } from './retrieval/search.js';
@@ -479,8 +479,46 @@ function bootstrapRawTailEvent(event) {
   };
 }
 
+function structuredForCheckpoint(checkpoint) {
+  return checkpoint?.structured || checkpoint?.metadata?.structured || null;
+}
+
+function structuredLiveStateWarnings(structured) {
+  const liveState = structured?.liveState;
+  if (!liveState || typeof liveState !== 'object' || Array.isArray(liveState)) {
+    return [];
+  }
+  const mutableFields = [
+    'repo',
+    'branch',
+    'baseBranch',
+    'headCommit',
+    'prNumber',
+    'prUrl',
+    'ciStatus',
+    'worktreeStatus',
+    'runtimeStatus',
+    'deploymentStatus',
+  ].filter((field) => liveState[field] != null && liveState[field] !== '');
+  if (!mutableFields.length && !liveState.verificationRequired) {
+    return [];
+  }
+  return [
+    {
+      code: 'live_state_may_be_stale',
+      fields: mutableFields.map((field) => `liveState.${field}`),
+      observedAt: liveState.observedAt || liveState.verifiedAt || null,
+      staleReasons: Array.isArray(liveState.staleReasons) ? liveState.staleReasons : [],
+      verifyHints: Array.isArray(liveState.verifyHints) ? liveState.verifyHints : [],
+      message: 'Structured checkpoint liveState is observed mutable state; verify it against live sources before acting.',
+    },
+  ];
+}
+
 function checkpointHandoffCompact(checkpoint, scope) {
   const sourceEventWindow = checkpoint.metadata?.sourceEventWindow || null;
+  const structured = structuredForCheckpoint(checkpoint);
+  const structuredWarnings = structuredLiveStateWarnings(structured);
   return {
     type: 'checkpoint',
     trust: 'credible_recent_handoff',
@@ -504,6 +542,8 @@ function checkpointHandoffCompact(checkpoint, scope) {
     openQuestions: checkpoint.openQuestions || [],
     sourceEventCount: checkpoint.sourceEventCount,
     provider: checkpoint.provider,
+    structured,
+    ...(structuredWarnings.length ? { structuredWarnings } : {}),
     ...(sourceEventWindow
       ? {
           sourceEventWindow: {
@@ -760,6 +800,7 @@ function resumeCheckpoint(result) {
 }
 
 function checkpointHandoffResult(checkpoint, group = 'session') {
+  const structured = structuredForCheckpoint(checkpoint);
   return resumeCheckpoint({
     group,
     type: 'checkpoint',
@@ -786,11 +827,14 @@ function checkpointHandoffResult(checkpoint, group = 'session') {
     coversTo: checkpoint.coversTo,
     checkpointSource: checkpoint.source,
     sourceRef: checkpoint.sourceRef,
+    structured,
+    structuredWarnings: structuredLiveStateWarnings(structured),
     createdAt: checkpoint.createdAt,
   });
 }
 
 function checkpointBasisResult(checkpoint) {
+  const structured = structuredForCheckpoint(checkpoint);
   return {
     type: 'checkpoint',
     key: checkpoint.id,
@@ -818,6 +862,8 @@ function checkpointBasisResult(checkpoint) {
     coversTo: checkpoint.coversTo,
     checkpointSource: checkpoint.source,
     sourceRef: checkpoint.sourceRef,
+    structured,
+    structuredWarnings: structuredLiveStateWarnings(structured),
   };
 }
 
@@ -880,7 +926,7 @@ function scorePromotionCandidate(indexedCandidate, warnings, skipWarningCodes = 
 
 function promotionProposal(indexedCandidate, warnings, rank) {
   const candidate = indexedCandidate.candidate || {};
-  return {
+  const proposal = {
     rank,
     candidateId: indexedCandidate.id,
     scope: indexedCandidate.scopeType,
@@ -894,10 +940,23 @@ function promotionProposal(indexedCandidate, warnings, rank) {
       checkpointId: indexedCandidate.checkpointId,
       sessionId: indexedCandidate.sessionId,
     },
-    whyDurable: candidate.reason || 'Candidate appears stable and useful beyond the current checkpoint.',
+    whyDurable:
+      candidate.durabilityReason ||
+      candidate.reason ||
+      'Candidate appears stable and useful beyond the current checkpoint.',
     warnings,
-    recommendedAction: 'ask_user',
+    recommendedAction: candidate.suggestedAction || 'ask_user',
   };
+  if (candidate.riskReason) {
+    proposal.riskReason = candidate.riskReason;
+  }
+  if (Array.isArray(candidate.evidenceRefs) && candidate.evidenceRefs.length) {
+    proposal.evidence.evidenceRefs = candidate.evidenceRefs;
+  }
+  if (candidate.schemaVersion) {
+    proposal.candidateSchemaVersion = candidate.schemaVersion;
+  }
+  return proposal;
 }
 
 function memoryUpdateCandidateProposal(candidate) {
@@ -1919,6 +1978,7 @@ export function createContextForge(options = {}) {
                   .map((checkpoint) => checkpointHandoffCompact(checkpoint, handoffScope)),
               )
             : [];
+        const latestHandoff = latestCheckpoints[0] || null;
         const workingSummary = sessionId
           ? bootstrapWorkingSummary(store.getWorkingSummary({ ...scope, sessionId }))
           : null;
@@ -1937,6 +1997,7 @@ export function createContextForge(options = {}) {
           includeShared,
           sharedLimit: includeShared ? sharedLimit : null,
           handoff: {
+            latestHandoff,
             latestCheckpoints,
             latestCheckpointLimit,
             relatedScopeKeys,
@@ -2002,6 +2063,7 @@ export function createContextForge(options = {}) {
         includeShared: bootstrap.includeShared,
         ...(bootstrap.sessionId ? { sessionId: bootstrap.sessionId } : {}),
         handoff: {
+          latestHandoff: bootstrap.handoff?.latestHandoff || null,
           workingSummary: bootstrap.workingSummary || null,
           structuredWorkingContext: bootstrap.structuredWorkingContext || null,
           rawTail: bootstrap.rawTail || [],
@@ -3802,6 +3864,10 @@ export function createContextForge(options = {}) {
           openQuestions: 'string[]',
           workingSummary: 'string',
           sessionWorkingContext: 'object?',
+          structured: {
+            schemaVersion: STRUCTURED_CHECKPOINT_SCHEMA_VERSION,
+            optional: true,
+          },
           memoryCandidates: 'object[]',
           sourceEventCount: 'number',
           provider: 'string',
@@ -3887,6 +3953,7 @@ export function createContextForge(options = {}) {
           metadata: {
             providerMetadata: output.metadata,
             memoryCandidates: output.memoryCandidates,
+            structured: output.structured || null,
             sourceProvenance,
             sourceRawEventIds: selectedRawEvents.map((event) => event.id),
             sourceEventWindow: distillWindow.metadata,

--- a/src/core.js
+++ b/src/core.js
@@ -327,6 +327,7 @@ function resultTextForVerification(result) {
       ...(result.checkpoint.decisions || []),
       ...(result.checkpoint.todos || []),
       ...(result.checkpoint.openQuestions || []),
+      structuredVerificationText(result.checkpoint.structured || result.checkpoint.metadata?.structured),
     ].join(' ');
   }
   if (result.candidate) {
@@ -339,6 +340,28 @@ function resultTextForVerification(result) {
     ].join(' ');
   }
   return '';
+}
+
+function structuredVerificationText(structured) {
+  if (!structured || typeof structured !== 'object' || Array.isArray(structured)) {
+    return '';
+  }
+  const liveState = structured.liveState && typeof structured.liveState === 'object' ? structured.liveState : {};
+  const values = [
+    liveState.repo,
+    liveState.branch,
+    liveState.baseBranch,
+    liveState.headCommit,
+    liveState.prNumber == null || liveState.prNumber === '' ? '' : `PR #${liveState.prNumber}`,
+    liveState.prUrl,
+    liveState.ciStatus,
+    liveState.worktreeStatus,
+    liveState.runtimeStatus,
+    liveState.deploymentStatus,
+    ...(Array.isArray(liveState.staleReasons) ? liveState.staleReasons : []),
+    ...(Array.isArray(liveState.verifyHints) ? liveState.verifyHints : []),
+  ];
+  return values.filter(Boolean).join(' ');
 }
 
 function requiresLiveStateVerification(result) {
@@ -502,6 +525,18 @@ function structuredLiveStateWarnings(structured) {
   ].filter((field) => liveState[field] != null && liveState[field] !== '');
   if (!mutableFields.length && !liveState.verificationRequired) {
     return [];
+  }
+  if (!mutableFields.length) {
+    return [
+      {
+        code: 'verification_required',
+        fields: [],
+        observedAt: liveState.observedAt || liveState.verifiedAt || null,
+        staleReasons: Array.isArray(liveState.staleReasons) ? liveState.staleReasons : [],
+        verifyHints: Array.isArray(liveState.verifyHints) ? liveState.verifyHints : [],
+        message: 'Structured checkpoint liveState requires live verification before acting.',
+      },
+    ];
   }
   return [
     {
@@ -939,19 +974,22 @@ function promotionProposal(indexedCandidate, warnings, rank) {
       sourceEventIds: candidate.sourceEventIds || [],
       checkpointId: indexedCandidate.checkpointId,
       sessionId: indexedCandidate.sessionId,
+      ...(Array.isArray(candidate.evidenceRefs) && candidate.evidenceRefs.length
+        ? { evidenceRefs: candidate.evidenceRefs }
+        : {}),
     },
     whyDurable:
       candidate.durabilityReason ||
       candidate.reason ||
       'Candidate appears stable and useful beyond the current checkpoint.',
     warnings,
-    recommendedAction: candidate.suggestedAction || 'ask_user',
+    recommendedAction: 'ask_user',
   };
+  if (candidate.suggestedAction) {
+    proposal.providerSuggestedAction = candidate.suggestedAction;
+  }
   if (candidate.riskReason) {
     proposal.riskReason = candidate.riskReason;
-  }
-  if (Array.isArray(candidate.evidenceRefs) && candidate.evidenceRefs.length) {
-    proposal.evidence.evidenceRefs = candidate.evidenceRefs;
   }
   if (candidate.schemaVersion) {
     proposal.candidateSchemaVersion = candidate.schemaVersion;

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -94,7 +94,7 @@ export const CHECKPOINT_OUTPUT_SCHEMA = {
           schemaVersion: { type: ['string', 'null'] },
           durabilityReason: { type: ['string', 'null'] },
           riskReason: { type: ['string', 'null'] },
-          evidenceRefs: { type: 'array', items: { type: 'string' } },
+          evidenceRefs: { type: ['array', 'null'], items: { type: 'string' } },
           suggestedAction: { type: ['string', 'null'], enum: ['promote', 'review', 'reject', 'skip', null] },
         },
       },

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -2,9 +2,10 @@ import { spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { STRUCTURED_CHECKPOINT_SCHEMA_VERSION } from '../validate.js';
 
-export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v6';
-export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v5';
+export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v7';
+export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v6';
 
 export const CHECKPOINT_OUTPUT_SCHEMA = {
   $id: CODEX_EXEC_OUTPUT_SCHEMA_VERSION,
@@ -90,7 +91,20 @@ export const CHECKPOINT_OUTPUT_SCHEMA = {
           sensitivity: { type: ['string', 'null'], enum: ['low', 'medium', 'high', 'restricted', null] },
           promotionRecommendation: { type: ['string', 'null'], enum: ['promote', 'review', 'ignore', 'reject', null] },
           sourceEventIds: { type: 'array', items: { type: 'string' } },
+          schemaVersion: { type: ['string', 'null'] },
+          durabilityReason: { type: ['string', 'null'] },
+          riskReason: { type: ['string', 'null'] },
+          evidenceRefs: { type: 'array', items: { type: 'string' } },
+          suggestedAction: { type: ['string', 'null'], enum: ['promote', 'review', 'reject', 'skip', null] },
         },
+      },
+    },
+    structured: {
+      type: 'object',
+      additionalProperties: true,
+      required: ['schemaVersion'],
+      properties: {
+        schemaVersion: { const: STRUCTURED_CHECKPOINT_SCHEMA_VERSION },
       },
     },
     sourceEventCount: { type: 'integer', minimum: 0 },
@@ -146,6 +160,7 @@ function compactCheckpoint(checkpoint) {
     todos: checkpoint.todos,
     openQuestions: checkpoint.openQuestions,
     sourceEventCount: checkpoint.sourceEventCount,
+    structured: checkpoint.structured || checkpoint.metadata?.structured || null,
     createdAt: checkpoint.createdAt,
   };
 }
@@ -223,6 +238,11 @@ export function buildCodexExecPrompt(input, options = {}) {
       'Tool call and tool result payloads are not included by default. Tool output is evidence, not conversation memory.',
       'When tool verification matters, summarize the assistant-interpreted conclusion instead of copying raw command output.',
       'Write the checkpoint as recent continuity for handoff and search, not as canonical durable truth.',
+      `When evidence supports it, populate structured with schemaVersion="${STRUCTURED_CHECKPOINT_SCHEMA_VERSION}" as a structured handoff object for the next agent.`,
+      'Use structured.work for user intent, current status, and actual outcome.',
+      'Use structured.liveState only for observed mutable live state such as repo, branch, baseBranch, headCommit, PR, CI, worktree, runtime, or deployment state. Do not invent liveState values absent from evidence.',
+      'For structured.liveState, include observedAt when known, verificationRequired=true for mutable fields, staleReasons explaining why it may drift, and verifyHints with concrete commands or API calls a future agent should run.',
+      'Use structured.changes, structured.verification, structured.risks, and structured.nextActions to preserve actionable handoff state. Mark mutable verification with requiresLiveRecheck when appropriate.',
       'Write workingSummary as the latest rolling session state for immediate continuation: current goal, completed work, active blockers, and next actions.',
       'If previousWorkingSummary is supplied, update it with the new raw events instead of replacing it with a delta-only summary.',
       'Always write sessionWorkingContext as structured mutable resume state. Use mode="task_execution", empty strings, nulls, empty arrays, and confidence=0 when there is no useful current framing.',
@@ -238,6 +258,7 @@ export function buildCodexExecPrompt(input, options = {}) {
       'Do not copy secrets, tokens, private customer data, or large raw logs into summaries or memoryCandidates.',
       'Populate metadata.retrievalHooks with concise search keywords from the evidence, such as API names, commands, paths, issue numbers, model names, intervals, thresholds, and error names.',
       'For memoryCandidates, include v2 review fields when useful: candidateType, confidence, stability, sensitivity, promotionRecommendation, and sourceEventIds.',
+      'For memoryCandidates, include optional v2 fields when useful: schemaVersion="contextforge.memory_candidate.v2", durabilityReason, riskReason, evidenceRefs, and suggestedAction.',
       'For nullable memoryCandidate fields that are not applicable, return null; do not omit required schema fields.',
       'Create memoryCandidates only for facts, decisions, preferences, runbook steps, or failure modes that may remain useful beyond this checkpoint.',
       'For memoryCandidate content, include decision plus rationale when both exist; put future-search keywords in tags and reason instead of flattening them away.',

--- a/src/distill/validate.js
+++ b/src/distill/validate.js
@@ -1,3 +1,5 @@
+export const STRUCTURED_CHECKPOINT_SCHEMA_VERSION = 'contextforge.structured_checkpoint.v1';
+
 const ARRAY_FIELDS = ['decisions', 'todos', 'openQuestions', 'memoryCandidates'];
 
 function receivedType(value) {
@@ -16,6 +18,19 @@ function assertArray(value, field) {
   if (!Array.isArray(value)) {
     throw new Error(`Provider output field "${field}" must be an array; received ${receivedType(value)}.`);
   }
+}
+
+function normalizeStructuredCheckpoint(value) {
+  if (value == null) return null;
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Provider output field "structured" must be an object when present; received ${receivedType(value)}.`);
+  }
+  if (value.schemaVersion !== STRUCTURED_CHECKPOINT_SCHEMA_VERSION) {
+    throw new Error(
+      `Provider output field "structured.schemaVersion" must be "${STRUCTURED_CHECKPOINT_SCHEMA_VERSION}".`,
+    );
+  }
+  return value;
 }
 
 export function validateDistillOutput(output) {
@@ -64,6 +79,8 @@ export function validateDistillOutput(output) {
     );
   }
 
+  const structured = normalizeStructuredCheckpoint(output.structured);
+
   return {
     summaryShort: output.summaryShort,
     summaryText: output.summaryText,
@@ -75,6 +92,7 @@ export function validateDistillOutput(output) {
         ? output.workingSummary
         : output.summaryText,
     memoryCandidates: output.memoryCandidates,
+    structured,
     sessionWorkingContext: output.sessionWorkingContext || null,
     sourceEventCount: output.sourceEventCount,
     provider: output.provider,

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -4,7 +4,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import Database from 'better-sqlite3';
 import * as sqliteVec from 'sqlite-vec';
 
-export const SCHEMA_VERSION = 15;
+export const SCHEMA_VERSION = 16;
 
 function nowIso() {
   return new Date().toISOString();
@@ -62,6 +62,7 @@ function hydrateRawEvent(row) {
 
 function hydrateCheckpoint(row) {
   if (!row) return null;
+  const metadata = parseJson(row.metadata_json, {});
   return {
     id: row.id,
     scopeType: row.scope_type,
@@ -81,7 +82,8 @@ function hydrateCheckpoint(row) {
     coversTo: row.covers_to,
     source: row.source || 'distill',
     sourceRef: row.source_ref,
-    metadata: parseJson(row.metadata_json, {}),
+    metadata,
+    structured: metadata.structured || null,
     createdAt: row.created_at,
   };
 }
@@ -164,6 +166,7 @@ function hydrateMemoryEvent(row) {
 
 function hydrateMemoryCandidate(row) {
   if (!row) return null;
+  const candidateJson = parseJson(row.candidate_json, {});
   const tags = parseJson(row.tags_json, []);
   return {
     type: 'memory_candidate',
@@ -176,6 +179,7 @@ function hydrateMemoryCandidate(row) {
     index: row.candidate_index,
     status: row.status,
     candidate: {
+      ...(candidateJson && typeof candidateJson === 'object' && !Array.isArray(candidateJson) ? candidateJson : {}),
       key: row.candidate_key,
       content: row.candidate_content,
       reason: row.candidate_reason,
@@ -324,6 +328,7 @@ function validateDimensions(dimensions) {
 function normalizeCandidate(candidate) {
   const value = candidate && typeof candidate === 'object' && !Array.isArray(candidate) ? candidate : {};
   return {
+    schemaVersion: value.schemaVersion ? String(value.schemaVersion) : null,
     key: String(value.key || ''),
     content: String(value.content || ''),
     reason: String(value.reason || ''),
@@ -336,7 +341,62 @@ function normalizeCandidate(candidate) {
     sensitivity: value.sensitivity ? String(value.sensitivity) : null,
     promotionRecommendation: value.promotionRecommendation ? String(value.promotionRecommendation) : null,
     sourceEventIds: Array.isArray(value.sourceEventIds) ? value.sourceEventIds.map((item) => String(item)) : [],
+    durabilityReason: value.durabilityReason ? String(value.durabilityReason) : null,
+    riskReason: value.riskReason ? String(value.riskReason) : null,
+    evidenceRefs: Array.isArray(value.evidenceRefs) ? value.evidenceRefs.map((item) => String(item)) : [],
+    suggestedAction: value.suggestedAction ? String(value.suggestedAction) : null,
   };
+}
+
+function candidateJsonForIndex(rawCandidate, candidate) {
+  const raw = rawCandidate && typeof rawCandidate === 'object' && !Array.isArray(rawCandidate) ? rawCandidate : {};
+  return {
+    ...raw,
+    ...candidate,
+  };
+}
+
+function stringValue(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : '';
+}
+
+function structuredItemsText(items, fields) {
+  if (!Array.isArray(items)) return [];
+  return items
+    .map((item) => {
+      if (typeof item === 'string') return item;
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return '';
+      return fields.map((field) => stringValue(item[field])).filter(Boolean).join(' ');
+    })
+    .filter(Boolean);
+}
+
+function structuredCheckpointEmbeddingText(structured) {
+  if (!structured || typeof structured !== 'object' || Array.isArray(structured)) {
+    return '';
+  }
+  const work = structured.work && typeof structured.work === 'object' ? structured.work : {};
+  const liveState = structured.liveState && typeof structured.liveState === 'object' ? structured.liveState : {};
+  const prNumber = liveState.prNumber == null || liveState.prNumber === '' ? '' : `PR #${liveState.prNumber}`;
+  return [
+    stringValue(work.intent),
+    stringValue(work.status),
+    stringValue(work.outcome),
+    stringValue(liveState.repo),
+    stringValue(liveState.branch),
+    stringValue(liveState.baseBranch),
+    stringValue(liveState.headCommit),
+    prNumber,
+    stringValue(liveState.ciStatus),
+    stringValue(liveState.worktreeStatus),
+    ...structuredItemsText(structured.changes, ['type', 'name', 'path', 'description']),
+    ...structuredItemsText(structured.verification, ['type', 'command', 'result', 'details']),
+    ...structuredItemsText(structured.decisions, ['decision', 'reason', 'durability']),
+    ...structuredItemsText(structured.risks, ['risk', 'status', 'mitigation']),
+    ...structuredItemsText(structured.nextActions, ['action', 'priority', 'reason']),
+  ]
+    .filter(Boolean)
+    .join('\n');
 }
 
 function normalizeStringList(value) {
@@ -555,6 +615,7 @@ export class ContextForgeStore {
         sensitivity TEXT,
         promotion_recommendation TEXT,
         source_event_ids_json TEXT NOT NULL DEFAULT '[]',
+        candidate_json TEXT NOT NULL DEFAULT '{}',
         status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'promoted', 'rejected', 'stale', 'snoozed')),
         created_at TEXT NOT NULL,
         reviewed_at TEXT,
@@ -694,6 +755,7 @@ export class ContextForgeStore {
     this.ensureColumn('memory_candidate_index', 'sensitivity', 'TEXT');
     this.ensureColumn('memory_candidate_index', 'promotion_recommendation', 'TEXT');
     this.ensureColumn('memory_candidate_index', 'source_event_ids_json', "TEXT NOT NULL DEFAULT '[]'");
+    this.ensureColumn('memory_candidate_index', 'candidate_json', "TEXT NOT NULL DEFAULT '{}'");
     this.ensureColumn('preference_occurrences', 'negative_count', 'INTEGER NOT NULL DEFAULT 0');
     this.ensureColumn('preference_occurrences', 'last_correction', 'TEXT');
     this.ensureColumn('preference_occurrences', 'review_reason', 'TEXT');
@@ -704,6 +766,7 @@ export class ContextForgeStore {
     this.ensureColumn('embedding_jobs', 'last_error', 'TEXT');
     this.ensureColumn('embedding_jobs', 'completed_at', 'TEXT');
     this.backfillMemoryCandidateIndexOnce();
+    this.backfillMemoryCandidateJsonOnce();
     this.backfillPreferenceOccurrencesOnce();
     this.ensureMemoryFts();
 
@@ -840,6 +903,7 @@ export class ContextForgeStore {
       checkpoint.todos.length ? `todos: ${checkpoint.todos.join('\n')}` : '',
       checkpoint.openQuestions.length ? `open questions: ${checkpoint.openQuestions.join('\n')}` : '',
       retrievalHooks.length ? `retrieval hooks: ${retrievalHooks.join(', ')}` : '',
+      structuredCheckpointEmbeddingText(checkpoint.structured || checkpoint.metadata?.structured),
     ]
       .filter(Boolean)
       .join('\n');
@@ -1461,6 +1525,46 @@ export class ContextForgeStore {
       .run(nowIso());
   }
 
+  backfillMemoryCandidateJsonOnce() {
+    const completed = this.db
+      .prepare("SELECT value FROM schema_meta WHERE key = 'memory_candidate_json_backfill_completed_at'")
+      .get();
+    if (completed?.value) {
+      return;
+    }
+    const rows = this.db
+      .prepare(`
+        SELECT
+          memory_candidate_index.id,
+          memory_candidate_index.candidate_index,
+          checkpoints.metadata_json
+        FROM memory_candidate_index
+        JOIN checkpoints ON checkpoints.id = memory_candidate_index.checkpoint_id
+        WHERE memory_candidate_index.candidate_json IS NULL
+           OR memory_candidate_index.candidate_json = '{}'
+      `)
+      .all();
+    const update = this.db.prepare('UPDATE memory_candidate_index SET candidate_json = ? WHERE id = ?');
+    for (const row of rows) {
+      const checkpointMetadata = parseJson(row.metadata_json, {});
+      const rawCandidate = Array.isArray(checkpointMetadata.memoryCandidates)
+        ? checkpointMetadata.memoryCandidates[row.candidate_index]
+        : null;
+      if (!rawCandidate) {
+        continue;
+      }
+      const candidate = normalizeCandidate(rawCandidate);
+      update.run(json(candidateJsonForIndex(rawCandidate, candidate), {}), row.id);
+    }
+    this.db
+      .prepare(`
+        INSERT INTO schema_meta (key, value)
+        VALUES ('memory_candidate_json_backfill_completed_at', ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+      `)
+      .run(nowIso());
+  }
+
   backfillPreferenceOccurrencesOnce() {
     const completed = this.db
       .prepare("SELECT value FROM schema_meta WHERE key = 'preference_occurrences_backfill_completed_at'")
@@ -1520,9 +1624,9 @@ export class ContextForgeStore {
         id, checkpoint_id, session_id, conversation_id, scope_type, scope_key,
         candidate_index, candidate_key, candidate_content, candidate_reason,
         category, tags_json, importance, candidate_type, confidence, stability,
-        sensitivity, promotion_recommendation, source_event_ids_json, status, created_at
+        sensitivity, promotion_recommendation, source_event_ids_json, candidate_json, status, created_at
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
       ON CONFLICT(checkpoint_id, candidate_index) DO NOTHING
     `);
 
@@ -1549,6 +1653,7 @@ export class ContextForgeStore {
         candidate.sensitivity,
         candidate.promotionRecommendation,
         json(candidate.sourceEventIds, []),
+        json(candidateJsonForIndex(rawCandidate, candidate), {}),
         checkpoint.createdAt,
       );
       if (inserted.changes > 0 && isPreferenceCandidate(candidate)) {

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -325,8 +325,11 @@ function validateDimensions(dimensions) {
   return parsed;
 }
 
+const SUGGESTED_ACTIONS = new Set(['promote', 'review', 'reject', 'skip']);
+
 function normalizeCandidate(candidate) {
   const value = candidate && typeof candidate === 'object' && !Array.isArray(candidate) ? candidate : {};
+  const suggestedAction = value.suggestedAction ? String(value.suggestedAction) : null;
   return {
     schemaVersion: value.schemaVersion ? String(value.schemaVersion) : null,
     key: String(value.key || ''),
@@ -344,16 +347,14 @@ function normalizeCandidate(candidate) {
     durabilityReason: value.durabilityReason ? String(value.durabilityReason) : null,
     riskReason: value.riskReason ? String(value.riskReason) : null,
     evidenceRefs: Array.isArray(value.evidenceRefs) ? value.evidenceRefs.map((item) => String(item)) : [],
-    suggestedAction: value.suggestedAction ? String(value.suggestedAction) : null,
+    suggestedAction: suggestedAction && SUGGESTED_ACTIONS.has(suggestedAction) ? suggestedAction : null,
   };
 }
 
 function candidateJsonForIndex(rawCandidate, candidate) {
-  const raw = rawCandidate && typeof rawCandidate === 'object' && !Array.isArray(rawCandidate) ? rawCandidate : {};
-  return {
-    ...raw,
-    ...candidate,
-  };
+  // Preserve the normalized candidate contract, including v2 review fields, without
+  // passing through arbitrary provider-supplied keys into list/audit surfaces.
+  return candidate;
 }
 
 function stringValue(value) {
@@ -391,7 +392,6 @@ function structuredCheckpointEmbeddingText(structured) {
     stringValue(liveState.worktreeStatus),
     ...structuredItemsText(structured.changes, ['type', 'name', 'path', 'description']),
     ...structuredItemsText(structured.verification, ['type', 'command', 'result', 'details']),
-    ...structuredItemsText(structured.decisions, ['decision', 'reason', 'durability']),
     ...structuredItemsText(structured.risks, ['risk', 'status', 'mitigation']),
     ...structuredItemsText(structured.nextActions, ['action', 'priority', 'reason']),
   ]

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -4574,10 +4574,11 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.equal(invocation.timeoutMs, 1234);
   assert.equal(schema.required.includes('structured'), false);
   assert.ok(schema.properties.structured);
+  assert.equal(schema.properties.structured.properties.schemaVersion.const, STRUCTURED_CHECKPOINT_SCHEMA_VERSION);
   const candidateSchema = schema.properties.memoryCandidates.items;
   assert.ok(candidateSchema.properties.durabilityReason);
   assert.ok(candidateSchema.properties.riskReason);
-  assert.ok(candidateSchema.properties.evidenceRefs);
+  assert.deepEqual(candidateSchema.properties.evidenceRefs.type, ['array', 'null']);
   assert.ok(candidateSchema.properties.suggestedAction);
   assert.ok(schema.properties.sessionWorkingContext);
   assert.deepEqual(
@@ -4605,6 +4606,8 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   });
   assert.equal(suggestions.proposals[0].whyDurable, 'Provider contract details can guide future distill debugging.');
   assert.equal(suggestions.proposals[0].riskReason, 'This is synthetic test evidence, not an operational incident.');
+  assert.equal(suggestions.proposals[0].recommendedAction, 'ask_user');
+  assert.equal(suggestions.proposals[0].providerSuggestedAction, 'promote');
   assert.deepEqual(suggestions.proposals[0].evidence.evidenceRefs, [
     'test:codex_exec provider distills synthetic raw events through a runner',
   ]);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -12,7 +12,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import Database from 'better-sqlite3';
 import { createCodexSdkPythonAutoPromoteAuditor } from '../src/audit/codex_sdk_python.js';
 import { createContextForge } from '../src/core.js';
-import { validateDistillOutput } from '../src/distill/validate.js';
+import { STRUCTURED_CHECKPOINT_SCHEMA_VERSION, validateDistillOutput } from '../src/distill/validate.js';
 import { createOpenAiEmbeddingProvider } from '../src/embeddings/index.js';
 import { createInterruptibleSleep, shouldSkipRecentFailedAutoDistill } from '../src/ingest/common.js';
 import { watchClaudeCodeSessions } from '../src/ingest/claude_code.js';
@@ -2897,6 +2897,75 @@ test('embedding dimension changes require an explicit forced rebuild', async () 
   assert.equal(rebuilt.dimensions, 2);
 });
 
+test('checkpoint embedding text flattens selected structured handoff fields', async () => {
+  const dataDir = await makeTempDir();
+  const store = new ContextForgeStore({ dataDir });
+  try {
+    const checkpoint = store.insertCheckpoint({
+      scopeType: 'repo',
+      scopeKey: 'repo-structured-embedding',
+      sessionId: 'structured-embedding-session',
+      summaryShort: 'Structured embedding checkpoint.',
+      summaryText: 'Structured embedding detail.',
+      decisions: [],
+      todos: [],
+      openQuestions: [],
+      provider: 'test',
+      metadata: {
+        structured: {
+          schemaVersion: STRUCTURED_CHECKPOINT_SCHEMA_VERSION,
+          work: {
+            intent: 'Index structured checkpoint handoff fields.',
+            status: 'verified',
+            outcome: 'Embedding text includes selected structured facts.',
+          },
+          liveState: {
+            repo: 'github.com/ginishuh/contextforge',
+            branch: 'feature/structured-checkpoints',
+            headCommit: 'abc1234',
+            prNumber: 119,
+            ciStatus: 'pass',
+          },
+          changes: [
+            {
+              type: 'storage',
+              name: 'candidate_json',
+              description: 'Preserve raw memory candidate fields.',
+            },
+          ],
+          verification: [
+            {
+              command: 'npm test',
+              result: 'pass',
+              details: 'structured checkpoint tests pass',
+            },
+          ],
+          risks: [
+            {
+              risk: 'Live state may be stale.',
+              mitigation: 'Recheck GitHub before acting.',
+            },
+          ],
+          nextActions: [
+            {
+              action: 'Open a PR.',
+              priority: 'medium',
+            },
+          ],
+        },
+      },
+    });
+    const text = store.embeddingTextForCheckpoint(checkpoint);
+    assert.match(text, /feature\/structured-checkpoints/);
+    assert.match(text, /PR #119/);
+    assert.match(text, /candidate_json/);
+    assert.match(text, /npm test pass/);
+    assert.doesNotMatch(text, /schemaVersion/);
+  } finally {
+    store.close();
+  }
+});
+
 test('OpenAI embeddings omit dimensions for legacy embedding models', async () => {
   let requestBody = null;
   const provider = createOpenAiEmbeddingProvider(
@@ -3327,6 +3396,28 @@ test('bootstrapContext includes latest checkpoints independently from search res
         todos: ['Recent todo.'],
         openQuestions: [],
         memoryCandidates: [],
+        structured: {
+          schemaVersion: STRUCTURED_CHECKPOINT_SCHEMA_VERSION,
+          work: {
+            intent: 'Preserve latest handoff independently from search ranking.',
+            status: 'verified',
+            outcome: 'Latest checkpoint should appear in handoff.latestHandoff.',
+          },
+          liveState: {
+            repo: 'github.com/example/mcp-repo',
+            branch: 'feature/handoff',
+            headCommit: 'abc1234',
+            ciStatus: 'pass',
+            observedAt: '2026-06-03T00:00:00Z',
+            verificationRequired: true,
+            staleReasons: ['branch, commit, and CI are mutable live state'],
+            verifyHints: ['git status --short --branch', 'gh pr view 123 --json statusCheckRollup'],
+          },
+          changes: [],
+          verification: [],
+          risks: [],
+          nextActions: [],
+        },
         sourceEventCount: input.rawEvents.length,
         metadata: { synthetic: true },
       }),
@@ -3361,6 +3452,15 @@ test('bootstrapContext includes latest checkpoints independently from search res
   assert.equal(bootstrap.results.some((item) => item.type === 'memory' && item.key === 'durable-bootstrap-hit'), true);
   assert.equal(bootstrap.handoff.latestCheckpointLimit, 1);
   assert.deepEqual(bootstrap.handoff.relatedScopeKeys, []);
+  assert.equal(bootstrap.handoff.latestHandoff.id, bootstrap.handoff.latestCheckpoints[0].id);
+  assert.equal(bootstrap.handoff.latestHandoff.structured.schemaVersion, STRUCTURED_CHECKPOINT_SCHEMA_VERSION);
+  assert.equal(bootstrap.handoff.latestHandoff.structured.liveState.branch, 'feature/handoff');
+  assert.equal(bootstrap.handoff.latestHandoff.structuredWarnings[0].code, 'live_state_may_be_stale');
+  assert.ok(bootstrap.handoff.latestHandoff.structuredWarnings[0].fields.includes('liveState.branch'));
+  assert.deepEqual(bootstrap.handoff.latestHandoff.structuredWarnings[0].verifyHints, [
+    'git status --short --branch',
+    'gh pr view 123 --json statusCheckRollup',
+  ]);
   assert.equal(bootstrap.handoff.latestCheckpoints.length, 1);
   assert.equal(bootstrap.handoff.latestCheckpoints[0].trust, 'credible_recent_handoff');
   assert.equal(bootstrap.handoff.latestCheckpoints[0].scope.scopeKey, 'repo-handoff');
@@ -3374,6 +3474,7 @@ test('bootstrapContext includes latest checkpoints independently from search res
     latestCheckpointLimit: 0,
   });
   assert.deepEqual(disabled.handoff.latestCheckpoints, []);
+  assert.equal(disabled.handoff.latestHandoff, null);
 });
 
 test('bootstrapContext can include latest checkpoints from related repo scopes', async () => {
@@ -4250,6 +4351,45 @@ test('distill output validation includes received types', () => {
       }),
     /decisions.*received string/,
   );
+  const legacy = validateDistillOutput({
+    summaryShort: 'Legacy checkpoint.',
+    summaryText: 'Legacy output has no structured payload.',
+    decisions: [],
+    todos: [],
+    openQuestions: [],
+    memoryCandidates: [],
+  });
+  assert.equal(legacy.structured, null);
+  const structured = validateDistillOutput({
+    summaryShort: 'Structured checkpoint.',
+    summaryText: 'Structured output has handoff state.',
+    decisions: [],
+    todos: [],
+    openQuestions: [],
+    memoryCandidates: [],
+    structured: {
+      schemaVersion: STRUCTURED_CHECKPOINT_SCHEMA_VERSION,
+      work: {
+        status: 'verified',
+      },
+    },
+  });
+  assert.equal(structured.structured.schemaVersion, STRUCTURED_CHECKPOINT_SCHEMA_VERSION);
+  assert.throws(
+    () =>
+      validateDistillOutput({
+        summaryShort: 'Invalid structured checkpoint.',
+        summaryText: 'Structured output has the wrong schema version.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [],
+        structured: {
+          schemaVersion: 'contextforge.structured_checkpoint.v999',
+        },
+      }),
+    /structured\.schemaVersion/,
+  );
 });
 
 test('distillCheckpoint records provider failures without deleting raw evidence', async () => {
@@ -4329,20 +4469,58 @@ test('codex_exec provider distills synthetic raw events through a runner', async
           openQuestions: [],
           memoryCandidates: [
             {
+              schemaVersion: 'contextforge.memory_candidate.v2',
               key: 'provider',
               content: 'codex_exec is available.',
               reason: 'Synthetic provider output.',
               category: 'note',
               tags: [],
-              importance: 0,
+              importance: 1,
               candidateType: null,
-              confidence: null,
-              stability: null,
+              confidence: 0.9,
+              stability: 0.9,
               sensitivity: null,
-              promotionRecommendation: null,
+              promotionRecommendation: 'promote',
               sourceEventIds: [],
+              durabilityReason: 'Provider contract details can guide future distill debugging.',
+              riskReason: 'This is synthetic test evidence, not an operational incident.',
+              evidenceRefs: ['test:codex_exec provider distills synthetic raw events through a runner'],
+              suggestedAction: 'promote',
             },
           ],
+          structured: {
+            schemaVersion: STRUCTURED_CHECKPOINT_SCHEMA_VERSION,
+            work: {
+              intent: 'Test the codex_exec provider path.',
+              status: 'verified',
+              outcome: 'Synthetic distill completed.',
+            },
+            liveState: {
+              repo: 'github.com/ginishuh/contextforge',
+              branch: 'feature/structured-checkpoints',
+              headCommit: 'synthetic',
+              observedAt: '2026-06-03T00:00:00Z',
+              verificationRequired: true,
+              staleReasons: ['branch and headCommit are mutable live state'],
+              verifyHints: ['git status --short --branch', 'git rev-parse HEAD'],
+            },
+            changes: [
+              {
+                type: 'provider',
+                name: 'codex_exec',
+                description: 'Synthetic provider schema accepted structured output.',
+              },
+            ],
+            verification: [
+              {
+                type: 'smoke',
+                result: 'pass',
+                details: 'Synthetic runner returned valid checkpoint JSON.',
+              },
+            ],
+            risks: [],
+            nextActions: [],
+          },
           sourceEventCount: 1,
           metadata: {
             providerNotes: 'synthetic provider output',
@@ -4379,24 +4557,57 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.model, 'gpt-test');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.reasoningEffort, 'low');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.timeoutMs, 1234);
-  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v6');
-  assert.equal(checkpoint.metadata.providerMetadata.codexExec.outputSchemaVersion, 'contextforge.checkpoint.v5');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v7');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.outputSchemaVersion, 'contextforge.checkpoint.v6');
+  assert.equal(checkpoint.structured.schemaVersion, STRUCTURED_CHECKPOINT_SCHEMA_VERSION);
+  assert.equal(checkpoint.metadata.structured.schemaVersion, STRUCTURED_CHECKPOINT_SCHEMA_VERSION);
+  assert.equal(checkpoint.metadata.providerMetadata.structured, undefined);
   assert.match(invocation.prompt, /Return exactly one JSON object/);
+  const promptPayload = JSON.parse(invocation.prompt.slice(invocation.prompt.indexOf('{')));
+  assert.equal(promptPayload.requestedOutputSchema.structured.schemaVersion, STRUCTURED_CHECKPOINT_SCHEMA_VERSION);
+  assert.match(invocation.prompt, /structured\.liveState/);
   assert.deepEqual(invocation.args.slice(0, 2), ['exec', '--skip-git-repo-check']);
   assert.ok(invocation.args.includes('--output-schema'));
   assert.ok(invocation.args.includes('--output-last-message'));
   assert.ok(invocation.args.includes('-c'));
   assert.ok(invocation.args.includes('model_reasoning_effort="low"'));
   assert.equal(invocation.timeoutMs, 1234);
-  assert.deepEqual(schema.required, Object.keys(schema.properties));
+  assert.equal(schema.required.includes('structured'), false);
+  assert.ok(schema.properties.structured);
   const candidateSchema = schema.properties.memoryCandidates.items;
-  assert.deepEqual(candidateSchema.required, Object.keys(candidateSchema.properties));
+  assert.ok(candidateSchema.properties.durabilityReason);
+  assert.ok(candidateSchema.properties.riskReason);
+  assert.ok(candidateSchema.properties.evidenceRefs);
+  assert.ok(candidateSchema.properties.suggestedAction);
   assert.ok(schema.properties.sessionWorkingContext);
   assert.deepEqual(
     schema.properties.sessionWorkingContext.required,
     Object.keys(schema.properties.sessionWorkingContext.properties),
   );
   assert.deepEqual(schema.properties.metadata.required, ['providerNotes', 'retrievalHooks']);
+  const indexedCandidate = app.listMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'repo-codex',
+    checkpointId: checkpoint.id,
+  })[0];
+  assert.equal(indexedCandidate.candidate.schemaVersion, 'contextforge.memory_candidate.v2');
+  assert.equal(indexedCandidate.candidate.durabilityReason, 'Provider contract details can guide future distill debugging.');
+  assert.equal(indexedCandidate.candidate.riskReason, 'This is synthetic test evidence, not an operational incident.');
+  assert.deepEqual(indexedCandidate.candidate.evidenceRefs, [
+    'test:codex_exec provider distills synthetic raw events through a runner',
+  ]);
+  assert.equal(indexedCandidate.candidate.suggestedAction, 'promote');
+  const suggestions = await app.suggestMemoryPromotions({
+    scope: 'repo',
+    scopeKey: 'repo-codex',
+    checkpointId: checkpoint.id,
+    trigger: 'manual_closeout',
+  });
+  assert.equal(suggestions.proposals[0].whyDurable, 'Provider contract details can guide future distill debugging.');
+  assert.equal(suggestions.proposals[0].riskReason, 'This is synthetic test evidence, not an operational incident.');
+  assert.deepEqual(suggestions.proposals[0].evidence.evidenceRefs, [
+    'test:codex_exec provider distills synthetic raw events through a runner',
+  ]);
 
   const runs = app.listDistillRuns({
     scope: 'repo',
@@ -4404,9 +4615,9 @@ test('codex_exec provider distills synthetic raw events through a runner', async
     sessionId: 'codex-session',
   });
   assert.equal(runs[0].status, 'succeeded');
-  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v6');
-  assert.equal(runs[0].inputMetadata.providerMetadata.outputSchemaVersion, 'contextforge.checkpoint.v5');
-  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v6');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v7');
+  assert.equal(runs[0].inputMetadata.providerMetadata.outputSchemaVersion, 'contextforge.checkpoint.v6');
+  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v7');
 });
 
 test('codex_exec records JSON brace fallback recovery metadata', async () => {
@@ -4570,6 +4781,100 @@ test('runtime settings are DB-backed, redacted, and hot-apply to session status'
   assert.equal(status.thresholds.minIntervalMs, 1);
   assert.equal(status.thresholds.charThreshold, 1);
   assert.equal(status.shouldDistill, true);
+});
+
+test('codex_exec prompt preserves previous structured checkpoint handoff', async () => {
+  const dataDir = await makeTempDir();
+  const invocations = [];
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'codex_exec',
+      CONTEXTFORGE_CODEX_EXEC_COMMAND: 'codex-fake',
+    },
+    cwd: process.cwd(),
+    codexExecRunner: async (args) => {
+      invocations.push(args);
+      const pass = invocations.length;
+      return {
+        stdout: JSON.stringify({
+          summaryShort: `Structured checkpoint pass ${pass}.`,
+          summaryText: `Structured checkpoint detail pass ${pass}.`,
+          workingSummary: `Working summary pass ${pass}.`,
+          sessionWorkingContext: {
+            mode: 'task_execution',
+            currentTask: 'Preserve previous structured checkpoint.',
+            currentUserIntent: 'Verify structured handoff continuity.',
+            targetSubject: null,
+            sourceSubject: null,
+            lastUserCorrection: null,
+            openQuestion: null,
+            nonGoals: [],
+            avoidMisreadings: [],
+            confidence: 0.9,
+          },
+          decisions: [],
+          todos: [],
+          openQuestions: [],
+          memoryCandidates: [],
+          structured: {
+            schemaVersion: STRUCTURED_CHECKPOINT_SCHEMA_VERSION,
+            work: {
+              intent: `Structured handoff pass ${pass}.`,
+              status: pass === 1 ? 'in_progress' : 'verified',
+              outcome: `Pass ${pass} stored structured handoff.`,
+            },
+            liveState: {
+              branch: `feature/pass-${pass}`,
+              observedAt: '2026-06-03T00:00:00Z',
+              verificationRequired: true,
+              staleReasons: ['branch is mutable'],
+              verifyHints: ['git status --short --branch'],
+            },
+            changes: [],
+            verification: [],
+            risks: [],
+            nextActions: [],
+          },
+          sourceEventCount: 1,
+          provider: 'codex_exec',
+          metadata: {
+            providerNotes: 'synthetic structured continuity',
+            retrievalHooks: ['structured checkpoint continuity'],
+          },
+        }),
+      };
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-structured-previous',
+    sessionId: 'structured-previous-session',
+    role: 'assistant',
+    content: 'First structured checkpoint event.',
+  });
+  const first = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-structured-previous',
+    sessionId: 'structured-previous-session',
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'repo-structured-previous',
+    sessionId: 'structured-previous-session',
+    role: 'assistant',
+    content: 'Second structured checkpoint event.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'repo-structured-previous',
+    sessionId: 'structured-previous-session',
+  });
+
+  const secondPromptPayload = JSON.parse(invocations[1].prompt.slice(invocations[1].prompt.indexOf('{')));
+  assert.equal(secondPromptPayload.previousCheckpoint.id, first.id);
+  assert.equal(secondPromptPayload.previousCheckpoint.structured.schemaVersion, STRUCTURED_CHECKPOINT_SCHEMA_VERSION);
+  assert.equal(secondPromptPayload.previousCheckpoint.structured.work.status, 'in_progress');
 });
 
 test('openai_compatible provider distills through a fake DeepSeek-style chat completions endpoint', async () => {
@@ -4942,8 +5247,8 @@ test('codex_exec parse failures preserve raw evidence', async () => {
   });
   assert.equal(runs[0].status, 'failed');
   assert.equal(runs[0].outputMetadata.providerFailed, true);
-  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v6');
-  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v6');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v7');
+  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v7');
 });
 
 test('bootstrapContext returns semantic retrieval with trust and verification hints', async () => {
@@ -5072,6 +5377,32 @@ test('syncResumeContext returns handoff context without promotion proposals', as
         decisions: ['Use checkpoint handoff for prior intent.'],
         todos: ['Verify CI before acting.'],
         openQuestions: [],
+        structured: {
+          schemaVersion: STRUCTURED_CHECKPOINT_SCHEMA_VERSION,
+          work: {
+            intent: 'Resume usage observability verification.',
+            status: 'in_progress',
+            outcome: 'Next agent should verify CI live.',
+          },
+          liveState: {
+            prNumber: 321,
+            ciStatus: 'unknown',
+            observedAt: '2026-06-03T00:00:00Z',
+            verificationRequired: true,
+            staleReasons: ['PR and CI state can change after checkpoint creation'],
+            verifyHints: ['gh pr view 321 --json statusCheckRollup'],
+          },
+          changes: [],
+          verification: [],
+          risks: [],
+          nextActions: [
+            {
+              action: 'Verify CI before acting.',
+              priority: 'high',
+              requiresLiveVerification: true,
+            },
+          ],
+        },
         sessionWorkingContext: {
           currentTask: 'Continue usage observability closeout verification.',
           currentUserIntent: 'Resume unfinished PR verification without proposing memory promotions.',
@@ -5125,6 +5456,8 @@ test('syncResumeContext returns handoff context without promotion proposals', as
   });
 
   assert.equal(result.kind, 'resume_context');
+  assert.equal(result.handoff.latestHandoff.structured.work.status, 'in_progress');
+  assert.equal(result.handoff.latestHandoff.structuredWarnings[0].code, 'live_state_may_be_stale');
   assert.equal(result.handoff.structuredWorkingContext.type, 'session_working_context');
   assert.equal(result.handoff.structuredWorkingContext.trust, 'mutable_session_state');
   assert.match(result.handoff.structuredWorkingContext.currentTask, /usage observability/);


### PR DESCRIPTION
## Summary

- Add optional structured checkpoint handoff payloads with schemaVersion `contextforge.structured_checkpoint.v1`.
- Store structured handoff at `checkpoint.metadata.structured` and expose `checkpoint.structured`.
- Update `codex_exec` schema/prompt to request structured handoff and preserve previous structured checkpoints in provider input.
- Preserve memory candidate v2 review fields via `memory_candidate_index.candidate_json` and surface durability/risk/evidence fields in promotion suggestions.
- Add deterministic `handoff.latestHandoff` plus live-state stale warnings, and flatten selected structured fields into checkpoint embedding text.

## Tests

- `npm test` 132/132 pass
- `git diff --check`

Closes #119