### PR TITLE
Add scope key alias migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added scope-key aliases plus an explicit `migrateScope` command for safely
+  canonicalizing renamed or transferred repository scopes without read-union
+  ambiguity.
 - Fixed `/ui` asset loading for requests without a trailing slash and made
   admin UI session cookies HTTP-aware by default while preserving `Secure`
   cookies for HTTPS reverse-proxy deployments.

--- a/README.ko.md
+++ b/README.ko.md
@@ -87,6 +87,33 @@ node src/cli.js dbInfo
 기본값은 현재 checkout 아래 `.contextforge/contextforge.db`에 저장하는
 `project-local` 모드다. 이 디렉터리와 SQLite sidecar 파일은 git에 넣지 않는다.
 
+repo가 이전되거나 이름이 바뀐 경우에는 서버 또는 local runtime에
+`CONTEXTFORGE_SCOPE_ALIASES`를 설정해서 이후 read/write를 canonical scope로
+접을 수 있다.
+
+```bash
+CONTEXTFORGE_SCOPE_ALIASES='repo:github.com/old/suite=repo:github.com/new/suite'
+```
+
+scope prefix를 생략하면 `repo`로 취급한다. `dbInfo`에서 로드된 alias를 확인할
+수 있다. 기존 row는 자동으로 옮기지 않는다. 먼저 dry-run으로 확인한 뒤 명시적으로
+migration을 실행한다.
+
+```bash
+node src/cli.js migrateScope \
+  --fromScope repo \
+  --fromScopeKey github.com/old/suite \
+  --toScope repo \
+  --toScopeKey github.com/new/suite
+
+node src/cli.js migrateScope \
+  --fromScope repo \
+  --fromScopeKey github.com/old/suite \
+  --toScope repo \
+  --toScopeKey github.com/new/suite \
+  --dryRun false
+```
+
 ## 저장 모드
 
 - `project-local`: checkout-local SQLite. 기본값이며 실험에 좋다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -93,6 +93,7 @@ repo가 이전되거나 이름이 바뀐 경우에는 서버 또는 local runtim
 
 ```bash
 CONTEXTFORGE_SCOPE_ALIASES='repo:github.com/old/suite=repo:github.com/new/suite'
+CONTEXTFORGE_SCOPE_ALIASES='{"repo:github.com/old/suite":"repo:github.com/new/suite"}'
 ```
 
 scope prefix를 생략하면 `repo`로 취급한다. `dbInfo`에서 로드된 alias를 확인할

--- a/README.ko.md
+++ b/README.ko.md
@@ -96,8 +96,11 @@ CONTEXTFORGE_SCOPE_ALIASES='repo:github.com/old/suite=repo:github.com/new/suite'
 ```
 
 scope prefix를 생략하면 `repo`로 취급한다. `dbInfo`에서 로드된 alias를 확인할
-수 있다. 기존 row는 자동으로 옮기지 않는다. 먼저 dry-run으로 확인한 뒤 명시적으로
-migration을 실행한다.
+수 있다. alias는 scope type을 바꿀 수 없으므로 `repo:old=repo:new`처럼 같은
+scope type 안에서만 사용한다. 구조화된 env 값을 선호하는 배포에서는 JSON object
+또는 array 형식도 사용할 수 있다. 기존 row는 자동으로 옮기지 않으며, alias를 켜면
+old scope row는 일반 scoped read에서 가려진다. 먼저 dry-run으로 확인한 뒤
+명시적으로 migration을 실행한다.
 
 ```bash
 node src/cli.js migrateScope \
@@ -113,6 +116,10 @@ node src/cli.js migrateScope \
   --toScopeKey github.com/new/suite \
   --dryRun false
 ```
+
+`migrateScope`의 `fromScope`/`fromScopeKey`는 alias canonicalization을 거치지
+않는 raw stored scope로 처리한다. 그래서 alias 설정 전에 쓰인 old row를 찾을 수
+있다. `toScope`/`toScopeKey`는 alias를 거쳐 canonical scope로 접힌다.
 
 ## 저장 모드
 

--- a/README.md
+++ b/README.md
@@ -161,8 +161,11 @@ CONTEXTFORGE_SCOPE_ALIASES='repo:github.com/old/suite=repo:github.com/new/suite'
 ```
 
 Scope prefixes are optional and default to `repo`. `dbInfo` reports the loaded
-aliases. Existing rows are not moved implicitly; inspect and migrate them
-explicitly:
+aliases. Aliases cannot change scope type; use `repo:old=repo:new`, not
+`repo:old=shared:new`. JSON object and array forms are also accepted for
+deployments that prefer structured environment values. Existing rows are not
+moved implicitly, and once an alias is enabled those old rows are hidden from
+normal scoped reads until you migrate them. Inspect and migrate them explicitly:
 
 ```bash
 node src/cli.js migrateScope \
@@ -178,6 +181,10 @@ node src/cli.js migrateScope \
   --toScopeKey github.com/new/suite \
   --dryRun false
 ```
