### PR TITLE
Run batched candidate audits automatically

### DIFF
--- a/docs/skills/contextforge-memory/SKILL.md
+++ b/docs/skills/contextforge-memory/SKILL.md
@@ -145,15 +145,17 @@ durable memory unless it is stable, reviewed, and no cheaper live source exists.
 
 ## Closeout Promotion
 
-At closeout triggers only, review durable memory candidates:
+At closeout triggers only, make sure durable memory candidates are audited:
 
-1. If `distill_checkpoint` returned candidates, call `suggest_memory_promotions` with the returned `checkpointId` or the current `sessionId`.
-2. If `session_status` reports `latestCheckpointMemoryCandidateCount > 0`, call `suggest_memory_promotions` or `list_memory_candidates` with that same `sessionId` or latest checkpoint id.
-3. If `suggest_memory_promotions` returns `missing_closeout_source`, no current-session review happened. Provide `sessionId` or `checkpointId`.
-4. When the user wants audited recommendations without writes, call
-   `audit_memory_candidates` with the same `sessionId` or `checkpointId`.
-   It should return read-only audit decisions and must not mutate memory or
-   candidate status.
+1. When distilling closeout evidence, pass `auditTrigger` to `distill_checkpoint`
+   so ContextForge runs the configured batched candidate audit automatically.
+2. Automatic candidate audit is scoped to the current `sessionId` or explicit
+   `checkpointId`. It never scans the whole scope backlog.
+3. Audit results are stored on pending candidates. Automatic promotion controls
+   only whether audit-approved strict-safe results are written to durable memory.
+4. Use `audit_memory_candidates` to inspect stored audited recommendations or to
+   audit unaudited candidates in the same closeout batch. It must not mutate
+   durable memory.
 5. Promote only reviewed, stable, scoped, non-secret facts.
 6. Prefer `promote_memory_candidate` by `candidateId`.
 7. Use `remember` or `promote_memory` for a corrected durable write when the candidate key/content is wrong.
@@ -161,11 +163,10 @@ At closeout triggers only, review durable memory candidates:
 
 `suggest_memory_promotions` defaults to `promotionRecommendation: "promote"`. If candidates exist but proposals are empty, inspect with `list_memory_candidates`; for `promotionRecommendation: "review"` candidates, either call `suggest_memory_promotions` with `promotionRecommendation: "review"` or manually review the listed candidates.
 
-Use `auto_promote_memory_candidates` only when automatic promotion is explicitly
-wanted. It must include `sessionId` or `checkpointId`; real promotion requires
-server-side enablement and `dryRun: false`. Dry runs preview policy results but
-may not execute the audit runner; use `audit_memory_candidates` when the user
-specifically wants audited read-only recommendations.
+Use `auto_promote_memory_candidates` only when automatic write-side promotion is
+explicitly wanted. It must include `sessionId` or `checkpointId`; real promotion
+requires server-side enablement and `dryRun: false`. Candidate audit itself is
+not the toggle; promotion writes are the toggle.
 
 ## What To Promote
 

--- a/src/admin-ui/app.js
+++ b/src/admin-ui/app.js
@@ -540,7 +540,7 @@ async function loadAuditedCandidates() {
     scopeKey,
     trigger: 'manual_closeout',
     ...(checkpointId ? { checkpointId } : { sessionId }),
-    limit: 3,
+    limit: 10,
     scanLimit: 100,
   });
   state.candidates = result.proposals || [];
@@ -564,8 +564,8 @@ async function loadAuditedCandidates() {
         key,
         content,
         category: candidate.category || 'note',
-        tags: [],
-        importance: 0,
+        tags: candidate.tags || [],
+        importance: candidate.importance ?? 0,
         allowWarnings: true,
       });
       await loadAuditedCandidates();
