### PR TITLE
Show structured distill output in admin UI

### DIFF
--- a/src/admin-ui/app.js
+++ b/src/admin-ui/app.js
@@ -4,6 +4,7 @@ const state = {
   scopeKeys: [],
   memories: [],
   candidates: [],
+  runs: [],
 };
 
 const $ = (selector) => document.querySelector(selector);
@@ -106,8 +107,39 @@ function table(rows, columns) {
     .join('')}</tbody></table>`;
 }
 
+function countLabel(label, value) {
+  const count = Array.isArray(value) ? value.length : 0;
+  return `${label} ${count}`;
+}
+
 function showDetail(title, content) {
   $('#detail').innerHTML = `<h2>${escapeHtml(title)}</h2><pre>${escapeHtml(JSON.stringify(content, null, 2))}</pre>`;
+  $('#detailDialog').showModal();
+}
+
+function showDistillDetail(bundle) {
+  const checkpoint = bundle.checkpoint;
+  const structured = checkpoint?.structured || checkpoint?.metadata?.structured || null;
+  const work = structured?.work || {};
+  const liveState = structured?.liveState || {};
+  $('#detail').innerHTML = `<h2>구조화 디스틸</h2>
+    <dl>
+      <dt>Run</dt><dd>${escapeHtml(bundle.run.id)}</dd>
+      <dt>Checkpoint</dt><dd>${escapeHtml(checkpoint?.id || bundle.run.outputMetadata?.checkpointId || '')}</dd>
+      <dt>세션</dt><dd>${escapeHtml(bundle.run.sessionId || '')}</dd>
+      <dt>프로바이더</dt><dd>${escapeHtml(bundle.run.provider || '')}</dd>
+      <dt>상태</dt><dd>${escapeHtml(bundle.run.status || '')}</dd>
+      <dt>작업 의도</dt><dd>${escapeHtml(work.intent || '')}</dd>
+      <dt>작업 상태</dt><dd>${escapeHtml(work.status || '')}</dd>
+      <dt>결과</dt><dd>${escapeHtml(work.outcome || '')}</dd>
+      <dt>브랜치</dt><dd>${escapeHtml(liveState.branch || '')}</dd>
+      <dt>PR</dt><dd>${escapeHtml(liveState.prNumber || liveState.prUrl || '')}</dd>
+      <dt>재검증 필요</dt><dd>${escapeHtml(liveState.verificationRequired == null ? '' : String(liveState.verificationRequired))}</dd>
+    </dl>
+    <h3>요약</h3>
+    <p>${escapeHtml(checkpoint?.summaryText || checkpoint?.summaryShort || '')}</p>
+    <h3>structured</h3>
+    <pre>${escapeHtml(JSON.stringify(structured, null, 2))}</pre>`;
   $('#detailDialog').showModal();
 }
 
@@ -327,15 +359,52 @@ async function loadRuns(target = '#runsTable', options = {}) {
   if (!scopeKey) return;
   const sessionId = options.sessionId ?? $('#runSession')?.value;
   const runs = await call('listDistillRuns', { scope, scopeKey, ...(sessionId ? { sessionId } : {}), limit: 25, order: 'desc' });
-  $(target).innerHTML = table(runs, [
-    { label: '생성 시각', value: (row) => row.createdAt },
-    { label: '스코프', value: (row) => `${row.scopeType}:${row.scopeKey}` },
-    { label: '프로바이더', value: (row) => row.provider },
-    { label: '상태', value: (row) => row.status },
-    { label: '세션', value: (row) => row.sessionId },
-    { label: '이벤트', value: (row) => row.sourceEventCount },
-    { label: '오류', value: (row) => row.errorMessage || '' },
-  ]);
+  const checkpointIds = new Set(runs.map((run) => run.outputMetadata?.checkpointId).filter(Boolean));
+  let checkpointById = new Map();
+  if (checkpointIds.size) {
+    const checkpoints = await call('listCheckpoints', { scope, scopeKey, ...(sessionId ? { sessionId } : {}), level: 0 });
+    checkpointById = new Map(checkpoints.filter((checkpoint) => checkpointIds.has(checkpoint.id)).map((checkpoint) => [checkpoint.id, checkpoint]));
+  }
+  state.runs = runs.map((run) => ({
+    run,
+    checkpoint: checkpointById.get(run.outputMetadata?.checkpointId) || null,
+  }));
+  $(target).innerHTML = state.runs.map(runItem).join('') || '<p class="muted">디스틸 실행 기록이 없습니다.</p>';
+  document.querySelectorAll('[data-run-detail]').forEach((button) => {
+    button.addEventListener('click', () => showDetail('디스틸 실행', state.runs[Number(button.dataset.runDetail)]));
+  });
+  document.querySelectorAll('[data-run-structured]').forEach((button) => {
+    button.addEventListener('click', () => showDistillDetail(state.runs[Number(button.dataset.runStructured)]));
+  });
+}
+
+function runItem(bundle, index) {
+  const { run, checkpoint } = bundle;
+  const structured = checkpoint?.structured || checkpoint?.metadata?.structured || null;
+  const work = structured?.work || {};
+  const liveState = structured?.liveState || {};
+  const checkpointId = checkpoint?.id || run.outputMetadata?.checkpointId || '';
+  const summary = checkpoint?.summaryShort || run.errorMessage || '체크포인트 본문이 없습니다.';
+  const structuredState = structured ? 'structured 있음' : 'structured 없음';
+  const counts = structured
+    ? [
+        countLabel('변경', structured.changes),
+        countLabel('검증', structured.verification),
+        countLabel('위험', structured.risks),
+        countLabel('다음 액션', structured.nextActions),
+      ].join(' · ')
+    : '구조화 payload 없음';
+  return `<article class="item">
+    <header><span class="item-title"><strong>${escapeHtml(run.createdAt || '')}</strong></span><span class="muted">${escapeHtml(run.status)} · ${escapeHtml(run.provider)} · ${escapeHtml(structuredState)}</span></header>
+    <p>${escapeHtml(summary.slice(0, 260))}</p>
+    <p class="muted">${escapeHtml(work.status || work.outcome || '')}${work.status || work.outcome ? ' · ' : ''}${escapeHtml(liveState.branch || liveState.prUrl || '')}</p>
+    <p class="muted">${escapeHtml(counts)}</p>
+    <div class="actions">
+      <button data-run-detail="${index}">실행 상세</button>
+      <button data-run-structured="${index}" ${structured ? '' : 'disabled'}>구조화 보기</button>
+      <span class="muted">${escapeHtml(checkpointId)}</span>
+    </div>
+  </article>`;
 }
 
 async function loadRecentRuns() {
@@ -414,13 +483,29 @@ function memoryItem(memory, index) {
   </article>`;
 }
 
