### PR TITLE
Fix codex_exec schema and admin UI auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- Fixed `/ui` asset loading for requests without a trailing slash and made
+  admin UI session cookies HTTP-aware by default while preserving `Secure`
+  cookies for HTTPS reverse-proxy deployments.
+- Updated the `codex_exec` checkpoint output schema for strict structured
+  output compatibility. New distill outputs must include the nullable
+  memory-candidate v2 review fields (`schemaVersion`, `durabilityReason`,
+  `riskReason`, `evidenceRefs`, and `suggestedAction`) when using the bundled
+  strict schema.
+- Localized human-readable memory-candidate review text and audit reasons to
+  Korean by default while keeping keys, enum values, paths, commands, and other
+  technical identifiers machine-readable.
+
 ## 0.5.0 - 2026-06-03
 
 - Added optional structured checkpoint handoff payloads for agent resume state,

--- a/README.ko.md
+++ b/README.ko.md
@@ -117,6 +117,11 @@ remote API 호출에는 `CONTEXTFORGE_REMOTE_TOKEN`이 필요하다.
 운영 UI는 `/ui/`에서 사용할 수 있다. UI에서는 runtime 설정, distill provider,
 모델, threshold, memory candidates, durable memory correction 등을 확인하고
 수정할 수 있다. API key는 write-only로 저장되며 응답에 노출되지 않는다.
+admin UI cookie는 기본적으로 `CONTEXTFORGE_ADMIN_COOKIE_SECURE=auto`로 동작한다.
+직접 HTTP 접속에서는 로컬 운영 세션이 동작하도록 non-`Secure` cookie를 쓰고,
+신뢰된 reverse proxy가 HTTPS 요청으로 표시한 경우에는 `Secure` cookie를 쓴다.
+Node가 직접 TLS를 종료하는 배포라면 `CONTEXTFORGE_ADMIN_COOKIE_SECURE=true`를
+설정하고, reverse proxy는 client가 보낸 `X-Forwarded-Proto`를 덮어써야 한다.
 
 ## 모델 분리
 

--- a/README.md
+++ b/README.md
@@ -402,7 +402,12 @@ provenance. Runtime settings saved in the UI override env defaults for new
 calls without restarting the server. API keys are write-only in the UI/API:
 callers can set, replace, clear, and test them, but stored values are never
 returned. Optional admin password login is cookie-session based; bearer-token
-access remains available for API clients.
+access remains available for API clients. Admin UI cookies use
+`CONTEXTFORGE_ADMIN_COOKIE_SECURE=auto` by default: direct HTTP access gets a
+non-`Secure` cookie so local operator sessions work, while requests marked as
+HTTPS by a trusted reverse proxy get a `Secure` cookie. If the server is exposed
+directly over TLS, set `CONTEXTFORGE_ADMIN_COOKIE_SECURE=true`; reverse proxies
+must overwrite client-supplied `X-Forwarded-Proto` before forwarding requests.
 
 `CONTEXTFORGE_OPENAI_API_KEY` is only needed on the process that performs
 embedding calls. In remote/server-backed deployments, keep that key only in the

--- a/docs/runtime-modes.md
+++ b/docs/runtime-modes.md
@@ -114,6 +114,11 @@ Meaning:
 - `/v0/*` is the JSON remote API.
 - Binding to a non-loopback host requires `CONTEXTFORGE_REMOTE_TOKEN`.
 - Public internet exposure should go through HTTPS reverse proxy when possible.
+- The operator UI cookie defaults to `CONTEXTFORGE_ADMIN_COOKIE_SECURE=auto`.
+  In this mode, direct HTTP access receives a non-`Secure` cookie, and requests
+  marked as HTTPS by a trusted reverse proxy receive a `Secure` cookie. If Node
+  terminates TLS directly, set `CONTEXTFORGE_ADMIN_COOKIE_SECURE=true`. Reverse
+  proxies must overwrite client-supplied `X-Forwarded-Proto`.
 
 Useful checks:
 

--- a/src/audit/codex_exec.js
+++ b/src/audit/codex_exec.js
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { parseCodexExecJson, runCodexExecCommand } from '../distill/providers/codex_exec.js';
 