@@ -663,7 +663,7 @@ $('#rejectSelectedCandidates').addEventListener('click', async (event) => {
   for (const index of indexes) {
     const candidate = state.candidates[index];
     if (candidate) {
-      await call('rejectMemoryCandidate', { scope, scopeKey, candidateId: candidate.id, reason });
+      await call('rejectMemoryCandidate', { scope, scopeKey, candidateId: candidate.candidateId, reason });
     }
   }
   $('#loadCandidates').click();

--- a/src/admin-ui/app.js
+++ b/src/admin-ui/app.js
@@ -112,6 +112,10 @@ function countLabel(label, value) {
   return `${label} ${count}`;
 }
 
+function checkpointStructured(checkpoint) {
+  return checkpoint?.structured || checkpoint?.metadata?.structured || null;
+}
+
 function showDetail(title, content) {
   $('#detail').innerHTML = `<h2>${escapeHtml(title)}</h2><pre>${escapeHtml(JSON.stringify(content, null, 2))}</pre>`;
   $('#detailDialog').showModal();
@@ -119,7 +123,7 @@ function showDetail(title, content) {
 
 function showDistillDetail(bundle) {
   const checkpoint = bundle.checkpoint;
-  const structured = checkpoint?.structured || checkpoint?.metadata?.structured || null;
+  const structured = checkpointStructured(checkpoint);
   const work = structured?.work || {};
   const liveState = structured?.liveState || {};
   $('#detail').innerHTML = `<h2>구조화 디스틸</h2>
@@ -376,11 +380,27 @@ async function loadRuns(target = '#runsTable', options = {}) {
   document.querySelectorAll('[data-run-structured]').forEach((button) => {
     button.addEventListener('click', () => showDistillDetail(state.runs[Number(button.dataset.runStructured)]));
   });
+  document.querySelectorAll('[data-run-audit]').forEach((button) => {
+    button.addEventListener('click', async () => {
+      const bundle = state.runs[Number(button.dataset.runAudit)];
+      const checkpointId = bundle.checkpoint?.id || bundle.run.outputMetadata?.checkpointId || '';
+      if (!checkpointId) return;
+      $('#memoryScope').value = bundle.run.scopeType;
+      await fillScopeKeySelect($('#memoryScopeKey'), bundle.run.scopeType);
+      $('#memoryScopeKey').value = bundle.run.scopeKey;
+      $('#candidateSession').value = bundle.run.sessionId || '';
+      $('#candidateCheckpoint').value = checkpointId;
+      document.querySelectorAll('.tabs button, .tab').forEach((item) => item.classList.remove('active'));
+      document.querySelector('[data-tab="memory"]').classList.add('active');
+      $('#memory').classList.add('active');
+      await loadAuditedCandidates();
+    });
+  });
 }
 
 function runItem(bundle, index) {
   const { run, checkpoint } = bundle;
-  const structured = checkpoint?.structured || checkpoint?.metadata?.structured || null;
+  const structured = checkpointStructured(checkpoint);
   const work = structured?.work || {};
   const liveState = structured?.liveState || {};
   const checkpointId = checkpoint?.id || run.outputMetadata?.checkpointId || '';
@@ -402,6 +422,7 @@ function runItem(bundle, index) {
     <div class="actions">
       <button data-run-detail="${index}">실행 상세</button>
       <button data-run-structured="${index}" ${structured ? '' : 'disabled'}>구조화 보기</button>
+      <button data-run-audit="${index}" ${checkpointId ? '' : 'disabled'}>감사 후보 보기</button>
       <span class="muted">${escapeHtml(checkpointId)}</span>
     </div>
   </article>`;
@@ -483,76 +504,102 @@ function memoryItem(memory, index) {
   </article>`;
 }
 
-function candidateRecommendationLabel(value) {
+function auditedActionLabel(value) {
   const labels = {
-    promote: '승격 추천',
-    review: '검토 필요',
-    ignore: '무시 권장',
-    reject: '거절 권장',
+    promote: '감사 승인',
+    review: '사람 검토',
+    ask_user: '사용자 확인',
+    dry_run_only: '드라이런',
   };
-  return labels[String(value || '').toLowerCase()] || '추천 없음';
+  return labels[String(value || '').toLowerCase()] || '감사 결과';
 }
 
-$('#loadCandidates').addEventListener('click', async (event) => {
-  event.preventDefault();
+function auditDecisionLabel(audit) {
+  if (!audit) return '감사 미실행';
+  const labels = {
+    approve: 'approve',
+    needs_review: 'needs_review',
+    reject: 'reject',
+  };
+  return labels[String(audit.decision || '').toLowerCase()] || String(audit.decision || 'unknown');
+}
+
+async function loadAuditedCandidates() {
   const scope = $('#memoryScope').value;
   const scopeKey = $('#memoryScopeKey').value;
-  const promotionRecommendation = $('#candidateRecommendation').value;
-  const request = { scope, scopeKey, status: 'pending', limit: 100 };
-  if (promotionRecommendation) request.promotionRecommendation = promotionRecommendation;
-  const candidates = await call('listMemoryCandidates', request);
-  state.candidates = candidates;
-  const emptyMessage = promotionRecommendation
-    ? `${candidateRecommendationLabel(promotionRecommendation)} 후보가 없습니다.`
-    : '원시 후보가 없습니다.';
-  $('#candidates').innerHTML = candidates.map(candidateItem).join('') || `<p class="muted">${escapeHtml(emptyMessage)}</p>`;
+  const sessionId = $('#candidateSession').value.trim();
+  const checkpointId = $('#candidateCheckpoint').value.trim();
+  if (!sessionId && !checkpointId) {
+    state.candidates = [];
+    $('#candidates').innerHTML =
+      '<p class="muted">감사할 세션 또는 체크포인트를 선택하세요. 실행 기록에서 감사 후보 보기를 누르면 자동으로 채워집니다.</p>';
+    return;
+  }
+  const result = await call('auditMemoryCandidates', {
+    scope,
+    scopeKey,
+    trigger: 'manual_closeout',
+    ...(checkpointId ? { checkpointId } : { sessionId }),
+    limit: 3,
+    scanLimit: 100,
+  });
+  state.candidates = result.proposals || [];
+  const warnings = (result.requestWarnings || []).map((warning) => warning.message || warning.code).join('\n');
+  const emptyMessage = warnings || 'GPT-5.5 감사 후보가 없습니다.';
+  $('#candidates').innerHTML = state.candidates.map(candidateItem).join('') || `<p class="muted">${escapeHtml(emptyMessage)}</p>`;
   document.querySelectorAll('[data-candidate]').forEach((button) => {
-    button.addEventListener('click', () => showDetail('후보', candidates[Number(button.dataset.candidate)]));
+    button.addEventListener('click', () => showDetail('감사 후보', state.candidates[Number(button.dataset.candidate)]));
   });
   document.querySelectorAll('[data-promote]').forEach((button) => {
     button.addEventListener('click', async () => {
-      const candidate = candidates[Number(button.dataset.promote)];
-      const key = prompt('메모리 키', candidate.candidate.key);
+      const candidate = state.candidates[Number(button.dataset.promote)];
+      const key = prompt('메모리 키', candidate.key);
       if (!key) return;
-      const content = prompt('메모리 내용', candidate.candidate.content);
+      const content = prompt('메모리 내용', candidate.content);
       if (!content) return;
       await call('promoteMemoryCandidate', {
         scope,
         scopeKey,
-        candidateId: candidate.id,
+        candidateId: candidate.candidateId,
         key,
         content,
-        category: candidate.candidate.category || 'note',
-        tags: candidate.candidate.tags || [],
-        importance: candidate.candidate.importance || 0,
+        category: candidate.category || 'note',
+        tags: [],
+        importance: 0,
         allowWarnings: true,
       });
-      $('#loadCandidates').click();
+      await loadAuditedCandidates();
     });
   });
   document.querySelectorAll('[data-reject]').forEach((button) => {
     button.addEventListener('click', async () => {
-      const candidate = candidates[Number(button.dataset.reject)];
+      const candidate = state.candidates[Number(button.dataset.reject)];
       const reason = prompt('후보 거절 이유를 입력하세요.');
       if (!reason) return;
-      await call('rejectMemoryCandidate', { scope, scopeKey, candidateId: candidate.id, reason });
-      $('#loadCandidates').click();
+      await call('rejectMemoryCandidate', { scope, scopeKey, candidateId: candidate.candidateId, reason });
+      await loadAuditedCandidates();
     });
   });
+}
+
+$('#loadCandidates').addEventListener('click', async (event) => {
+  event.preventDefault();
+  await loadAuditedCandidates();
 });
 
 function candidateItem(candidate, index) {
-  const recommendation = candidateRecommendationLabel(candidate.candidate.promotionRecommendation);
-  const type = candidate.candidate.candidateType || 'raw';
-  const confidence = candidate.candidate.confidence == null ? '' : ` · 신뢰도 ${candidate.candidate.confidence}`;
-  const stability = candidate.candidate.stability == null ? '' : ` · 안정성 ${candidate.candidate.stability}`;
+  const action = auditedActionLabel(candidate.recommendedAction);
+  const decision = auditDecisionLabel(candidate.audit);
+  const risks = Array.isArray(candidate.audit?.riskCodes) && candidate.audit.riskCodes.length
+    ? ` · 위험 ${candidate.audit.riskCodes.join(', ')}`
+    : '';
   return `<article class="item">
-    <header><span class="item-title"><input type="checkbox" data-candidate-select="${index}" aria-label="후보 선택" /><strong>${escapeHtml(candidate.candidate.key)}</strong></span><span class="muted">${escapeHtml(candidate.status)} · ${escapeHtml(recommendation)}</span></header>
-    <p>${escapeHtml(candidate.candidate.content.slice(0, 220))}</p>
-    <p class="muted">원시 디스틸 후보 · ${escapeHtml(type)}${escapeHtml(confidence)}${escapeHtml(stability)}</p>
+    <header><span class="item-title"><input type="checkbox" data-candidate-select="${index}" aria-label="후보 선택" /><strong>${escapeHtml(candidate.key)}</strong></span><span class="muted">${escapeHtml(action)} · ${escapeHtml(decision)}</span></header>
+    <p>${escapeHtml(candidate.content.slice(0, 220))}</p>
+    <p class="muted">GPT 감사 후보 · ${escapeHtml(candidate.category || 'note')} · ${escapeHtml(candidate.auditReason || candidate.whyDurable || '')}${escapeHtml(risks)}</p>
     <div class="actions">
       <button data-candidate="${index}">상세</button>
-      <button data-promote="${index}">검토 후 승격</button>
+      <button data-promote="${index}" ${candidate.recommendedAction === 'promote' ? '' : 'disabled'}>승격</button>
       <button class="danger" data-reject="${index}">거절</button>
     </div>
   </article>`;

--- a/src/admin-ui/index.html
+++ b/src/admin-ui/index.html
@@ -174,11 +174,12 @@
             <label>스코프 키 <select id="memoryScopeKey"></select></label>
             <label>검색 <input id="memoryQuery" /></label>
             <label>상태 <select id="memoryStatus"><option value="active">활성</option><option value="inactive">비활성</option><option value="all">전체</option></select></label>
-            <label>후보 추천 <select id="candidateRecommendation"><option value="promote">승격 추천</option><option value="review">검토 필요</option><option value="ignore">무시 권장</option><option value="reject">거절 권장</option><option value="">전체 원시 후보</option></select></label>
+            <label>후보 세션 <input id="candidateSession" placeholder="선택 사항" /></label>
+            <label>후보 체크포인트 <input id="candidateCheckpoint" placeholder="선택 사항" /></label>
           </div>
           <div class="actions">
             <button id="loadMemories">메모리 불러오기</button>
-            <button id="loadCandidates">후보 불러오기</button>
+            <button id="loadCandidates">감사 후보 불러오기</button>
           </div>
         </section>
         <div class="split">
@@ -193,6 +194,7 @@
           </section>
           <section class="panel">
             <h2>후보 검토</h2>
+            <p class="muted">GPT-5.5 감사 결과만 표시합니다. 자동승격 설정은 실제 저장 여부만 제어합니다.</p>
             <div class="actions bulkbar">
               <button id="selectAllCandidates">전체 선택</button>
               <button id="clearCandidateSelection">선택 해제</button>

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -254,6 +254,16 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
           'CONTEXTFORGE_AUTO_PROMOTE_AUDIT_CODEX_TIMEOUT_MS',
           120000,
         ),
+        minBatchCandidates: parsePositiveInteger(
+          env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_MIN_BATCH_CANDIDATES,
+          'CONTEXTFORGE_AUTO_PROMOTE_AUDIT_MIN_BATCH_CANDIDATES',
+          5,
+        ),
+        batchLimit: parsePositiveInteger(
+          env.CONTEXTFORGE_AUTO_PROMOTE_AUDIT_BATCH_LIMIT,
+          'CONTEXTFORGE_AUTO_PROMOTE_AUDIT_BATCH_LIMIT',
+          5,
+        ),
       },
     },
     codexExec: {

--- a/src/core.js
+++ b/src/core.js
@@ -1115,6 +1115,13 @@ function auditedPromotionProposal(indexedCandidate, warnings, audit, rank, { aud
   };
 }
 
+function storedAuditProposal(indexedCandidate, rank) {
+  const audit = indexedCandidate.reviewMetadata?.audit || null;
+  return auditedPromotionProposal(indexedCandidate, [], audit, rank, {
+    auditEnabled: Boolean(audit),
+  });
+}
+
 function promoteCandidateToMemory(
   store,
   scope,
@@ -2734,7 +2741,7 @@ export function createContextForge(options = {}) {
           };
         }
 
-        if (options.sessionId && !checkpointId) {
+        if (options.sessionId && sourceMode === 'latest_checkpoint' && !checkpointId) {
           return {
             kind: 'memory_promotion_suggestions',
             trigger,
@@ -2880,12 +2887,14 @@ export function createContextForge(options = {}) {
         let sourceMode = null;
         if (checkpointId) {
           sourceMode = 'checkpoint';
+        } else if (options.sessionId) {
+          sourceMode = 'session_pending_batch';
         } else {
           const latestCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId, level: 0 });
           checkpointId = latestCheckpoint?.id || null;
           sourceMode = 'latest_checkpoint';
         }
-        const auditor = checkpointId ? getAutoPromoteAuditor(store) : null;
+        const auditor = checkpointId || options.sessionId ? getAutoPromoteAuditor(store) : null;
         const auditPolicy = {
           enabled: Boolean(auditor),
           executed: false,
@@ -2893,7 +2902,7 @@ export function createContextForge(options = {}) {
           model: auditor?.metadata?.model || null,
           reasoningEffort: auditor?.metadata?.reasoningEffort || null,
         };
-        if (options.sessionId && !checkpointId) {
+        if (options.sessionId && sourceMode === 'latest_checkpoint' && !checkpointId) {
           return {
             kind: 'memory_candidate_audit_suggestions',
             trigger,
@@ -2921,7 +2930,7 @@ export function createContextForge(options = {}) {
         }
 
         const policy = { minConfidence, minStability, allowedCategories };
-        const candidates = store.listMemoryCandidates({
+        const allCandidates = store.listMemoryCandidates({
           ...scope,
           sessionId: options.sessionId || null,
           checkpointId,
@@ -2930,6 +2939,10 @@ export function createContextForge(options = {}) {
           sort: 'recommendation',
           limit: scanLimit,
         });
+        const storedAudited = truthyOption(options.force)
+          ? []
+          : allCandidates.filter((candidate) => candidate.reviewMetadata?.audit);
+        const candidates = allCandidates.filter((candidate) => truthyOption(options.force) || !candidate.reviewMetadata?.audit);
         const assessed = candidates.map((candidate) => {
           const warnings = autoPromotionWarnings(store, scope, candidate, policy);
           const score = scorePromotionCandidate(candidate, warnings, AUTO_PROMOTE_SKIP_WARNING_CODES);
@@ -2940,20 +2953,51 @@ export function createContextForge(options = {}) {
           .sort((a, b) => b.score - a.score)
           .slice(0, limit);
         const audited = [];
+        const auditBatchId = randomUUID();
         for (const item of selected) {
           try {
             const audit = await auditAutoPromotionCandidate({ auditor, store, scope, item });
-            audited.push({ ...item, audit });
+            const auditedCandidate = store.markMemoryCandidateAudited({
+              ...scope,
+              candidateId: item.candidate.id,
+              audit,
+              reason: audit.reason,
+              metadata: {
+                auditBatchId,
+                trigger,
+                sourceMode,
+                checkpointId,
+                sessionId: options.sessionId || null,
+                mutates: false,
+              },
+            });
+            audited.push({ ...item, candidate: auditedCandidate, audit });
           } catch (error) {
+            const audit = {
+              approved: false,
+              decision: 'needs_review',
+              reason: `Memory candidate audit failed: ${error.message}`,
+              riskCodes: ['audit_failed'],
+              metadata: { errorName: error.name },
+            };
+            const auditedCandidate = store.markMemoryCandidateAudited({
+              ...scope,
+              candidateId: item.candidate.id,
+              audit,
+              reason: audit.reason,
+              metadata: {
+                auditBatchId,
+                trigger,
+                sourceMode,
+                checkpointId,
+                sessionId: options.sessionId || null,
+                mutates: false,
+              },
+            });
             audited.push({
               ...item,
-              audit: {
-                approved: false,
-                decision: 'needs_review',
-                reason: `Memory candidate audit failed: ${error.message}`,
-                riskCodes: ['audit_failed'],
-                metadata: { errorName: error.name },
-              },
+              candidate: auditedCandidate,
+              audit,
             });
           }
         }
@@ -2977,11 +3021,14 @@ export function createContextForge(options = {}) {
               executed: Boolean(auditor) && audited.length > 0,
             },
           },
-          proposals: audited.map((item, index) =>
-            auditedPromotionProposal(item.candidate, item.warnings, item.audit, index + 1, {
-              auditEnabled: Boolean(auditor),
-            }),
-          ),
+          proposals: [
+            ...storedAudited.map((candidate, index) => storedAuditProposal(candidate, index + 1)),
+            ...audited.map((item, index) =>
+              auditedPromotionProposal(item.candidate, item.warnings, item.audit, storedAudited.length + index + 1, {
+                auditEnabled: Boolean(auditor),
+              }),
+            ),
+          ].slice(0, limit),
           skipped: assessed
             .filter((item) => item.score <= 0)
             .map((item) => ({
@@ -3079,12 +3126,14 @@ export function createContextForge(options = {}) {
         let sourceMode = null;
         if (checkpointId) {
           sourceMode = 'checkpoint';
+        } else if (options.sessionId) {
+          sourceMode = 'session_pending_batch';
         } else {
           const latestCheckpoint = store.getLatestCheckpoint({ ...scope, sessionId: options.sessionId, level: 0 });
           checkpointId = latestCheckpoint?.id || null;
           sourceMode = 'latest_checkpoint';
         }
-        if (options.sessionId && !checkpointId) {
+        if (options.sessionId && sourceMode === 'latest_checkpoint' && !checkpointId) {
           return {
             kind: 'auto_memory_promotion_result',
             trigger,
@@ -3134,21 +3183,36 @@ export function createContextForge(options = {}) {
         const auditor = getAutoPromoteAuditor(store);
         const audited = [];
         if (!dryRun) {
-          for (const item of selected) {
-            try {
-              const audit = await auditAutoPromotionCandidate({ auditor, store, scope, item });
-              audited.push({ ...item, audit });
-            } catch (error) {
+          if (!auditor) {
+            for (const item of selected) {
               audited.push({
                 ...item,
                 audit: {
                   approved: false,
                   decision: 'needs_review',
-                  reason: `Auto-promotion audit failed: ${error.message}`,
-                  riskCodes: ['audit_failed'],
-                  metadata: { errorName: error.name },
+                  reason: 'Auto-promotion audit provider is disabled; automatic promotion requires audit approval.',
+                  riskCodes: ['audit_disabled'],
+                  metadata: { provider: 'none' },
                 },
               });
+            }
+          } else {
+            for (const item of selected) {
+              try {
+                const audit = await auditAutoPromotionCandidate({ auditor, store, scope, item });
+                audited.push({ ...item, audit });
+              } catch (error) {
+                audited.push({
+                  ...item,
+                  audit: {
+                    approved: false,
+                    decision: 'needs_review',
+                    reason: `Auto-promotion audit failed: ${error.message}`,
+                    riskCodes: ['audit_failed'],
+                    metadata: { errorName: error.name },
+                  },
+                });
+              }
             }
           }
         }
@@ -4081,12 +4145,140 @@ export function createContextForge(options = {}) {
           throw checkpointError;
         }
 
+        let candidateAudit = {
+          enabled: false,
+          executed: false,
+          reason: 'no_candidates',
+          audited: 0,
+          promoted: 0,
+          error: null,
+        };
+        try {
+          const auditTrigger = options.auditTrigger || options.trigger || null;
+          const forceAudit = CLOSEOUT_TRIGGERS.has(auditTrigger);
+          const effectiveForAudit = getEffectiveRuntime(store);
+          const auditConfig = effectiveForAudit.autoPromoteAudit || {};
+          const minBatchCandidates = Number(auditConfig.minBatchCandidates || 5);
+          const batchLimit = Number(auditConfig.batchLimit || 5);
+          const unauditedPending = store
+            .listMemoryCandidates({
+              ...scope,
+              sessionId: options.sessionId,
+              status: 'pending',
+              promotionRecommendation: 'promote',
+              sort: 'recommendation',
+              limit: Math.max(minBatchCandidates, batchLimit, 1),
+            })
+            .filter((candidate) => !candidate.reviewMetadata?.audit);
+          const shouldAudit =
+            checkpointLevel === 0 &&
+            unauditedPending.length > 0 &&
+            (forceAudit || unauditedPending.length >= minBatchCandidates);
+          if (!shouldAudit) {
+            candidateAudit = {
+              ...candidateAudit,
+              enabled: auditConfig.enabled !== false,
+              reason:
+                checkpointLevel !== 0
+                  ? 'non_level_zero_checkpoint'
+                  : unauditedPending.length === 0
+                    ? 'no_unaudited_pending_candidates'
+                    : 'below_batch_threshold',
+              pendingUnaudited: unauditedPending.length,
+              minBatchCandidates,
+            };
+          } else {
+            const auditor = getAutoPromoteAuditor(store);
+            const policy = {
+              minConfidence: 0.85,
+              minStability: 0.85,
+              allowedCategories: SAFE_AUTO_PROMOTE_CATEGORIES,
+            };
+            const assessed = unauditedPending.map((candidate) => {
+              const warnings = autoPromotionWarnings(store, scope, candidate, policy);
+              const score = scorePromotionCandidate(candidate, warnings, AUTO_PROMOTE_SKIP_WARNING_CODES);
+              return { candidate, warnings, score };
+            });
+            const selected = assessed
+              .filter((item) => item.score > 0)
+              .sort((a, b) => b.score - a.score)
+              .slice(0, batchLimit);
+            const auditBatchId = randomUUID();
+            let auditedCount = 0;
+            let promotedCount = 0;
+            for (const item of selected) {
+              let audit;
+              try {
+                audit = await auditAutoPromotionCandidate({ auditor, store, scope, item });
+              } catch (error) {
+                audit = {
+                  approved: false,
+                  decision: 'needs_review',
+                  reason: `Automatic candidate audit failed: ${error.message}`,
+                  riskCodes: ['audit_failed'],
+                  metadata: { errorName: error.name },
+                };
+              }
+              const auditedCandidate = store.markMemoryCandidateAudited({
+                ...scope,
+                candidateId: item.candidate.id,
+                audit,
+                reason: audit.reason,
+                metadata: {
+                  auditBatchId,
+                  trigger: auditTrigger || 'batch_threshold',
+                  sourceMode: forceAudit ? 'closeout_batch' : 'threshold_batch',
+                  sessionId: options.sessionId,
+                  checkpointId: checkpoint.id,
+                  minBatchCandidates,
+                  batchLimit,
+                  autoPromoteEnabled: config.autoPromote.enabled,
+                },
+              });
+              auditedCount += 1;
+              if (config.autoPromote.enabled && auditor && audit.approved === true) {
+                const reason =
+                  'Auto-promoted after automatic batched candidate audit approved this strict safe candidate.';
+                const memory = autoPromoteIndexedCandidate(store, scope, auditedCandidate, item.warnings, reason, audit);
+                enqueueEmbeddingSources(store, [store.embeddingSourceForMemory(memory)]);
+                promotedCount += 1;
+              }
+            }
+            candidateAudit = {
+              enabled: Boolean(auditor),
+              executed: selected.length > 0,
+              reason: forceAudit ? 'closeout_trigger' : 'batch_threshold',
+              trigger: auditTrigger || null,
+              pendingUnaudited: unauditedPending.length,
+              selected: selected.length,
+              audited: auditedCount,
+              promoted: promotedCount,
+              minBatchCandidates,
+              batchLimit,
+              provider: auditor?.metadata?.provider || 'none',
+              model: auditor?.metadata?.model || null,
+              reasoningEffort: auditor?.metadata?.reasoningEffort || null,
+              error: null,
+            };
+          }
+        } catch (error) {
+          candidateAudit = {
+            enabled: true,
+            executed: false,
+            reason: 'audit_error',
+            audited: 0,
+            promoted: 0,
+            error: errorSummary(error),
+          };
+        }
+
         store.completeDistillRun({
           id: distillRun.id,
           outputMetadata: {
             checkpointId: checkpoint.id,
             provider: checkpoint.provider,
             memoryCandidateCount: output.memoryCandidates.length,
+            candidateAudit,
             workingSummaryUpdated: Boolean(workingSummary),
             workingSummaryId: workingSummary?.id || null,
             workingSummaryError: errorSummary(workingSummaryError),
@@ -4126,6 +4318,7 @@ export function createContextForge(options = {}) {
         return {
           ...checkpoint,
           memoryCandidateCount: output.memoryCandidates.length,
+          candidateAudit,
           workingSummary: {
             updated: Boolean(workingSummary),
             id: workingSummary?.id || null,

--- a/src/core.js
+++ b/src/core.js
@@ -969,6 +969,8 @@ function promotionProposal(indexedCandidate, warnings, rank) {
     key: candidate.key,
     category: candidate.category,
     content: candidate.content,
+    tags: candidate.tags || [],
+    importance: candidate.importance ?? 0,
     evidence: {
       reason: candidate.reason || null,
       sourceEventIds: candidate.sourceEventIds || [],
@@ -1115,10 +1117,15 @@ function auditedPromotionProposal(indexedCandidate, warnings, audit, rank, { aud
   };
 }
 
+function hasRealAuditProvider(audit) {
+  const provider = audit?.metadata?.provider;
+  return Boolean(provider && provider !== 'none');
+}
+
 function storedAuditProposal(indexedCandidate, rank) {
   const audit = indexedCandidate.reviewMetadata?.audit || null;
   return auditedPromotionProposal(indexedCandidate, [], audit, rank, {
-    auditEnabled: Boolean(audit),
+    auditEnabled: hasRealAuditProvider(audit),
   });
 }
 
@@ -1208,10 +1215,10 @@ function autoPromoteIndexedCandidate(store, scope, indexedCandidate, warnings, r
 async function auditAutoPromotionCandidate({ auditor, store, scope, item }) {
   if (!auditor) {
     return {
-      approved: true,
-      decision: 'approve',
-      reason: 'Auto-promotion audit disabled; local strict safety checks only.',
-      riskCodes: [],
+      approved: false,
+      decision: 'needs_review',
+      reason: 'Auto-promotion audit provider is disabled; GPT audit approval is required.',
+      riskCodes: ['audit_disabled'],
       metadata: { provider: 'none' },
     };
   }
@@ -2811,13 +2818,13 @@ export function createContextForge(options = {}) {
         throw new Error('trigger must be a closeout trigger.');
       }
       const requestedLimit = positiveNumber(options.limit == null ? 3 : Number(options.limit), 'limit');
-      const limit = Math.min(3, requestedLimit);
+      const limit = Math.min(10, requestedLimit);
       const requestWarnings =
-        requestedLimit > 3
+        requestedLimit > 10
           ? [
               {
                 code: 'limit_capped',
-                message: 'audit_memory_candidates returns at most 3 proposals.',
+                message: 'audit_memory_candidates returns at most 10 proposals.',
                 requestedLimit,
                 effectiveLimit: limit,
               },
@@ -2943,6 +2950,41 @@ export function createContextForge(options = {}) {
           ? []
           : allCandidates.filter((candidate) => candidate.reviewMetadata?.audit);
         const candidates = allCandidates.filter((candidate) => truthyOption(options.force) || !candidate.reviewMetadata?.audit);
+        if (!auditor) {
+          return {
+            kind: 'memory_candidate_audit_suggestions',
+            trigger,
+            source: {
+              sessionId: options.sessionId || null,
+              checkpointId,
+              mode: sourceMode,
+            },
+            policy: {
+              minConfidence,
+              minStability,
+              allowedCategories: Array.from(allowedCategories),
+              scopeFallback: false,
+              mutates: false,
+              audit: auditPolicy,
+            },
+            proposals: storedAudited.map((candidate, index) => storedAuditProposal(candidate, index + 1)).slice(0, limit),
+            skipped: candidates.map((candidate) => ({
+              candidateId: candidate.id,
+              reason: 'audit_disabled',
+            })),
+            requestWarnings: [
+              ...requestWarnings,
+              {
+                code: 'audit_disabled',
+                message: 'Automatic candidate audit provider is disabled; no new GPT audit results were stored.',
+              },
+            ],
+            nextActions: [
+              'Enable the automatic candidate audit provider before requesting GPT-reviewed candidate suggestions.',
+              'No memory candidates were promoted.',
+            ],
+          };
+        }
         const assessed = candidates.map((candidate) => {
           const warnings = autoPromotionWarnings(store, scope, candidate, policy);
           const score = scorePromotionCandidate(candidate, warnings, AUTO_PROMOTE_SKIP_WARNING_CODES);
@@ -4160,6 +4202,8 @@ export function createContextForge(options = {}) {
           const auditConfig = effectiveForAudit.autoPromoteAudit || {};
           const minBatchCandidates = Number(auditConfig.minBatchCandidates || 5);
           const batchLimit = Number(auditConfig.batchLimit || 5);
+          const scanLimit = Math.max(minBatchCandidates, batchLimit, 1) * 10;
+          const auditor = getAutoPromoteAuditor(store);
           const unauditedPending = store
             .listMemoryCandidates({
               ...scope,
@@ -4167,28 +4211,40 @@ export function createContextForge(options = {}) {
               status: 'pending',
               promotionRecommendation: 'promote',
               sort: 'recommendation',
-              limit: Math.max(minBatchCandidates, batchLimit, 1),
+              limit: scanLimit,
             })
             .filter((candidate) => !candidate.reviewMetadata?.audit);
           const shouldAudit =
             checkpointLevel === 0 &&
+            Boolean(auditor) &&
             unauditedPending.length > 0 &&
             (forceAudit || unauditedPending.length >= minBatchCandidates);
           if (!shouldAudit) {
+            const wouldAuditIfEnabled =
+              checkpointLevel === 0 &&
+              !auditor &&
+              unauditedPending.length > 0 &&
+              (forceAudit || unauditedPending.length >= minBatchCandidates);
             candidateAudit = {
               ...candidateAudit,
-              enabled: auditConfig.enabled !== false,
+              enabled: Boolean(auditor),
               reason:
                 checkpointLevel !== 0
                   ? 'non_level_zero_checkpoint'
+                  : wouldAuditIfEnabled
+                    ? 'audit_disabled'
                   : unauditedPending.length === 0
                     ? 'no_unaudited_pending_candidates'
                     : 'below_batch_threshold',
               pendingUnaudited: unauditedPending.length,
               minBatchCandidates,
+              batchLimit,
+              scanLimit,
+              provider: auditor?.metadata?.provider || 'none',
+              model: auditor?.metadata?.model || null,
+              reasoningEffort: auditor?.metadata?.reasoningEffort || null,
             };
           } else {
-            const auditor = getAutoPromoteAuditor(store);
             const policy = {
               minConfidence: 0.85,
               minStability: 0.85,
@@ -4255,6 +4311,7 @@ export function createContextForge(options = {}) {
               promoted: promotedCount,
               minBatchCandidates,
               batchLimit,
+              scanLimit,
               provider: auditor?.metadata?.provider || 'none',
               model: auditor?.metadata?.model || null,
               reasoningEffort: auditor?.metadata?.reasoningEffort || null,

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -30,9 +30,9 @@ const MCP_INSTRUCTIONS = [
   'Read bootstrap_context.handoff.latestCheckpoints before durable memory for recent work status, recent decisions, open todos, branch/PR/CI flow, and next actions. Durable memory is for reviewed stable facts, contracts, policies, and runbooks. Verify mutable checkpoint claims with git/GitHub/CI/runtime/migrations before final action.',
   'Search result types have different trust roles: memory is reviewed durable fact or decision; checkpoint is credible recent handoff state for continuity, planning, prior intent, recent decisions, and unfinished work, but mutable live-state claims must be verified with git/GitHub/CI/runtime/migrations before acting; memory_candidate is unreviewed promotion material and not durable truth.',
   'For task start or loose continuation prompts such as "지난 환경 작업과 동기화", "어제 하던 거 이어서", "previous work", or "continue", call bootstrap_context first; it includes latest checkpoint handoff independent of search ranking. Use sync_resume_context only when you know the exact sessionId and need session working state or raw tail.',
-  'For closeout triggers only, call suggest_memory_promotions with the current sessionId or the checkpointId returned by distill_checkpoint: after this agent merges a PR, after the user says they merged and the agent syncs main/cleans branches, or when the user explicitly says today\'s work is done. Suggest at most 1-3 durable memory promotions and never promote automatically.',
-  'When an agent needs audited closeout recommendations without writes, call audit_memory_candidates with sessionId or checkpointId. It runs the configured audit provider and returns proposals for promote/edit/skip/reject, but never mutates durable memory or candidate status.',
-  'For strict closeout-scoped safe automatic promotion, call auto_promote_memory_candidates only when the user wants automatic promotion and always include sessionId or checkpointId. By default use dryRun=true. Use dryRun=false only when CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true is intentionally configured; never use scope-wide backlog fallback and never auto-promote preference candidates.',
+  'For closeout distillation, pass auditTrigger to distill_checkpoint. Candidate audit is automatic and batched: session pending candidates are audited after closeout triggers or once the configured batch threshold is reached. Audit results are stored on candidates; automatic promotion only controls whether approved strict-safe results are written to durable memory.',
+  'When an agent needs to inspect audited recommendations, call audit_memory_candidates with sessionId or checkpointId. It returns stored audit proposals and audits unaudited candidates in the same scoped batch when needed, but never mutates durable memory.',
+  'For strict closeout-scoped safe automatic promotion, call auto_promote_memory_candidates only when the user wants write-side automatic promotion and always include sessionId or checkpointId. By default use dryRun=true. Use dryRun=false only when CONTEXTFORGE_AUTO_PROMOTE_ENABLED=true is intentionally configured; never use scope-wide backlog fallback and never auto-promote preference candidates.',
   'Preference-like candidates are tracked as merged occurrences; use list_preference_occurrences to review repeated evidence and weakened corrections, but do not treat occurrence evidence alone as durable preference truth.',
   'For user corrections such as "너 잘못 알고 있잖아", "그거 아니야", "그건 X가 아니라 Y야", or "기억 수정해", call reconcile_memory. Show the basis for prior knowledge, assess conflicts, and only apply safe corrections when the user explicitly asks to fix memory.',
   'Use list_memory_update_candidates to review proposed durable-memory corrections, deactivations, duplicate merges, or corrective notes. reconcile_memory propose mode is read-only by default; pass createUpdateCandidates=true only when persistent review proposals are wanted. Apply or reject update candidates only after explicit user approval.',
@@ -504,7 +504,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Distill Checkpoint',
       description:
-        'Distill raw session evidence into a checkpoint with the configured provider. Keep the returned checkpointId and memoryCandidateCount for closeout review with suggest_memory_promotions, list_memory_candidates, or auto_promote_memory_candidates. level defaults to 0 for session distills; higher levels are reserved for later daily/weekly consolidation.',
+        'Distill raw session evidence into a checkpoint with the configured provider. Returns checkpointId and memoryCandidateCount. Candidate audit runs automatically in scoped batches when auditTrigger is supplied or the batch threshold is reached; automatic promotion only writes approved strict-safe audit results when enabled. level defaults to 0 for session distills; higher levels are reserved for later daily/weekly consolidation.',
       inputSchema: {
         ...scopedSchema,
         sessionId: z.string(),
@@ -517,6 +517,9 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
         coversTo: z.string().optional(),
         source: z.enum(['distill', 'daily_consolidation', 'weekly_consolidation', 'topic_batch', 'manual']).optional(),
         sourceRef: z.string().optional(),
+        auditTrigger: z
+          .enum(['agent_merged_pr', 'user_merged_then_synced', 'user_declared_work_done', 'manual_closeout'])
+          .optional(),
       },
       annotations: {
         title: 'Distill Checkpoint',
@@ -768,7 +771,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Audit Memory Candidates',
       description:
-        'Run the configured audit provider on closeout-scoped pending memory candidates and return read-only audited recommendations for the agent/user to choose from. Requires sessionId or checkpointId, never scans scope fallback, and never promotes or changes candidate status.',
+        'Return stored audited recommendations and run the configured audit provider on unaudited closeout-scoped pending memory candidates when needed. Requires sessionId or checkpointId, never scans scope fallback, and never promotes or changes candidate status.',
       inputSchema: {
         ...scopedSchema,
         sessionId: z.string().optional(),

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -2770,6 +2770,53 @@ export class ContextForgeStore {
     return this.getMemoryCandidate({ scopeType, scopeKey, candidateId });
   }
 
+  markMemoryCandidateAudited({
+    scopeType,
+    scopeKey,
+    candidateId,
+    audit,
+    reason = null,
+    metadata = {},
+    expectedStatus = 'pending',
+  }) {
+    const existing = this.getMemoryCandidate({ scopeType, scopeKey, candidateId });
+    if (!existing) {
+      throw new Error(`Memory candidate not found: ${candidateId}`);
+    }
+    if (existing.status !== expectedStatus) {
+      throw new Error(`Memory candidate ${candidateId} is ${existing.status}; expected ${expectedStatus}.`);
+    }
+    const reviewedAt = nowIso();
+    const reviewMetadata = {
+      ...(existing.reviewMetadata || {}),
+      audit,
+      auditMetadata: metadata,
+      auditedAt: reviewedAt,
+    };
+    const result = this.db
+      .prepare(`
+        UPDATE memory_candidate_index
+        SET reviewed_at = ?,
+            review_reason = ?,
+            review_metadata_json = ?
+        WHERE scope_type = ?
+          AND scope_key = ?
+          AND id = ?
+      `)
+      .run(
+        reviewedAt,
+        reason || audit?.reason || existing.reviewReason || null,
+        json(reviewMetadata, {}),
+        scopeType,
+        scopeKey,
+        candidateId,
+      );
+    if (result.changes === 0) {
+      throw new Error(`Memory candidate not found: ${candidateId}`);
+    }
+    return this.getMemoryCandidate({ scopeType, scopeKey, candidateId });
+  }
+
   insertCheckpoint({
     scopeType,
     scopeKey,

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -5930,7 +5930,7 @@ test('auditMemoryCandidates returns audited read-only recommendations', async ()
     scopeKey: 'audit-suggestions-repo',
     checkpointId: checkpoint.id,
     trigger: 'user_declared_work_done',
-    limit: 5,
+    limit: 50,
   });
 
   assert.equal(result.kind, 'memory_candidate_audit_suggestions');
@@ -6051,6 +6051,103 @@ test('distillCheckpoint automatically audits session candidate batches', async (
   assert.equal(storedAudit.proposals.length, 2);
   assert.equal(storedAudit.proposals[0].audit.metadata.model, 'gpt-5.5');
   assert.equal(auditInvocations.length, 2);
+});
+
+test('distillCheckpoint audits new candidates even when audited pending candidates fill the first window', async () => {
+  const dataDir = await makeTempDir();
+  const auditInvocations = [];
+  let distillCount = 0;
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'batch_window_provider',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_MIN_BATCH_CANDIDATES: '2',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_BATCH_LIMIT: '2',
+    },
+    cwd: process.cwd(),
+    autoPromoteAuditor: async ({ candidate }) => {
+      auditInvocations.push(candidate.candidate.key);
+      return {
+        approved: true,
+        decision: 'approve',
+        reason: `Audited ${candidate.candidate.key}.`,
+        riskCodes: [],
+        metadata: {
+          provider: 'codex_sdk_python',
+          model: 'gpt-5.5',
+        },
+      };
+    },
+    distillProviders: {
+      batch_window_provider: async () => {
+        distillCount += 1;
+        return {
+          summaryShort: `Batch audit checkpoint ${distillCount}.`,
+          summaryText: 'The checkpoint produced enough candidates for automatic batched audit.',
+          decisions: [],
+          todos: [],
+          openQuestions: [],
+          memoryCandidates: [
+            {
+              key: `batch-window-${distillCount}-a`,
+              content: `Batch audit candidate A ${distillCount}.`,
+              category: 'runbook',
+              candidateType: 'runbook',
+              confidence: 0.96,
+              stability: 0.96,
+              sensitivity: 'low',
+              promotionRecommendation: 'promote',
+            },
+            {
+              key: `batch-window-${distillCount}-b`,
+              content: `Batch audit candidate B ${distillCount}.`,
+              category: 'api-contract',
+              candidateType: 'api-contract',
+              confidence: 0.95,
+              stability: 0.95,
+              sensitivity: 'low',
+              promotionRecommendation: 'promote',
+            },
+          ],
+        };
+      },
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'batch-window-repo',
+    sessionId: 'batch-window-session',
+    role: 'assistant',
+    content: 'First audit batch.',
+  });
+  const first = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'batch-window-repo',
+    sessionId: 'batch-window-session',
+  });
+  assert.equal(first.candidateAudit.audited, 2);
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'batch-window-repo',
+    sessionId: 'batch-window-session',
+    role: 'assistant',
+    content: 'Second audit batch should not be blocked by the first audited pending batch.',
+  });
+  const second = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'batch-window-repo',
+    sessionId: 'batch-window-session',
+  });
+
+  assert.equal(second.candidateAudit.executed, true);
+  assert.equal(second.candidateAudit.audited, 2);
+  assert.deepEqual(auditInvocations, [
+    'batch-window-1-a',
+    'batch-window-1-b',
+    'batch-window-2-a',
+    'batch-window-2-b',
+  ]);
 });
 
 test('distillCheckpoint waits below audit threshold but closeout trigger forces audit', async () => {
@@ -6175,11 +6272,23 @@ test('auditMemoryCandidates keeps recommendations conservative when audit is dis
     role: 'assistant',
     content: 'Audit disabled read-only candidate.',
   });
-  await app.distillCheckpoint({
+  const checkpoint = await app.distillCheckpoint({
     scope: 'repo',
     scopeKey: 'audit-disabled-repo',
     sessionId: 'audit-disabled-session',
+    auditTrigger: 'manual_closeout',
   });
+  assert.equal(checkpoint.candidateAudit.executed, false);
+  assert.equal(checkpoint.candidateAudit.reason, 'audit_disabled');
+
+  const pendingBeforeAudit = app.listMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'audit-disabled-repo',
+    sessionId: 'audit-disabled-session',
+    status: 'pending',
+  });
+  assert.equal(pendingBeforeAudit.length, 1);
+  assert.equal(pendingBeforeAudit[0].reviewMetadata.audit, undefined);
 
   const result = await app.auditMemoryCandidates({
     scope: 'repo',
@@ -6190,11 +6299,18 @@ test('auditMemoryCandidates keeps recommendations conservative when audit is dis
 
   assert.equal(result.policy.audit.enabled, false);
   assert.equal(result.policy.audit.executed, false);
-  assert.equal(result.proposals.length, 1);
-  assert.equal(result.proposals[0].recommendedAction, 'review');
-  assert.equal(result.proposals[0].audit.approved, true);
-  assert.equal(result.proposals[0].audit.metadata.provider, 'none');
+  assert.equal(result.proposals.length, 0);
+  assert.equal(result.skipped.length, 1);
+  assert.equal(result.skipped[0].reason, 'audit_disabled');
+  assert.ok(result.requestWarnings.some((warning) => warning.code === 'audit_disabled'));
   assert.equal(app.getMemory({ scope: 'repo', scopeKey: 'audit-disabled-repo', key: 'audit-disabled-runbook' }), null);
+  const pendingAfterAudit = app.listMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'audit-disabled-repo',
+    sessionId: 'audit-disabled-session',
+    status: 'pending',
+  });
+  assert.equal(pendingAfterAudit[0].reviewMetadata.audit, undefined);
 });
 
 test('autoPromoteMemoryCandidates returns stable empty arrays and preference input warnings', async () => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -5955,6 +5955,188 @@ test('auditMemoryCandidates returns audited read-only recommendations', async ()
   assert.equal(pendingCandidates[0].candidate.key, 'audited-readonly-runbook');
 });
 
+test('distillCheckpoint automatically audits session candidate batches', async () => {
+  const dataDir = await makeTempDir();
+  const auditInvocations = [];
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'batch_audit_provider',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_MIN_BATCH_CANDIDATES: '2',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_BATCH_LIMIT: '2',
+    },
+    cwd: process.cwd(),
+    autoPromoteAuditor: async ({ candidate }) => {
+      auditInvocations.push(candidate.id);
+      return {
+        approved: true,
+        decision: 'approve',
+        reason: `Audited ${candidate.candidate.key} in a batch.`,
+        riskCodes: [],
+        metadata: {
+          provider: 'codex_sdk_python',
+          model: 'gpt-5.5',
+          reasoningEffort: 'low',
+        },
+      };
+    },
+    distillProviders: {
+      batch_audit_provider: async () => ({
+        summaryShort: 'Batch audit checkpoint.',
+        summaryText: 'The checkpoint produced enough candidates for automatic batched audit.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'batch-audit-runbook',
+            content: 'Run automatic candidate audits in batches.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.96,
+            stability: 0.96,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+          {
+            key: 'batch-audit-contract',
+            content: 'Automatic promotion writes require audit approval.',
+            category: 'api-contract',
+            candidateType: 'api-contract',
+            confidence: 0.95,
+            stability: 0.95,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'batch-audit-repo',
+    sessionId: 'batch-audit-session',
+    role: 'assistant',
+    content: 'Create enough candidates for batch audit.',
+  });
+
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'batch-audit-repo',
+    sessionId: 'batch-audit-session',
+  });
+
+  assert.equal(checkpoint.candidateAudit.executed, true);
+  assert.equal(checkpoint.candidateAudit.reason, 'batch_threshold');
+  assert.equal(checkpoint.candidateAudit.audited, 2);
+  assert.equal(checkpoint.candidateAudit.promoted, 0);
+  assert.equal(auditInvocations.length, 2);
+  const candidates = app.listMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'batch-audit-repo',
+    sessionId: 'batch-audit-session',
+    status: 'pending',
+  });
+  assert.equal(candidates.length, 2);
+  assert.ok(candidates.every((candidate) => candidate.reviewMetadata.audit?.metadata?.model === 'gpt-5.5'));
+  assert.ok(candidates.every((candidate) => candidate.reviewMetadata.auditMetadata?.sourceMode === 'threshold_batch'));
+
+  const storedAudit = await app.auditMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'batch-audit-repo',
+    sessionId: 'batch-audit-session',
+    trigger: 'manual_closeout',
+    limit: 2,
+  });
+  assert.equal(storedAudit.proposals.length, 2);
+  assert.equal(storedAudit.proposals[0].audit.metadata.model, 'gpt-5.5');
+  assert.equal(auditInvocations.length, 2);
+});
+
+test('distillCheckpoint waits below audit threshold but closeout trigger forces audit', async () => {
+  const dataDir = await makeTempDir();
+  let auditCount = 0;
+  let distillCount = 0;
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'closeout_audit_provider',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_MIN_BATCH_CANDIDATES: '5',
+    },
+    cwd: process.cwd(),
+    autoPromoteAuditor: async () => {
+      auditCount += 1;
+      return {
+        approved: false,
+        decision: 'needs_review',
+        reason: 'Closeout audit should run even below the batch threshold.',
+        riskCodes: [],
+        metadata: {
+          provider: 'codex_sdk_python',
+          model: 'gpt-5.5',
+        },
+      };
+    },
+    distillProviders: {
+      closeout_audit_provider: async () => {
+        distillCount += 1;
+        return {
+          summaryShort: 'Closeout audit checkpoint.',
+          summaryText: 'The checkpoint produced one candidate.',
+          decisions: [],
+          todos: [],
+          openQuestions: [],
+          memoryCandidates: [
+            {
+              key: `closeout-audit-${distillCount}`,
+              content: `Closeout audits force candidate review ${distillCount}.`,
+              category: 'runbook',
+              candidateType: 'runbook',
+              confidence: 0.96,
+              stability: 0.96,
+              sensitivity: 'low',
+              promotionRecommendation: 'promote',
+            },
+          ],
+        };
+      },
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'closeout-audit-repo',
+    sessionId: 'closeout-audit-session',
+    role: 'assistant',
+    content: 'First candidate should wait below threshold.',
+  });
+  const first = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'closeout-audit-repo',
+    sessionId: 'closeout-audit-session',
+  });
+  assert.equal(first.candidateAudit.executed, false);
+  assert.equal(first.candidateAudit.reason, 'below_batch_threshold');
+  assert.equal(auditCount, 0);
+
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'closeout-audit-repo',
+    sessionId: 'closeout-audit-session',
+    role: 'assistant',
+    content: 'Closeout should force audit.',
+  });
+  const second = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'closeout-audit-repo',
+    sessionId: 'closeout-audit-session',
+    auditTrigger: 'manual_closeout',
+  });
+  assert.equal(second.candidateAudit.executed, true);
+  assert.equal(second.candidateAudit.reason, 'closeout_trigger');
+  assert.equal(second.candidateAudit.audited, 2);
+  assert.equal(auditCount, 2);
+});
+
 test('auditMemoryCandidates keeps recommendations conservative when audit is disabled', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({
@@ -7962,14 +8144,15 @@ test('HTTP server serves admin UI assets', async () => {
     const html = await response.text();
     assert.match(html, /ContextForge 관리/);
     assert.match(html, /후보 검토/);
-    assert.match(html, /candidateRecommendation/);
+    assert.match(html, /candidateSession/);
+    assert.match(html, /감사 후보 불러오기/);
 
     const script = await fetch(`${remote.url}/ui/app.js`);
     assert.equal(script.status, 200);
     assert.match(script.headers.get('content-type'), /text\/javascript/);
     const scriptText = await script.text();
-    assert.match(scriptText, /promotionRecommendation/);
-    assert.match(scriptText, /원시 디스틸 후보/);
+    assert.match(scriptText, /auditMemoryCandidates/);
+    assert.match(scriptText, /GPT 감사 후보/);
     assert.match(scriptText, /구조화 디스틸/);
     assert.match(scriptText, /structured 있음/);
 


### PR DESCRIPTION
## 요약
- distillCheckpoint 성공 후 세션 pending 후보를 묶어서 자동 감사합니다.
- 기본 cadence는 batch threshold 도달 시 자동 감사, closeout auditTrigger가 있으면 threshold와 무관하게 강제 감사입니다.
- 감사 결과는 pending 후보 review metadata에 저장하고, 후보 상태나 durable memory는 바꾸지 않습니다.
- 자동승격은 audit-approved strict-safe 후보를 durable memory로 write할지 여부만 제어합니다.
- Admin UI 후보 검토는 GPT 감사 결과 중심으로 표시하고, 실행 기록에서 해당 세션/체크포인트 후보 검토로 이동할 수 있게 했습니다.
- MCP/skill 안내를 새 감사 cadence에 맞게 갱신했습니다.

## 감사 cadence
- distill은 자주 실행될 수 있습니다.
- 감사는 세션 단위 pending 후보 batch로 실행됩니다.
- 기본 threshold: CONTEXTFORGE_AUTO_PROMOTE_AUDIT_MIN_BATCH_CANDIDATES=5
- 기본 batch limit: CONTEXTFORGE_AUTO_PROMOTE_AUDIT_BATCH_LIMIT=5
- closeout distill은 auditTrigger를 넘기면 후보 수와 무관하게 감사합니다.
- 자동승격 OFF 상태에서는 감사 결과만 저장되고 memory write는 없습니다.

## 검증
- npm test 137/137 pass
- git diff --check pass