+
+`migrateScope` treats `fromScope`/`fromScopeKey` as the raw stored scope, without
+alias canonicalization, so it can still find rows written before the alias was
+configured. `toScope`/`toScopeKey` is canonicalized through aliases.
 
 ## Usage Modes
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ comma, newline, or semicolon separated entries with `=` or `->` separators:
 
 ```bash
 CONTEXTFORGE_SCOPE_ALIASES='repo:github.com/old/suite=repo:github.com/new/suite'
+CONTEXTFORGE_SCOPE_ALIASES='{"repo:github.com/old/suite":"repo:github.com/new/suite"}'
 ```
 
 Scope prefixes are optional and default to `repo`. `dbInfo` reports the loaded

--- a/README.md
+++ b/README.md
@@ -152,6 +152,33 @@ same GitHub repo. Outside a git checkout it falls back to a deterministic
 `path:<hash>:<name>` key. Pass `--scopeKey` or set
 `CONTEXTFORGE_DEFAULT_SCOPE_KEY` when you want an explicit canonical scope key.
 
+When a repository moves or is renamed, set `CONTEXTFORGE_SCOPE_ALIASES` on the
+server or local runtime to canonicalize future reads and writes. Aliases accept
+comma, newline, or semicolon separated entries with `=` or `->` separators:
+
+```bash
+CONTEXTFORGE_SCOPE_ALIASES='repo:github.com/old/suite=repo:github.com/new/suite'
+```
+
+Scope prefixes are optional and default to `repo`. `dbInfo` reports the loaded
+aliases. Existing rows are not moved implicitly; inspect and migrate them
+explicitly:
+
+```bash
+node src/cli.js migrateScope \
+  --fromScope repo \
+  --fromScopeKey github.com/old/suite \
+  --toScope repo \
+  --toScopeKey github.com/new/suite
+
+node src/cli.js migrateScope \
+  --fromScope repo \
+  --fromScopeKey github.com/old/suite \
+  --toScope repo \
+  --toScopeKey github.com/new/suite \
+  --dryRun false
+```
+
 ## Usage Modes
 
 ContextForge supports two common deployment modes. Choose one first; mixing the