-export const AUTO_PROMOTE_AUDIT_PROMPT_VERSION = 'auto_promote_audit.codex_exec.v1';
+export const AUTO_PROMOTE_AUDIT_PROMPT_VERSION = 'auto_promote_audit.codex_exec.v2';
 export const AUTO_PROMOTE_AUDIT_SCHEMA_VERSION = 'contextforge.auto_promote_audit.v1';
 
 export const AUDIT_OUTPUT_SCHEMA = {
@@ -47,6 +47,8 @@ export function buildAuditPrompt(input, metadata) {
       'Use needs_review when the candidate might be useful but needs a human edit, narrower wording, or live verification.',
       'Do not approve merely because promotionRecommendation is promote or confidence is high.',
       'Treat this as an audit gate before automatic promotion; be conservative.',
+      'Write the human-readable reason in Korean by default.',
+      'Keep riskCodes as short machine-readable English tokens, and preserve exact technical identifiers, commands, paths, API names, model names, and quoted error strings.',
     ],
     requestedOutputSchema: AUDIT_OUTPUT_SCHEMA,
     auditProvider: metadata,

--- a/src/audit/codex_sdk_python.js
+++ b/src/audit/codex_sdk_python.js
@@ -8,7 +8,7 @@ import {
   buildAuditPrompt,
 } from './codex_exec.js';
 
-export const AUTO_PROMOTE_AUDIT_PYTHON_SDK_PROMPT_VERSION = 'auto_promote_audit.codex_sdk_python.v1';
+export const AUTO_PROMOTE_AUDIT_PYTHON_SDK_PROMPT_VERSION = 'auto_promote_audit.codex_sdk_python.v2';
 
 const RUNNER_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), 'codex_sdk_python_runner.py');
 const REASONING_EFFORTS = new Set(['minimal', 'low', 'medium', 'high']);

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -7,6 +7,92 @@ import { STRUCTURED_CHECKPOINT_SCHEMA_VERSION } from '../validate.js';
 export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v7';
 export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v6';
 