+function candidateRecommendationLabel(value) {
+  const labels = {
+    promote: '승격 추천',
+    review: '검토 필요',
+    ignore: '무시 권장',
+    reject: '거절 권장',
+  };
+  return labels[String(value || '').toLowerCase()] || '추천 없음';
+}
+
 $('#loadCandidates').addEventListener('click', async (event) => {
   event.preventDefault();
   const scope = $('#memoryScope').value;
   const scopeKey = $('#memoryScopeKey').value;
-  const candidates = await call('listMemoryCandidates', { scope, scopeKey, limit: 100 });
+  const promotionRecommendation = $('#candidateRecommendation').value;
+  const request = { scope, scopeKey, status: 'pending', limit: 100 };
+  if (promotionRecommendation) request.promotionRecommendation = promotionRecommendation;
+  const candidates = await call('listMemoryCandidates', request);
   state.candidates = candidates;
-  $('#candidates').innerHTML = candidates.map(candidateItem).join('') || '<p class="muted">후보가 없습니다.</p>';
+  const emptyMessage = promotionRecommendation
+    ? `${candidateRecommendationLabel(promotionRecommendation)} 후보가 없습니다.`
+    : '원시 후보가 없습니다.';
+  $('#candidates').innerHTML = candidates.map(candidateItem).join('') || `<p class="muted">${escapeHtml(emptyMessage)}</p>`;
   document.querySelectorAll('[data-candidate]').forEach((button) => {
     button.addEventListener('click', () => showDetail('후보', candidates[Number(button.dataset.candidate)]));
   });
@@ -457,12 +542,17 @@ $('#loadCandidates').addEventListener('click', async (event) => {
 });
 
 function candidateItem(candidate, index) {
+  const recommendation = candidateRecommendationLabel(candidate.candidate.promotionRecommendation);
+  const type = candidate.candidate.candidateType || 'raw';
+  const confidence = candidate.candidate.confidence == null ? '' : ` · 신뢰도 ${candidate.candidate.confidence}`;
+  const stability = candidate.candidate.stability == null ? '' : ` · 안정성 ${candidate.candidate.stability}`;
   return `<article class="item">
-    <header><span class="item-title"><input type="checkbox" data-candidate-select="${index}" aria-label="후보 선택" /><strong>${escapeHtml(candidate.candidate.key)}</strong></span><span class="muted">${escapeHtml(candidate.status)}</span></header>
+    <header><span class="item-title"><input type="checkbox" data-candidate-select="${index}" aria-label="후보 선택" /><strong>${escapeHtml(candidate.candidate.key)}</strong></span><span class="muted">${escapeHtml(candidate.status)} · ${escapeHtml(recommendation)}</span></header>
     <p>${escapeHtml(candidate.candidate.content.slice(0, 220))}</p>
+    <p class="muted">원시 디스틸 후보 · ${escapeHtml(type)}${escapeHtml(confidence)}${escapeHtml(stability)}</p>
     <div class="actions">
       <button data-candidate="${index}">상세</button>
-      <button data-promote="${index}">승격</button>
+      <button data-promote="${index}">검토 후 승격</button>
       <button class="danger" data-reject="${index}">거절</button>
     </div>
   </article>`;

--- a/src/admin-ui/index.html
+++ b/src/admin-ui/index.html
@@ -174,6 +174,7 @@
             <label>스코프 키 <select id="memoryScopeKey"></select></label>
             <label>검색 <input id="memoryQuery" /></label>
             <label>상태 <select id="memoryStatus"><option value="active">활성</option><option value="inactive">비활성</option><option value="all">전체</option></select></label>
+            <label>후보 추천 <select id="candidateRecommendation"><option value="promote">승격 추천</option><option value="review">검토 필요</option><option value="ignore">무시 권장</option><option value="reject">거절 권장</option><option value="">전체 원시 후보</option></select></label>
           </div>
           <div class="actions">
             <button id="loadMemories">메모리 불러오기</button>
@@ -191,7 +192,7 @@
             <div id="memories" class="list"></div>
           </section>
           <section class="panel">
-            <h2>승격 후보</h2>
+            <h2>후보 검토</h2>
             <div class="actions bulkbar">
               <button id="selectAllCandidates">전체 선택</button>
               <button id="clearCandidateSelection">선택 해제</button>

--- a/src/distill/providers/codex_exec.js
+++ b/src/distill/providers/codex_exec.js
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { STRUCTURED_CHECKPOINT_SCHEMA_VERSION } from '../validate.js';
 
-export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v8';
+export const CODEX_EXEC_PROMPT_VERSION = 'codex_exec.prompt.v9';
 export const CODEX_EXEC_OUTPUT_SCHEMA_VERSION = 'contextforge.checkpoint.v6';
 
 function nullableStringSchema() {
@@ -347,6 +347,8 @@ export function buildCodexExecPrompt(input, options = {}) {
       'For memoryCandidates, include optional v2 fields when useful: schemaVersion="contextforge.memory_candidate.v2", durabilityReason, riskReason, evidenceRefs, and suggestedAction.',
       'For nullable memoryCandidate fields that are not applicable, return null; do not omit required schema fields.',
       'Create memoryCandidates only for facts, decisions, preferences, runbook steps, or failure modes that may remain useful beyond this checkpoint.',
+      'Do not create memoryCandidates for one-time PR status updates, ordinary test pass records, review comments posted, temporary smoke-test ports, draft CI state, branch cleanup, or other transient work logs unless they reveal a reusable repo runbook, stable preference, architecture decision, API contract, or recurring failure mode.',
+      'Do not set promotionRecommendation="promote" for PR-specific findings, review comments, or verification snapshots until they have been resolved or generalized into durable guidance.',
       'Write human-readable memoryCandidate review fields in Korean by default: content, reason, durabilityReason, and riskReason.',
       'Do not mix English prose into those Korean memoryCandidate review fields unless preserving exact technical identifiers, code symbols, file paths, commands, model names, API names, product names, or quoted error strings.',
       'Keep memoryCandidate keys, categories, tags, enum values, sourceEventIds, evidenceRefs, and schemaVersion machine-readable and in their original technical form.',

--- a/src/distill/providers/openai_compatible.js
+++ b/src/distill/providers/openai_compatible.js
@@ -1,7 +1,7 @@
 import { buildCodexExecPrompt, CHECKPOINT_OUTPUT_SCHEMA, CODEX_EXEC_OUTPUT_SCHEMA_VERSION } from './codex_exec.js';
 import { validateDistillOutput } from '../validate.js';
 
-export const OPENAI_COMPATIBLE_PROMPT_VERSION = 'openai_compatible.prompt.v2';
+export const OPENAI_COMPATIBLE_PROMPT_VERSION = 'openai_compatible.prompt.v3';
 
 const DEFAULT_TIMEOUT_MS = 120000;
 const DEFAULT_BASE_URL = 'https://api.deepseek.com';

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -4557,7 +4557,7 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.model, 'gpt-test');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.reasoningEffort, 'low');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.timeoutMs, 1234);
-  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v8');
+  assert.equal(checkpoint.metadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v9');
   assert.equal(checkpoint.metadata.providerMetadata.codexExec.outputSchemaVersion, 'contextforge.checkpoint.v6');
   assert.equal(checkpoint.structured.schemaVersion, STRUCTURED_CHECKPOINT_SCHEMA_VERSION);
   assert.equal(checkpoint.metadata.structured.schemaVersion, STRUCTURED_CHECKPOINT_SCHEMA_VERSION);
@@ -4568,6 +4568,8 @@ test('codex_exec provider distills synthetic raw events through a runner', async
   assert.match(invocation.prompt, /structured\.liveState/);
   assert.match(invocation.prompt, /human-readable memoryCandidate review fields in Korean/);
   assert.match(invocation.prompt, /content, reason, durabilityReason, and riskReason/);
+  assert.match(invocation.prompt, /one-time PR status updates/);
+  assert.match(invocation.prompt, /review comments posted/);
   assert.deepEqual(invocation.args.slice(0, 2), ['exec', '--skip-git-repo-check']);
   assert.ok(invocation.args.includes('--output-schema'));
   assert.ok(invocation.args.includes('--output-last-message'));
@@ -4634,9 +4636,9 @@ test('codex_exec provider distills synthetic raw events through a runner', async
     sessionId: 'codex-session',
   });
   assert.equal(runs[0].status, 'succeeded');
-  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v8');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v9');
   assert.equal(runs[0].inputMetadata.providerMetadata.outputSchemaVersion, 'contextforge.checkpoint.v6');
-  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v8');
+  assert.equal(runs[0].outputMetadata.providerMetadata.codexExec.promptVersion, 'codex_exec.prompt.v9');
 });
 
 test('codex_exec records JSON brace fallback recovery metadata', async () => {
@@ -5266,8 +5268,8 @@ test('codex_exec parse failures preserve raw evidence', async () => {
   });
   assert.equal(runs[0].status, 'failed');
   assert.equal(runs[0].outputMetadata.providerFailed, true);
-  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v8');
-  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v8');
+  assert.equal(runs[0].inputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v9');
+  assert.equal(runs[0].outputMetadata.providerMetadata.promptVersion, 'codex_exec.prompt.v9');
 });
 
 test('bootstrapContext returns semantic retrieval with trust and verification hints', async () => {
@@ -7957,11 +7959,19 @@ test('HTTP server serves admin UI assets', async () => {
     const response = await fetch(`${remote.url}/ui/`);
     assert.equal(response.status, 200);
     assert.equal(response.headers.get('cache-control'), 'no-store');
-    assert.match(await response.text(), /ContextForge 관리/);
+    const html = await response.text();
+    assert.match(html, /ContextForge 관리/);
+    assert.match(html, /후보 검토/);
+    assert.match(html, /candidateRecommendation/);
 
     const script = await fetch(`${remote.url}/ui/app.js`);
     assert.equal(script.status, 200);
     assert.match(script.headers.get('content-type'), /text\/javascript/);
+    const scriptText = await script.text();
+    assert.match(scriptText, /promotionRecommendation/);
+    assert.match(scriptText, /원시 디스틸 후보/);
+    assert.match(scriptText, /구조화 디스틸/);
+    assert.match(scriptText, /structured 있음/);
 
     const stylesheet = await fetch(`${remote.url}/ui/styles.css`);
     assert.equal(stylesheet.status, 200);


### PR DESCRIPTION
## 요약
- 실행 기록 탭에서 distill run과 연결된 checkpoint를 함께 표시합니다.
- checkpoint에 structured payload가 있으면 structured 있음 상태와 구조화 보기 버튼으로 실제 구조화 디스틸 내용을 확인할 수 있게 했습니다.
- 메모리 후보 화면은 raw pending 후보를 승격 추천처럼 보이지 않게 후보 검토로 바꾸고, 추천 필터와 원시 후보 표시를 추가했습니다.
- distill prompt는 일회성 PR 상태, 테스트 통과, 리뷰 댓글, 임시 smoke port 같은 transient 로그를 memoryCandidate로 만들지 않도록 더 보수적으로 조정했습니다.

## 검증
- npm test 135/135 pass
- git diff --check pass