--- a/src/cli.js
+++ b/src/cli.js
@@ -60,6 +60,12 @@ function toCoreOptions(options) {
   return {
     scope: options.scope,
     scopeKey: options.scopeKey,
+    fromScope: options.fromScope,
+    fromScopeType: options.fromScopeType,
+    fromScopeKey: options.fromScopeKey,
+    toScope: options.toScope,
+    toScopeType: options.toScopeType,
+    toScopeKey: options.toScopeKey,
     cwd: options.cwd,
     repoPath: options.repoPath,
     key: options.key,
@@ -193,6 +199,7 @@ async function main() {
   const { command, options } = parseArgs(process.argv);
   const commands = {
     dbInfo: (app) => app.dbInfo(),
+    migrateScope: (app, coreOptions) => app.migrateScope(coreOptions),
     getRuntimeSettings: (app) => app.getRuntimeSettings(),
     updateRuntimeSettings: (app, coreOptions) => app.updateRuntimeSettings(coreOptions),
     checkDistillProvider: (app, coreOptions) => app.checkDistillProvider(coreOptions),

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -7,6 +7,92 @@ const VALID_SCOPES = new Set(['shared', 'repo', 'local']);
 const VALID_STORAGE_MODES = new Set(['local', 'project-local', 'remote']);
 const VALID_EMBEDDINGS_PROVIDERS = new Set(['none', 'openai']);
 
+function parseScopedKey(value, fallbackScope = 'repo') {
+  const text = String(value || '').trim();
+  if (!text) {
+    throw new Error('scope alias entries must not be empty.');
+  }
+  const match = text.match(/^(shared|repo|local):(.+)$/);
+  if (match) {
+    return {
+      scopeType: match[1],
+      scopeKey: match[2].trim(),
+    };
+  }
+  return {
+    scopeType: fallbackScope,
+    scopeKey: text,
+  };
+}
+
+function scopeAliasEntry(from, to) {
+  const parsedFrom = typeof from === 'object' && from
+    ? { scopeType: from.scopeType || from.scope || 'repo', scopeKey: from.scopeKey }
+    : parseScopedKey(from);
+  const parsedTo = typeof to === 'object' && to
+    ? { scopeType: to.scopeType || to.scope || parsedFrom.scopeType, scopeKey: to.scopeKey }
+    : parseScopedKey(to, parsedFrom.scopeType);
+  if (!VALID_SCOPES.has(parsedFrom.scopeType) || !VALID_SCOPES.has(parsedTo.scopeType)) {
+    throw new Error('scope alias scope type must be shared, repo, or local.');
+  }
+  if (!parsedFrom.scopeKey || !parsedTo.scopeKey) {
+    throw new Error('scope alias entries require both source and target scope keys.');
+  }
+  return {
+    from: parsedFrom,
+    to: parsedTo,
+  };
+}
+
+export function parseScopeAliases(value) {
+  if (value == null || value === '') {
+    return [];
+  }
+  const text = String(value).trim();
+  let parsed = null;
+  if (text.startsWith('{') || text.startsWith('[')) {
+    parsed = JSON.parse(text);
+  }
+  if (Array.isArray(parsed)) {
+    return parsed.map((entry) => scopeAliasEntry(entry.from, entry.to));
+  }
+  if (parsed && typeof parsed === 'object') {
+    return Object.entries(parsed).map(([from, to]) => scopeAliasEntry(from, to));
+  }
+
+  return text
+    .split(/[,\n;]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const parts = entry.includes('->') ? entry.split('->') : entry.split('=');
+      if (parts.length !== 2) {
+        throw new Error('CONTEXTFORGE_SCOPE_ALIASES entries must use "=" or "->".');
+      }
+      return scopeAliasEntry(parts[0], parts[1]);
+    });
+}
+
+export function canonicalizeScope(scope, aliases = []) {
+  let current = { scopeType: scope.scopeType, scopeKey: scope.scopeKey };
+  const seen = new Set();
+  for (let depth = 0; depth < 20; depth += 1) {
+    const signature = `${current.scopeType}:${current.scopeKey}`;
+    if (seen.has(signature)) {
+      throw new Error(`Scope alias cycle detected at ${signature}.`);
+    }
+    seen.add(signature);
+    const alias = aliases.find(
+      (item) => item.from.scopeType === current.scopeType && item.from.scopeKey === current.scopeKey,
+    );
+    if (!alias) {
+      return current;
+    }
+    current = { ...alias.to };
+  }
+  throw new Error('Scope alias chain is too deep.');
+}
+
 function parsePositiveInteger(value, name, fallback) {
   if (value == null || value === '') {
     return fallback;
@@ -194,8 +280,14 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
     10 * 60 * 1000,
   );
   const defaultSharedScopeKey = env.CONTEXTFORGE_SHARED_SCOPE_KEY || 'global';
-  const defaultScopeKey =
-    env.CONTEXTFORGE_DEFAULT_SCOPE_KEY || defaultScopeKeyFor(defaultScope, resolvedCwd, defaultSharedScopeKey);
+  const scopeAliases = parseScopeAliases(env.CONTEXTFORGE_SCOPE_ALIASES);
+  const defaultScopeKey = canonicalizeScope(
+    {
+      scopeType: defaultScope,
+      scopeKey: env.CONTEXTFORGE_DEFAULT_SCOPE_KEY || defaultScopeKeyFor(defaultScope, resolvedCwd, defaultSharedScopeKey),
+    },
+    scopeAliases,
+  ).scopeKey;
 
   return {
     storageMode,
@@ -204,6 +296,7 @@ export function loadConfig({ env = process.env, cwd = process.cwd() } = {}) {
     defaultScope,
     defaultScopeKey,
     defaultSharedScopeKey,
+    scopeAliases,
     distillProvider: env.CONTEXTFORGE_DISTILL_PROVIDER || 'mock',
     embeddings: {
       provider: embeddingsProvider,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -35,6 +35,9 @@ function scopeAliasEntry(from, to) {
   if (!VALID_SCOPES.has(parsedFrom.scopeType) || !VALID_SCOPES.has(parsedTo.scopeType)) {
     throw new Error('scope alias scope type must be shared, repo, or local.');
   }
+  if (parsedFrom.scopeType !== parsedTo.scopeType) {
+    throw new Error('scope aliases cannot change scope type.');
+  }
   if (!parsedFrom.scopeKey || !parsedTo.scopeKey) {
     throw new Error('scope alias entries require both source and target scope keys.');
   }
@@ -51,7 +54,11 @@ export function parseScopeAliases(value) {
   const text = String(value).trim();
   let parsed = null;
   if (text.startsWith('{') || text.startsWith('[')) {
-    parsed = JSON.parse(text);
+    try {
+      parsed = JSON.parse(text);
+    } catch (error) {
+      throw new Error(`CONTEXTFORGE_SCOPE_ALIASES must be valid JSON or alias text: ${error.message}`);
+    }
   }
   if (Array.isArray(parsed)) {
     return parsed.map((entry) => scopeAliasEntry(entry.from, entry.to));

--- a/src/core.js
+++ b/src/core.js
@@ -18,6 +18,16 @@ function requireOption(value, name) {
   }
 }
 
+function migrationScopeOptions(options, prefix, fallbackScope = 'repo') {
+  const scopeType = options[`${prefix}ScopeType`] || options[`${prefix}Scope`] || fallbackScope;
+  const scopeKey = options[`${prefix}ScopeKey`];
+  if (!['shared', 'repo', 'local'].includes(scopeType)) {
+    throw new Error(`${prefix}Scope must be shared, repo, or local.`);
+  }
+  requireOption(scopeKey, `${prefix}ScopeKey`);
+  return { scopeType, scopeKey };
+}
+
 function ownValue(source, keys) {
   for (const key of keys) {
     if (Object.prototype.hasOwnProperty.call(source, key) && source[key] !== undefined) {
@@ -1703,6 +1713,10 @@ export function createContextForge(options = {}) {
         ttlDays: config.rawRetention.ttlDays,
         pruneIntervalMs: config.rawRetention.pruneIntervalMs,
       },
+      scopeAliases: {
+        count: config.scopeAliases.length,
+        aliases: config.scopeAliases,
+      },
     };
   }
 
@@ -1891,6 +1905,21 @@ export function createContextForge(options = {}) {
 
     dbInfo() {
       return useStore((store) => buildDbInfo(store));
+    },
+
+    migrateScope(options = {}) {
+      const from = migrationScopeOptions(options, 'from');
+      const toInput = migrationScopeOptions(options, 'to', from.scopeType);
+      const to = normalizeScopeOptions({ scope: toInput.scopeType, scopeKey: toInput.scopeKey }, config);
+      return useStore((store) =>
+        store.migrateScope({
+          fromScopeType: from.scopeType,
+          fromScopeKey: from.scopeKey,
+          toScopeType: to.scopeType,
+          toScopeKey: to.scopeKey,
+          dryRun: options.dryRun == null ? true : truthyOption(options.dryRun),
+        }),
+      );
     },
 
     getRuntimeSettings() {

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -78,7 +78,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Migrate Scope',
       description:
-        'Move existing rows from one explicit scope key to another after a repository rename or transfer. Defaults to dryRun=true and reports row counts plus conflicts; use dryRun=false only after reviewing the dry-run result.',
+        'Move existing rows from one explicit scope key to another after a repository rename or transfer. Defaults to dryRun=true and reports row counts plus conflicts; use dryRun=false only after reviewing the dry-run result. The from scope is treated as the raw stored scope and is not alias-canonicalized.',
       inputSchema: {
         fromScope: scopeSchema.optional(),
         fromScopeType: scopeSchema.optional(),

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -74,6 +74,30 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
   );
 
   server.registerTool(
+    'migrate_scope',
+    {
+      title: 'Migrate Scope',
+      description:
+        'Move existing rows from one explicit scope key to another after a repository rename or transfer. Defaults to dryRun=true and reports row counts plus conflicts; use dryRun=false only after reviewing the dry-run result.',
+      inputSchema: {
+        fromScope: scopeSchema.optional(),
+        fromScopeType: scopeSchema.optional(),
+        fromScopeKey: z.string(),
+        toScope: scopeSchema.optional(),
+        toScopeType: scopeSchema.optional(),
+        toScopeKey: z.string(),
+        dryRun: z.boolean().optional(),
+      },
+      annotations: {
+        title: 'Migrate Scope',
+        readOnlyHint: false,
+        idempotentHint: false,
+      },
+    },
+    async (args) => jsonResult(await app.migrateScope(args)),
+  );
+
+  server.registerTool(
     'get_runtime_settings',
     {
       title: 'Get Runtime Settings',

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -2,6 +2,7 @@ import { normalizeScopeOptions } from '../scopes/index.js';
 
 const REMOTE_METHODS = [
   'dbInfo',
+  'migrateScope',
   'getRuntimeSettings',
   'updateRuntimeSettings',
   'checkDistillProvider',
@@ -51,6 +52,7 @@ const REMOTE_METHODS = [
 
 const UNSCOPED_REMOTE_METHODS = new Set([
   'dbInfo',
+  'migrateScope',
   'getRuntimeSettings',
   'updateRuntimeSettings',
   'checkDistillProvider',

--- a/src/scopes/index.js
+++ b/src/scopes/index.js
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { inferRepoScopeKey } from '../config/index.js';
+import { canonicalizeScope, inferRepoScopeKey } from '../config/index.js';
 
 const VALID_SCOPE_TYPES = new Set(['shared', 'repo', 'local']);
 
@@ -27,5 +27,5 @@ export function normalizeScopeOptions(options, config) {
   if (!scopeKey) {
     scopeKey = config.defaultScopeKey;
   }
-  return validateScope(scopeType, scopeKey);
+  return canonicalizeScope(validateScope(scopeType, scopeKey), config.scopeAliases || []);
 }

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -413,6 +413,30 @@ function normalizeConfidence(value) {
   return Math.max(0, Math.min(1, parsed));
 }
 
+const SCOPE_MIGRATION_TABLES = [
+  'memories',
+  'raw_events',
+  'checkpoints',
+  'distill_runs',
+  'working_summaries',
+  'session_working_context',
+  'memory_candidate_index',
+  'preference_occurrences',
+  'embedding_jobs',
+  'memory_update_candidates',
+  'memory_fts',
+  'embedding_index',
+];
+
+const SCOPE_MIGRATION_UPDATE_TABLES = SCOPE_MIGRATION_TABLES.filter((table) => table !== 'memory_fts');
+
+const SCOPE_MIGRATION_CONFLICTS = [
+  { table: 'memories', keyColumn: 'memory_key' },
+  { table: 'working_summaries', keyColumn: 'session_id' },
+  { table: 'session_working_context', keyColumn: 'session_id' },
+  { table: 'preference_occurrences', keyColumn: 'merge_key' },
+];
+
 export class ContextForgeStore {
   constructor({ dataDir }) {
     this.dataDir = dataDir;
@@ -3213,6 +3237,123 @@ export class ContextForgeStore {
         checkpoints: Number(row.checkpoints || 0),
         lastTouchedAt: row.last_touched_at,
       }));
+  }
+
+  countScopeRows({ scopeType, scopeKey }) {
+    return Object.fromEntries(
+      SCOPE_MIGRATION_TABLES.map((table) => {
+        if (!this.tableExists(table)) {
+          return [table, 0];
+        }
+        return [
+          table,
+          Number(
+            this.db
+              .prepare(`SELECT COUNT(*) AS count FROM ${table} WHERE scope_type = ? AND scope_key = ?`)
+              .get(scopeType, scopeKey).count || 0,
+          ),
+        ];
+      }),
+    );
+  }
+
+  tableExists(table) {
+    return Boolean(
+      this.db
+        .prepare("SELECT name FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ?")
+        .get(table),
+    );
+  }
+
+  scopeMigrationConflicts({ fromScopeType, fromScopeKey, toScopeType, toScopeKey }) {
+    return SCOPE_MIGRATION_CONFLICTS.map(({ table, keyColumn }) => {
+      const count = Number(
+        this.db
+          .prepare(`
+            SELECT COUNT(*) AS count
+            FROM ${table} source
+            INNER JOIN ${table} target
+              ON target.${keyColumn} = source.${keyColumn}
+             AND target.scope_type = ?
+             AND target.scope_key = ?
+            WHERE source.scope_type = ?
+              AND source.scope_key = ?
+          `)
+          .get(toScopeType, toScopeKey, fromScopeType, fromScopeKey).count || 0,
+      );
+      const rows = this.db
+        .prepare(`
+          SELECT source.${keyColumn} AS key
+          FROM ${table} source
+          INNER JOIN ${table} target
+            ON target.${keyColumn} = source.${keyColumn}
+           AND target.scope_type = ?
+           AND target.scope_key = ?
+          WHERE source.scope_type = ?
+            AND source.scope_key = ?
+          ORDER BY source.${keyColumn} ASC
+          LIMIT 20
+        `)
+        .all(toScopeType, toScopeKey, fromScopeType, fromScopeKey)
+        .map((row) => row.key);
+      return {
+        table,
+        keyColumn,
+        count,
+        sampleKeys: rows,
+      };
+    }).filter((item) => item.count > 0);
+  }
+
+  migrateScope({ fromScopeType, fromScopeKey, toScopeType, toScopeKey, dryRun = true }) {
+    if (fromScopeType === toScopeType && fromScopeKey === toScopeKey) {
+      throw new Error('Cannot migrate a scope to itself.');
+    }
+    const from = { scopeType: fromScopeType, scopeKey: fromScopeKey };
+    const to = { scopeType: toScopeType, scopeKey: toScopeKey };
+    const before = this.countScopeRows(from);
+    const targetBefore = this.countScopeRows(to);
+    const conflicts = this.scopeMigrationConflicts({ fromScopeType, fromScopeKey, toScopeType, toScopeKey });
+    const totalRows = Object.values(before).reduce((total, count) => total + count, 0);
+    if (dryRun || conflicts.length) {
+      return {
+        dryRun: true,
+        from,
+        to,
+        totalRows,
+        counts: before,
+        targetCounts: targetBefore,
+        conflicts,
+        canMigrate: totalRows > 0 && conflicts.length === 0,
+      };
+    }
+
+    const updated = this.withTransaction(() =>
+      Object.fromEntries(
+        SCOPE_MIGRATION_UPDATE_TABLES.map((table) => {
+          if (!this.tableExists(table)) {
+            return [table, 0];
+          }
+          const result = this.db
+            .prepare(`UPDATE ${table} SET scope_type = ?, scope_key = ? WHERE scope_type = ? AND scope_key = ?`)
+            .run(toScopeType, toScopeKey, fromScopeType, fromScopeKey);
+          return [table, result.changes];
+        }),
+      ),
+    );
+    this.rebuildMemoryFts();
+    updated.memory_fts = before.memory_fts;
+    return {
+      dryRun: false,
+      from,
+      to,
+      totalRows,
+      counts: before,
+      targetCounts: targetBefore,
+      updated,
+      conflicts: [],
+      canMigrate: true,
+    };
   }
 
   getRuntimeSettings({ includeSecrets = false } = {}) {

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -3267,6 +3267,9 @@ export class ContextForgeStore {
 
   scopeMigrationConflicts({ fromScopeType, fromScopeKey, toScopeType, toScopeKey }) {
     return SCOPE_MIGRATION_CONFLICTS.map(({ table, keyColumn }) => {
+      if (!this.tableExists(table)) {
+        return null;
+      }
       const count = Number(
         this.db
           .prepare(`
@@ -3302,7 +3305,7 @@ export class ContextForgeStore {
         count,
         sampleKeys: rows,
       };
-    }).filter((item) => item.count > 0);
+    }).filter((item) => item?.count > 0);
   }
 
   migrateScope({ fromScopeType, fromScopeKey, toScopeType, toScopeKey, dryRun = true }) {
@@ -3317,7 +3320,10 @@ export class ContextForgeStore {
     const totalRows = Object.values(before).reduce((total, count) => total + count, 0);
     if (dryRun || conflicts.length) {
       return {
-        dryRun: true,
+        dryRun: Boolean(dryRun),
+        requestedDryRun: Boolean(dryRun),
+        blocked: conflicts.length > 0,
+        blockedReason: conflicts.length > 0 ? 'conflicts' : null,
         from,
         to,
         totalRows,
@@ -3328,8 +3334,8 @@ export class ContextForgeStore {
       };
     }
 
-    const updated = this.withTransaction(() =>
-      Object.fromEntries(
+    const updated = this.withTransaction(() => {
+      const changes = Object.fromEntries(
         SCOPE_MIGRATION_UPDATE_TABLES.map((table) => {
           if (!this.tableExists(table)) {
             return [table, 0];
@@ -3339,12 +3345,16 @@ export class ContextForgeStore {
             .run(toScopeType, toScopeKey, fromScopeType, fromScopeKey);
           return [table, result.changes];
         }),
-      ),
-    );
-    this.rebuildMemoryFts();
-    updated.memory_fts = before.memory_fts;
+      );
+      this.rebuildMemoryFts();
+      changes.memory_fts = before.memory_fts;
+      return changes;
+    });
     return {
       dryRun: false,
+      requestedDryRun: false,
+      blocked: false,
+      blockedReason: null,
       from,
       to,
       totalRows,

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -428,7 +428,8 @@ const SCOPE_MIGRATION_TABLES = [
   'embedding_index',
 ];
 
-const SCOPE_MIGRATION_UPDATE_TABLES = SCOPE_MIGRATION_TABLES.filter((table) => table !== 'memory_fts');
+const SCOPE_MIGRATION_DERIVED_TABLES = new Set(['memory_fts']);
+const SCOPE_MIGRATION_UPDATE_TABLES = SCOPE_MIGRATION_TABLES.filter((table) => !SCOPE_MIGRATION_DERIVED_TABLES.has(table));
 
 const SCOPE_MIGRATION_CONFLICTS = [
   { table: 'memories', keyColumn: 'memory_key' },
@@ -3317,7 +3318,14 @@ export class ContextForgeStore {
     const before = this.countScopeRows(from);
     const targetBefore = this.countScopeRows(to);
     const conflicts = this.scopeMigrationConflicts({ fromScopeType, fromScopeKey, toScopeType, toScopeKey });
-    const totalRows = Object.values(before).reduce((total, count) => total + count, 0);
+    const totalRows = SCOPE_MIGRATION_UPDATE_TABLES.reduce((total, table) => total + (before[table] || 0), 0);
+    const derivedRows = Object.fromEntries(
+      SCOPE_MIGRATION_TABLES.filter((table) => SCOPE_MIGRATION_DERIVED_TABLES.has(table)).map((table) => [
+        table,
+        before[table] || 0,
+      ]),
+    );
+    const hasRows = totalRows > 0;
     if (dryRun || conflicts.length) {
       return {
         dryRun: Boolean(dryRun),
@@ -3327,10 +3335,13 @@ export class ContextForgeStore {
         from,
         to,
         totalRows,
+        derivedRows,
+        hasRows,
+        empty: !hasRows,
         counts: before,
         targetCounts: targetBefore,
         conflicts,
-        canMigrate: totalRows > 0 && conflicts.length === 0,
+        canMigrate: hasRows && conflicts.length === 0,
       };
     }
 
@@ -3347,7 +3358,6 @@ export class ContextForgeStore {
         }),
       );
       this.rebuildMemoryFts();
-      changes.memory_fts = before.memory_fts;
       return changes;
     });
     return {
@@ -3358,9 +3368,15 @@ export class ContextForgeStore {
       from,
       to,
       totalRows,
+      derivedRows,
+      hasRows,
+      empty: !hasRows,
       counts: before,
       targetCounts: targetBefore,
       updated,
+      rebuilt: {
+        memory_fts: before.memory_fts,
+      },
       conflicts: [],
       canMigrate: true,
     };

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -465,6 +465,144 @@ test('repoPath and cwd resolve repo scope independently of the app cwd', async (
   assert.equal(explicit.scopeKey, 'explicit/repo');
 });
 
+test('scope aliases canonicalize explicit repo keys', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_SCOPE_ALIASES: 'repo:github.com/old/suite=repo:github.com/new/suite',
+    },
+    cwd: process.cwd(),
+  });
+
+  const memory = app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/old/suite',
+    key: 'canonical-memory',
+    content: 'Old repo scope writes are stored under the canonical repo scope.',
+  });
+  assert.equal(memory.scopeKey, 'github.com/new/suite');
+
+  const fetchedViaOld = app.getMemory({
+    scope: 'repo',
+    scopeKey: 'github.com/old/suite',
+    key: 'canonical-memory',
+  });
+  assert.equal(fetchedViaOld.scopeKey, 'github.com/new/suite');
+
+  const scopes = app.listScopeKeys({ scope: 'repo' }).map((item) => item.scopeKey);
+  assert.deepEqual(scopes, ['github.com/new/suite']);
+});
+
+test('migrateScope dry-runs and moves existing scoped rows into the canonical scope', async () => {
+  const dataDir = await makeTempDir();
+  const seedApp = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'scope_migration_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      scope_migration_provider: async () => ({
+        summaryShort: 'Scope migration checkpoint.',
+        summaryText: 'Existing old-scope rows should migrate to the canonical scope.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'scope-migration-candidate',
+            content: 'Scope migration should move candidate index rows.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.9,
+            stability: 0.9,
+            sensitivity: 'low',
+            promotionRecommendation: 'review',
+          },
+        ],
+      }),
+    },
+  });
+  const oldScope = {
+    scope: 'repo',
+    scopeKey: 'github.com/old/suite',
+  };
+  seedApp.remember({
+    ...oldScope,
+    key: 'old-scope-memory',
+    content: 'Existing rows can be moved from a deprecated repo scope.',
+  });
+  seedApp.appendRaw({
+    ...oldScope,
+    sessionId: 'scope-migration-session',
+    role: 'assistant',
+    content: 'Raw evidence in the old scope.',
+  });
+  await seedApp.distillCheckpoint({
+    ...oldScope,
+    sessionId: 'scope-migration-session',
+  });
+  seedApp.close();
+
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_SCOPE_ALIASES: 'repo:github.com/old/suite=repo:github.com/new/suite',
+    },
+    cwd: process.cwd(),
+  });
+
+  const dryRun = app.migrateScope({
+    fromScope: 'repo',
+    fromScopeKey: 'github.com/old/suite',
+    toScope: 'repo',
+    toScopeKey: 'github.com/new/suite',
+  });
+  assert.equal(dryRun.dryRun, true);
+  assert.equal(dryRun.canMigrate, true);
+  assert.equal(dryRun.counts.memories, 1);
+  assert.equal(dryRun.counts.raw_events, 1);
+  assert.equal(dryRun.counts.checkpoints, 1);
+  assert.equal(dryRun.counts.memory_candidate_index, 1);
+
+  const migrated = app.migrateScope({
+    fromScope: 'repo',
+    fromScopeKey: 'github.com/old/suite',
+    toScope: 'repo',
+    toScopeKey: 'github.com/new/suite',
+    dryRun: false,
+  });
+  assert.equal(migrated.dryRun, false);
+  assert.equal(migrated.updated.memories, 1);
+  assert.equal(migrated.updated.raw_events, 1);
+  assert.equal(migrated.updated.checkpoints, 1);
+  assert.equal(migrated.updated.memory_candidate_index, 1);
+
+  const scopes = app.listScopeKeys({ scope: 'repo' }).map((item) => item.scopeKey);
+  assert.deepEqual(scopes, ['github.com/new/suite']);
+  assert.equal(
+    app.getMemory({ scope: 'repo', scopeKey: 'github.com/new/suite', key: 'old-scope-memory' }).content,
+    'Existing rows can be moved from a deprecated repo scope.',
+  );
+  assert.equal(
+    app.listRawEvents({
+      scope: 'repo',
+      scopeKey: 'github.com/new/suite',
+      sessionId: 'scope-migration-session',
+    }).length,
+    1,
+  );
+  assert.equal(
+    app.listCheckpoints({
+      scope: 'repo',
+      scopeKey: 'github.com/new/suite',
+      sessionId: 'scope-migration-session',
+    }).length,
+    1,
+  );
+});
+
 test('default shared and local scopes get usable default keys', async () => {
   const cwd = await makeNonGitTempDir();
   const sharedApp = createContextForge({
@@ -7578,6 +7716,7 @@ test('listScopeKeys returns real scopes from memories, candidates, and distill r
 });
 
 test('REMOTE_METHODS exposes resume, suggestion, auto-promotion, and reconciliation wrappers', () => {
+  assert.ok(REMOTE_METHODS.includes('migrateScope'));
   assert.ok(REMOTE_METHODS.includes('syncResumeContext'));
   assert.ok(REMOTE_METHODS.includes('getRuntimeSettings'));
   assert.ok(REMOTE_METHODS.includes('updateRuntimeSettings'));
@@ -7771,6 +7910,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'list_memory_events',
       'list_memory_update_candidates',
       'list_preference_occurrences',
+      'migrate_scope',
       'process_due_distills',
       'process_embedding_jobs',
       'promote_memory',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -589,10 +589,14 @@ test('migrateScope dry-runs and moves existing scoped rows into the canonical sc
   assert.equal(dryRun.requestedDryRun, true);
   assert.equal(dryRun.blocked, false);
   assert.equal(dryRun.canMigrate, true);
+  assert.equal(dryRun.hasRows, true);
+  assert.equal(dryRun.empty, false);
+  assert.equal(dryRun.totalRows, 6);
   assert.equal(dryRun.counts.memories, 1);
   assert.equal(dryRun.counts.raw_events, 1);
   assert.equal(dryRun.counts.checkpoints, 1);
   assert.equal(dryRun.counts.memory_candidate_index, 1);
+  assert.equal(dryRun.derivedRows.memory_fts, 1);
 
   const migrated = app.migrateScope({
     fromScope: 'repo',
@@ -604,10 +608,13 @@ test('migrateScope dry-runs and moves existing scoped rows into the canonical sc
   assert.equal(migrated.dryRun, false);
   assert.equal(migrated.requestedDryRun, false);
   assert.equal(migrated.blocked, false);
+  assert.equal(migrated.totalRows, 6);
   assert.equal(migrated.updated.memories, 1);
   assert.equal(migrated.updated.raw_events, 1);
   assert.equal(migrated.updated.checkpoints, 1);
   assert.equal(migrated.updated.memory_candidate_index, 1);
+  assert.equal(migrated.updated.memory_fts, undefined);
+  assert.equal(migrated.rebuilt.memory_fts, 1);
 
   const scopes = app.listScopeKeys({ scope: 'repo' }).map((item) => item.scopeKey);
   assert.deepEqual(scopes, ['github.com/new/suite']);
@@ -667,6 +674,8 @@ test('migrateScope reports conflicts without pretending an actual request was a 
   assert.equal(result.requestedDryRun, false);
   assert.equal(result.blocked, true);
   assert.equal(result.blockedReason, 'conflicts');
+  assert.equal(result.hasRows, true);
+  assert.equal(result.empty, false);
   assert.equal(result.canMigrate, false);
   assert.equal(result.conflicts[0].table, 'memories');
   assert.deepEqual(result.conflicts[0].sampleKeys, ['conflicting-memory']);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -11,6 +11,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import Database from 'better-sqlite3';
 import { createCodexSdkPythonAutoPromoteAuditor } from '../src/audit/codex_sdk_python.js';
+import { canonicalizeScope, parseScopeAliases } from '../src/config/index.js';
 import { createContextForge } from '../src/core.js';
 import { STRUCTURED_CHECKPOINT_SCHEMA_VERSION, validateDistillOutput } from '../src/distill/validate.js';
 import { createOpenAiEmbeddingProvider } from '../src/embeddings/index.js';
@@ -494,6 +495,31 @@ test('scope aliases canonicalize explicit repo keys', async () => {
   assert.deepEqual(scopes, ['github.com/new/suite']);
 });
 
+test('scope aliases reject unsafe definitions and support chained canonicalization', () => {
+  const aliases = parseScopeAliases('repo:A=repo:B, repo:B=repo:C');
+  assert.deepEqual(canonicalizeScope({ scopeType: 'repo', scopeKey: 'A' }, aliases), {
+    scopeType: 'repo',
+    scopeKey: 'C',
+  });
+
+  assert.throws(
+    () => parseScopeAliases('repo:A=shared:B'),
+    /cannot change scope type/,
+  );
+  assert.throws(
+    () => parseScopeAliases('{broken json'),
+    /CONTEXTFORGE_SCOPE_ALIASES must be valid JSON/,
+  );
+  assert.throws(
+    () =>
+      canonicalizeScope(
+        { scopeType: 'repo', scopeKey: 'A' },
+        parseScopeAliases('repo:A=repo:B, repo:B=repo:A'),
+      ),
+    /cycle/,
+  );
+});
+
 test('migrateScope dry-runs and moves existing scoped rows into the canonical scope', async () => {
   const dataDir = await makeTempDir();
   const seedApp = createContextForge({
@@ -560,6 +586,8 @@ test('migrateScope dry-runs and moves existing scoped rows into the canonical sc
     toScopeKey: 'github.com/new/suite',
   });
   assert.equal(dryRun.dryRun, true);
+  assert.equal(dryRun.requestedDryRun, true);
+  assert.equal(dryRun.blocked, false);
   assert.equal(dryRun.canMigrate, true);
   assert.equal(dryRun.counts.memories, 1);
   assert.equal(dryRun.counts.raw_events, 1);
@@ -574,6 +602,8 @@ test('migrateScope dry-runs and moves existing scoped rows into the canonical sc
     dryRun: false,
   });
   assert.equal(migrated.dryRun, false);
+  assert.equal(migrated.requestedDryRun, false);
+  assert.equal(migrated.blocked, false);
   assert.equal(migrated.updated.memories, 1);
   assert.equal(migrated.updated.raw_events, 1);
   assert.equal(migrated.updated.checkpoints, 1);
@@ -601,6 +631,45 @@ test('migrateScope dry-runs and moves existing scoped rows into the canonical sc
     }).length,
     1,
   );
+});
+
+test('migrateScope reports conflicts without pretending an actual request was a dry-run', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+    },
+    cwd: process.cwd(),
+  });
+
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/old/suite',
+    key: 'conflicting-memory',
+    content: 'Old scope value.',
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/new/suite',
+    key: 'conflicting-memory',
+    content: 'New scope value.',
+  });
+
+  const result = app.migrateScope({
+    fromScope: 'repo',
+    fromScopeKey: 'github.com/old/suite',
+    toScope: 'repo',
+    toScopeKey: 'github.com/new/suite',
+    dryRun: false,
+  });
+
+  assert.equal(result.dryRun, false);
+  assert.equal(result.requestedDryRun, false);
+  assert.equal(result.blocked, true);
+  assert.equal(result.blockedReason, 'conflicts');
+  assert.equal(result.canMigrate, false);
+  assert.equal(result.conflicts[0].table, 'memories');
+  assert.deepEqual(result.conflicts[0].sampleKeys, ['conflicting-memory']);
 });
 
 test('default shared and local scopes get usable default keys', async () => {


### PR DESCRIPTION
## 요약

- `CONTEXTFORGE_SCOPE_ALIASES`로 repo/shared/local scope key alias를 설정하고 future read/write를 canonical scope로 접도록 추가했습니다.
- 기존 old-scope row는 자동 union하지 않고 `migrateScope` dry-run/실행 명령으로 명시적으로 이동할 수 있게 했습니다.
- CLI, remote v0, MCP `migrate_scope`, README/README.ko/CHANGELOG, 회귀 테스트를 함께 갱신했습니다.

## 검증

- `npm test`
- `git diff --check`

## 운영 메모

기본 migration은 dry-run입니다. 실제 이동은 dry-run 결과의 row count/conflict를 확인한 뒤 `--dryRun false`로 실행합니다.