+function nullableStringSchema() {
+  return { type: ['string', 'null'] };
+}
+
+function nullableBooleanSchema() {
+  return { type: ['boolean', 'null'] };
+}
+
+function stringArraySchema() {
+  return { type: 'array', items: { type: 'string' } };
+}
+
+function strictObjectSchema(properties, { nullable = false } = {}) {
+  return {
+    type: nullable ? ['object', 'null'] : 'object',
+    additionalProperties: false,
+    required: Object.keys(properties),
+    properties,
+  };
+}
+
+function strictObjectArraySchema(properties) {
+  return {
+    type: 'array',
+    items: strictObjectSchema(properties),
+  };
+}
+
+const STRUCTURED_OUTPUT_SCHEMA = strictObjectSchema(
+  {
+    schemaVersion: { type: 'string', enum: [STRUCTURED_CHECKPOINT_SCHEMA_VERSION] },
+    work: strictObjectSchema(
+      {
+        intent: nullableStringSchema(),
+        status: nullableStringSchema(),
+        outcome: nullableStringSchema(),
+      },
+      { nullable: true },
+    ),
+    liveState: strictObjectSchema(
+      {
+        repo: nullableStringSchema(),
+        branch: nullableStringSchema(),
+        baseBranch: nullableStringSchema(),
+        headCommit: nullableStringSchema(),
+        prNumber: { type: ['integer', 'null'] },
+        prUrl: nullableStringSchema(),
+        ciStatus: nullableStringSchema(),
+        worktreeStatus: nullableStringSchema(),
+        runtimeStatus: nullableStringSchema(),
+        deploymentStatus: nullableStringSchema(),
+        observedAt: nullableStringSchema(),
+        verifiedAt: nullableStringSchema(),
+        verificationRequired: nullableBooleanSchema(),
+        staleReasons: stringArraySchema(),
+        verifyHints: stringArraySchema(),
+      },
+      { nullable: true },
+    ),
+    changes: strictObjectArraySchema({
+      type: nullableStringSchema(),
+      name: nullableStringSchema(),
+      path: nullableStringSchema(),
+      description: nullableStringSchema(),
+    }),
+    verification: strictObjectArraySchema({
+      type: nullableStringSchema(),
+      command: nullableStringSchema(),
+      result: nullableStringSchema(),
+      details: nullableStringSchema(),
+      requiresLiveRecheck: nullableBooleanSchema(),
+    }),
+    risks: strictObjectArraySchema({
+      risk: nullableStringSchema(),
+      status: nullableStringSchema(),
+      mitigation: nullableStringSchema(),
+    }),
+    nextActions: strictObjectArraySchema({
+      action: nullableStringSchema(),
+      priority: nullableStringSchema(),
+      reason: nullableStringSchema(),
+    }),
+  },
+  { nullable: true },
+);
+
 export const CHECKPOINT_OUTPUT_SCHEMA = {
   $id: CODEX_EXEC_OUTPUT_SCHEMA_VERSION,
   type: 'object',
@@ -20,6 +106,7 @@ export const CHECKPOINT_OUTPUT_SCHEMA = {
     'todos',
     'openQuestions',
     'memoryCandidates',
+    'structured',
     'sourceEventCount',
     'provider',
     'metadata',
@@ -77,6 +164,11 @@ export const CHECKPOINT_OUTPUT_SCHEMA = {
           'sensitivity',
           'promotionRecommendation',
           'sourceEventIds',
+          'schemaVersion',
+          'durabilityReason',
+          'riskReason',
+          'evidenceRefs',
+          'suggestedAction',
         ],
         properties: {
           key: { type: 'string' },
@@ -99,14 +191,7 @@ export const CHECKPOINT_OUTPUT_SCHEMA = {
         },
       },
     },
-    structured: {
-      type: 'object',
-      additionalProperties: true,
-      required: ['schemaVersion'],
-      properties: {
-        schemaVersion: { const: STRUCTURED_CHECKPOINT_SCHEMA_VERSION },
-      },
-    },
+    structured: STRUCTURED_OUTPUT_SCHEMA,
     sourceEventCount: { type: 'integer', minimum: 0 },
     provider: { type: 'string' },
     metadata: {
@@ -239,6 +324,7 @@ export function buildCodexExecPrompt(input, options = {}) {
       'When tool verification matters, summarize the assistant-interpreted conclusion instead of copying raw command output.',
       'Write the checkpoint as recent continuity for handoff and search, not as canonical durable truth.',
       `When evidence supports it, populate structured with schemaVersion="${STRUCTURED_CHECKPOINT_SCHEMA_VERSION}" as a structured handoff object for the next agent.`,
+      'Return structured=null when the supplied evidence does not support a useful structured handoff.',
       'Use structured.work for user intent, current status, and actual outcome.',
       'Use structured.liveState only for observed mutable live state such as repo, branch, baseBranch, headCommit, PR, CI, worktree, runtime, or deployment state. Do not invent liveState values absent from evidence.',
       'For structured.liveState, include observedAt when known, verificationRequired=true for mutable fields, staleReasons explaining why it may drift, and verifyHints with concrete commands or API calls a future agent should run.',

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { STRUCTURED_CHECKPOINT_SCHEMA_VERSION } from '../validate.js';
 
-export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v7';
+export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v8';
 export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v6';
 
 function nullableStringSchema() {
@@ -347,6 +347,9 @@ export function buildCodexExecPrompt(input, options = {}) {
       'For memoryCandidates, include optional v2 fields when useful: schemaVersion="contextforge.memory_candidate.v2", durabilityReason, riskReason, evidenceRefs, and suggestedAction.',
       'For nullable memoryCandidate fields that are not applicable, return null; do not omit required schema fields.',
       'Create memoryCandidates only for facts, decisions, preferences, runbook steps, or failure modes that may remain useful beyond this checkpoint.',
+      'Write human-readable memoryCandidate review fields in Korean by default: content, reason, durabilityReason, and riskReason.',
+      'Do not mix English prose into those Korean memoryCandidate review fields unless preserving exact technical identifiers, code symbols, file paths, commands, model names, API names, product names, or quoted error strings.',
+      'Keep memoryCandidate keys, categories, tags, enum values, sourceEventIds, evidenceRefs, and schemaVersion machine-readable and in their original technical form.',
       'For memoryCandidate content, include decision plus rationale when both exist; put future-search keywords in tags and reason instead of flattening them away.',
       'Set promotionRecommendation to promote only for stable, reviewed-looking durable facts; otherwise prefer review, ignore, or reject.',
       'Use low confidence or low stability for guesses, temporary state, implementation-in-progress details, and facts that require current runtime verification.',

--- a/src/distill/providers/openai_compatible.js
+++ b/src/distill/providers/openai_compatible.js
@@ -1,7 +1,7 @@
 import { buildCodexExecPrompt, CHECKPOINT_OUTPUT_SCHEMA, CODEX_EXEC_OUTPUT_SCHEMA_VERSION } from './codex_exec.js';
 import { validateDistillOutput } from '../validate.js';
 
-export const OPENAI_COMPATIBLE_PROMPT_VERSION = 'openai_compatible.prompt.v1';
+export const OPENAI_COMPATIBLE_PROMPT_VERSION = 'openai_compatible.prompt.v2';
 
 const DEFAULT_TIMEOUT_MS = 120000;
 const DEFAULT_BASE_URL = 'https://api.deepseek.com';

--- a/src/server.js
+++ b/src/server.js
@@ -156,6 +156,7 @@ function parseAdminCookieSecureMode(value) {
 }
 
 function requestIsSecure(request) {
+  if (request.socket.encrypted) return true;
   const forwardedProto = String(request.headers['x-forwarded-proto'] || '')
     .split(',')[0]
     .trim()
@@ -464,7 +465,7 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
 
     if (request.method === 'GET' && requestUrl.pathname === '/ui') {
       response.writeHead(308, {
-        location: '/ui/',
+        location: `/ui/${requestUrl.search}`,
         'cache-control': 'no-store',
       });
       response.end();

--- a/src/server.js
+++ b/src/server.js
@@ -40,7 +40,7 @@ function sendJson(response, statusCode, body) {
 }
 
 async function sendStaticUi(requestUrl, response) {
-  const pathname = requestUrl.pathname === '/ui' ? '/ui/' : requestUrl.pathname;
+  const pathname = requestUrl.pathname;
   let relative;
   try {
     relative = pathname === '/ui/' ? 'index.html' : decodeURIComponent(pathname.slice('/ui/'.length));
@@ -144,6 +144,30 @@ function originMatchesHost(request) {
   } catch {
     return false;
   }
+}
+
+function parseAdminCookieSecureMode(value) {
+  if (value == null || value === '') return 'auto';
+  const normalized = String(value).trim().toLowerCase();
+  if (['true', '1', 'yes'].includes(normalized)) return 'always';
+  if (['false', '0', 'no'].includes(normalized)) return 'never';
+  if (normalized === 'auto') return 'auto';
+  throw new Error('CONTEXTFORGE_ADMIN_COOKIE_SECURE must be true, false, or auto.');
+}
+
+function requestIsSecure(request) {
+  const forwardedProto = String(request.headers['x-forwarded-proto'] || '')
+    .split(',')[0]
+    .trim()
+    .toLowerCase();
+  if (forwardedProto) return forwardedProto === 'https';
+  return Boolean(request.socket.encrypted);
+}
+
+function adminCookieSecureForRequest(request, mode) {
+  if (mode === 'always') return true;
+  if (mode === 'never') return false;
+  return requestIsSecure(request);
 }
 
 function parsePositiveInteger(value, fallback) {
@@ -322,7 +346,7 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
     env.CONTEXTFORGE_ADMIN_LOGIN_MAX_FAILURES,
     DEFAULT_ADMIN_LOGIN_MAX_FAILURES,
   );
-  const adminCookieSecure = env.CONTEXTFORGE_ADMIN_COOKIE_SECURE !== 'false';
+  const adminCookieSecureMode = parseAdminCookieSecureMode(env.CONTEXTFORGE_ADMIN_COOKIE_SECURE);
   const adminSessions = new Map();
   const failedAdminLogins = new Map();
 
@@ -407,7 +431,7 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
           'cache-control': 'no-store',
           'set-cookie': makeCookie(ADMIN_COOKIE_NAME, session, {
             maxAge: Math.ceil(adminSessionTtlMs / 1000),
-            secure: adminCookieSecure,
+            secure: adminCookieSecureForRequest(request, adminCookieSecureMode),
           }),
         });
         response.end(`${JSON.stringify({ ok: true })}\n`);
@@ -423,13 +447,31 @@ export function createContextForgeServer({ app, env = process.env } = {}) {
       response.writeHead(200, {
         'content-type': 'application/json',
         'cache-control': 'no-store',
-        'set-cookie': makeCookie(ADMIN_COOKIE_NAME, '', { maxAge: 0, secure: adminCookieSecure }),
+        'set-cookie': makeCookie(ADMIN_COOKIE_NAME, '', {
+          maxAge: 0,
+          secure: adminCookieSecureForRequest(request, adminCookieSecureMode),
+        }),
       });
       response.end('{"ok":true}\n');
       return;
     }
 
-    if (request.method === 'GET' && (requestUrl.pathname === '/ui' || requestUrl.pathname.startsWith('/ui/'))) {
+    if (request.method === 'GET' && requestUrl.pathname === '/favicon.ico') {
+      response.writeHead(204, { 'cache-control': 'no-store' });
+      response.end();
+      return;
+    }
+
+    if (request.method === 'GET' && requestUrl.pathname === '/ui') {
+      response.writeHead(308, {
+        location: '/ui/',
+        'cache-control': 'no-store',
+      });
+      response.end();
+      return;
+    }
+
+    if (request.method === 'GET' && requestUrl.pathname.startsWith('/ui/')) {
       await sendStaticUi(requestUrl, response);
       return;
     }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -7950,6 +7950,10 @@ test('HTTP server serves admin UI assets', async () => {
     assert.equal(redirect.status, 308);
     assert.equal(redirect.headers.get('location'), '/ui/');
 
+    const redirectWithQuery = await fetch(`${remote.url}/ui?tab=memory`, { redirect: 'manual' });
+    assert.equal(redirectWithQuery.status, 308);
+    assert.equal(redirectWithQuery.headers.get('location'), '/ui/?tab=memory');
+
     const response = await fetch(`${remote.url}/ui/`);
     assert.equal(response.status, 200);
     assert.equal(response.headers.get('cache-control'), 'no-store');
@@ -8014,6 +8018,35 @@ test('HTTP server accepts admin UI login sessions', async () => {
   }
 });
 
+test('HTTP server auto-secures admin UI cookies behind HTTPS reverse proxies', async () => {
+  const dataDir = await makeTempDir();
+  const password = 'proxy-cookie-CON' + 'TEXT';
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+      CONTEXTFORGE_ADMIN_USER: 'ginishuh',
+      CONTEXTFORGE_ADMIN_PASSWORD_PBKDF2: testAdminPasswordHash(password),
+    },
+  });
+
+  try {
+    const login = await fetch(`${remote.url}/ui/login`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-forwarded-proto': 'https',
+      },
+      body: JSON.stringify({ username: 'ginishuh', password }),
+    });
+    assert.equal(login.status, 200);
+    assert.match(login.headers.get('set-cookie'), /;\s*Secure\b/);
+  } finally {
+    await remote.close();
+  }
+});
+
 test('HTTP server can force secure admin UI cookies for HTTPS deployments', async () => {
   const dataDir = await makeTempDir();
   const password = 'secure-cookie-CON' + 'TEXT';
@@ -8039,6 +8072,22 @@ test('HTTP server can force secure admin UI cookies for HTTPS deployments', asyn
   } finally {
     await remote.close();
   }
+});
+
+test('HTTP server rejects invalid admin cookie secure mode', async () => {
+  const dataDir = await makeTempDir();
+  assert.throws(
+    () =>
+      startContextForgeServer({
+        port: 0,
+        env: {
+          CONTEXTFORGE_DATA_DIR: dataDir,
+          CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+          CONTEXTFORGE_ADMIN_COOKIE_SECURE: 'sometimes',
+        },
+      }),
+    /CONTEXTFORGE_ADMIN_COOKIE_SECURE/,
+  );
 });
 
 test('HTTP server keeps admin UI login disabled unless credentials are configured', async () => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -4557,7 +4557,7 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.model, 'gpt-test');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.reasoningEffort, 'low');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.timeoutMs, 1234);
-  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v7');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v8');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.outputSchemaVersion, 'contextforge.checkpoint.v6');
   assert.equal(checkpoint.structured.schemaVersion, STRUCTURED_CHECKPOINT_SCHEMA_VERSION);
   assert.equal(checkpoint.metadata.structured.schemaVersion, STRUCTURED_CHECKPOINT_SCHEMA_VERSION);
@@ -4566,6 +4566,8 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   const promptPayload = JSON.parse(invocation.prompt.slice(invocation.prompt.indexOf('{')));
   assert.equal(promptPayload.requestedOutputSchema.structured.schemaVersion, STRUCTURED_CHECKPOINT_SCHEMA_VERSION);
   assert.match(invocation.prompt, /structured\.liveState/);
+  assert.match(invocation.prompt, /human-readable memoryCandidate review fields in Korean/);
+  assert.match(invocation.prompt, /content, reason, durabilityReason, and riskReason/);
   assert.deepEqual(invocation.args.slice(0, 2), ['exec', '--skip-git-repo-check']);
   assert.ok(invocation.args.includes('--output-schema'));
   assert.ok(invocation.args.includes('--output-last-message'));
@@ -4632,9 +4634,9 @@ test('codex_exec provider distills synthetic raw events through a runner', async
     sessionId: 'codex-session',
   });
   assert.equal(runs[0].status, 'succeeded');
-  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v7');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v8');
   assert.equal(runs[0].inputMetadata.providerMetadata.outputSchemaVersion, 'contextforge.checkpoint.v6');
-  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v7');
+  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v8');
 });
 
 test('codex_exec records JSON brace fallback recovery metadata', async () => {
@@ -5264,8 +5266,8 @@ test('codex_exec parse failures preserve raw evidence', async () => {
   });
   assert.equal(runs[0].status, 'failed');
   assert.equal(runs[0].outputMetadata.providerFailed, true);
-  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v7');
-  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v7');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v8');
+  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v8');
 });
 
 test('bootstrapContext returns semantic retrieval with trust and verification hints', async () => {
@@ -6449,6 +6451,7 @@ test('autoPromoteMemoryCandidates can audit through the Codex Python SDK provide
   assert.equal(auditInvocations[0].pythonCommand, 'python3');
   assert.equal(auditInvocations[0].pythonPath, '/tmp/contextforge-codex-sdk');
   assert.match(auditInvocations[0].prompt, /ContextForge automatic memory promotion auditor/);
+  assert.match(auditInvocations[0].prompt, /human-readable reason in Korean/);
   assert.ok(
     app.getMemory({ scope: 'repo', scopeKey: 'python-sdk-audit-repo', key: 'python-sdk-audit-runbook' }),
   );

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -4572,10 +4572,24 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.ok(invocation.args.includes('-c'));
   assert.ok(invocation.args.includes('model_reasoning_effort="low"'));
   assert.equal(invocation.timeoutMs, 1234);
-  assert.equal(schema.required.includes('structured'), false);
+  assert.equal(schema.required.includes('structured'), true);
   assert.ok(schema.properties.structured);
-  assert.equal(schema.properties.structured.properties.schemaVersion.const, STRUCTURED_CHECKPOINT_SCHEMA_VERSION);
+  assert.deepEqual(schema.properties.structured.type, ['object', 'null']);
+  assert.equal(schema.properties.structured.additionalProperties, false);
+  assert.deepEqual(schema.properties.structured.required, [
+    'schemaVersion',
+    'work',
+    'liveState',
+    'changes',
+    'verification',
+    'risks',
+    'nextActions',
+  ]);
+  assert.deepEqual(schema.properties.structured.properties.schemaVersion.enum, [STRUCTURED_CHECKPOINT_SCHEMA_VERSION]);
+  assert.equal(schema.properties.structured.properties.liveState.additionalProperties, false);
+  assert.ok(schema.properties.structured.properties.liveState.required.includes('verifyHints'));
   const candidateSchema = schema.properties.memoryCandidates.items;
+  assert.equal(candidateSchema.required.includes('schemaVersion'), true);
   assert.ok(candidateSchema.properties.durabilityReason);
   assert.ok(candidateSchema.properties.riskReason);
   assert.deepEqual(candidateSchema.properties.evidenceRefs.type, ['array', 'null']);
@@ -7929,10 +7943,25 @@ test('HTTP server serves admin UI assets', async () => {
   });
 
   try {
+    const redirect = await fetch(`${remote.url}/ui`, { redirect: 'manual' });
+    assert.equal(redirect.status, 308);
+    assert.equal(redirect.headers.get('location'), '/ui/');
+
     const response = await fetch(`${remote.url}/ui/`);
     assert.equal(response.status, 200);
     assert.equal(response.headers.get('cache-control'), 'no-store');
     assert.match(await response.text(), /ContextForge 관리/);
+
+    const script = await fetch(`${remote.url}/ui/app.js`);
+    assert.equal(script.status, 200);
+    assert.match(script.headers.get('content-type'), /text\/javascript/);
+
+    const stylesheet = await fetch(`${remote.url}/ui/styles.css`);
+    assert.equal(stylesheet.status, 200);
+    assert.match(stylesheet.headers.get('content-type'), /text\/css/);
+
+    const favicon = await fetch(`${remote.url}/favicon.ico`);
+    assert.equal(favicon.status, 204);
   } finally {
     await remote.close();
   }
@@ -7948,7 +7977,6 @@ test('HTTP server accepts admin UI login sessions', async () => {
       CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
       CONTEXTFORGE_ADMIN_USER: 'ginishuh',
       CONTEXTFORGE_ADMIN_PASSWORD_PBKDF2: testAdminPasswordHash(password),
-      CONTEXTFORGE_ADMIN_COOKIE_SECURE: 'false',
     },
   });
 
@@ -7962,6 +7990,7 @@ test('HTTP server accepts admin UI login sessions', async () => {
     assert.equal(login.headers.get('cache-control'), 'no-store');
     const cookie = login.headers.get('set-cookie');
     assert.match(cookie, /contextforge_admin=/);
+    assert.doesNotMatch(cookie, /;\s*Secure\b/);
     const session = await fetch(`${remote.url}/ui/session`, {
       headers: { cookie },
     });
@@ -7977,6 +8006,33 @@ test('HTTP server accepts admin UI login sessions', async () => {
       body: '{}',
     });
     assert.equal(info.status, 200);
+  } finally {
+    await remote.close();
+  }
+});
+
+test('HTTP server can force secure admin UI cookies for HTTPS deployments', async () => {
+  const dataDir = await makeTempDir();
+  const password = 'secure-cookie-CON' + 'TEXT';
+  const remote = await startContextForgeServer({
+    port: 0,
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_REMOTE_TOKEN: 'test-token',
+      CONTEXTFORGE_ADMIN_USER: 'ginishuh',
+      CONTEXTFORGE_ADMIN_PASSWORD_PBKDF2: testAdminPasswordHash(password),
+      CONTEXTFORGE_ADMIN_COOKIE_SECURE: 'true',
+    },
+  });
+
+  try {
+    const login = await fetch(`${remote.url}/ui/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ username: 'ginishuh', password }),
+    });
+    assert.equal(login.status, 200);
+    assert.match(login.headers.get('set-cookie'), /;\s*Secure\b/);
   } finally {
     await remote.close();
   }


### PR DESCRIPTION
## Summary
- make codex_exec structured checkpoint schema compatible with strict response schemas
- redirect /ui to /ui/ and serve UI assets/favicon cleanly
- make admin UI cookie security HTTP-aware so local HTTP UI sessions authorize /v0 calls

## Verification
- npm test
- git diff --check
- live UI smoke: /ui redirects, /ui/ and /ui/app.js return 200, bearer /v0/dbInfo returns 200
- codex_exec temp distill smoke produced a structured checkpoint without schema errors