### PR TITLE
Tighten audited memory candidate selection

### DIFF
--- a/src/audit/codex_exec.js
+++ b/src/audit/codex_exec.js
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { parseCodexExecJson, runCodexExecCommand } from '../distill/providers/codex_exec.js';
 
-export const AUTO_PROMOTE_AUDIT_PROMPT_VERSION = 'auto_promote_audit.codex_exec.v2';
+export const AUTO_PROMOTE_AUDIT_PROMPT_VERSION = 'auto_promote_audit.codex_exec.v3';
 export const AUTO_PROMOTE_AUDIT_SCHEMA_VERSION = 'contextforge.auto_promote_audit.v1';
 
 export const AUDIT_OUTPUT_SCHEMA = {
@@ -42,7 +42,9 @@ export function buildAuditPrompt(input, metadata) {
     task: 'Audit whether one ContextForge memory candidate is safe for automatic durable-memory promotion.',
     rules: [
       'Return exactly one JSON object and no surrounding text.',
-      'Approve only if the candidate is stable, specific, useful beyond the current session, and directly supported by the checkpoint/candidate evidence.',
+      'Approve only if the candidate is a repository-wide development rule, API/architecture contract, recurring failure mode, or runbook step that future agents must remember to work correctly.',
+      'Reject one-off project events such as PR status, CI/test pass snapshots, review comments posted, branch cleanup, version bumps, release notes, or temporary smoke-test details.',
+      'Reject facts tied to one machine, one deployment environment, one local path, one port, one service restart, or other environment-specific runtime state.',
       'Reject if it contains secrets, personal data, credentials, broad guesses, temporary state, user preferences, or unsupported claims.',
       'Use needs_review when the candidate might be useful but needs a human edit, narrower wording, or live verification.',
       'Do not approve merely because promotionRecommendation is promote or confidence is high.',

--- a/src/core.js
+++ b/src/core.js
@@ -780,6 +780,9 @@ const AUTO_PROMOTE_SKIP_WARNING_CODES = new Set([
   'auto_low_confidence',
   'auto_low_stability',
   'auto_disallowed_category',
+  'auto_environment_specific',
+  'auto_one_off_event',
+  'auto_transient_category',
   'preference_auto_excluded',
 ]);
 
@@ -792,7 +795,40 @@ const DURABLE_PROPOSAL_CATEGORIES = new Set([
   'environment',
 ]);
 
-const SAFE_AUTO_PROMOTE_CATEGORIES = new Set(['runbook', 'failure-mode', 'api-contract', 'environment', 'decision']);
+const AUDIT_CANDIDATE_CATEGORIES = new Set([
+  'agent_guidance',
+  'agent-guidance',
+  'api-contract',
+  'api_contract',
+  'architecture',
+  'decision',
+  'failure-mode',
+  'failure_mode',
+  'policy',
+  'runbook',
+]);
+const SAFE_AUTO_PROMOTE_CATEGORIES = new Set(['runbook', 'failure-mode', 'api-contract', 'decision']);
+const AUTO_TRANSIENT_CATEGORIES = new Set([
+  'bugfix',
+  'documentation',
+  'project-release',
+  'project_release',
+  'project-state',
+  'project_state',
+  'project-status',
+  'project_status',
+  'runtime-config',
+  'runtime_config',
+  'state',
+  'task-note',
+  'task_note',
+  'test-contract',
+  'test_contract',
+]);
+const AUTO_ENVIRONMENT_SPECIFIC_PATTERN =
+  /\b(?:localhost|127\.0\.0\.1|0\.0\.0\.0|systemctl|journalctl|port\s+\d{2,5}|pid\s+\d+)\b|\/home\/|\/tmp\/|\.service\b/i;
+const AUTO_ONE_OFF_EVENT_PATTERN =
+  /\b(?:pr\s*#\d+|pull request\s*#\d+|issue\s*#\d+|ci\s+(?:green|passed|success|failure|failed)|(?:green|passed|successful|failed)\s+ci|merge state|review comment|commented|npm test\s+\d+\/\d+|git diff --check|smoke test|smoke port|branch cleanup|release\s+\d|version bump)\b/i;
 const CHECKPOINT_SOURCES = new Set(['distill', 'daily_consolidation', 'weekly_consolidation', 'topic_batch', 'manual']);
 const RECONCILE_UPDATE_CONFIDENCE = {
   durableMemory: 0.7,
@@ -1076,6 +1112,18 @@ function normalizeAllowedCategories(value, defaultCategories = SAFE_AUTO_PROMOTE
 function autoPromotionWarnings(store, scope, indexedCandidate, policy) {
   const candidate = indexedCandidate.candidate || {};
   const warnings = [...promotionCandidateWarnings(store, scope, indexedCandidate)];
+  const category = normalizeToken(candidate.category);
+  const searchableText = [
+    candidate.key,
+    candidate.content,
+    candidate.reason,
+    candidate.durabilityReason,
+    candidate.riskReason,
+    ...(Array.isArray(candidate.tags) ? candidate.tags : []),
+    ...(Array.isArray(candidate.evidenceRefs) ? candidate.evidenceRefs : []),
+  ]
+    .filter(Boolean)
+    .join('\n');
   if (Number(candidate.confidence || 0) < policy.minConfidence) {
     warnings.push({
       code: 'auto_low_confidence',
@@ -1092,7 +1140,27 @@ function autoPromotionWarnings(store, scope, indexedCandidate, policy) {
       minStability: policy.minStability,
     });
   }
-  const category = normalizeToken(candidate.category);
+  if (AUTO_TRANSIENT_CATEGORIES.has(category)) {
+    warnings.push({
+      code: 'auto_transient_category',
+      message: `Candidate category "${candidate.category}" describes a transient event or implementation note, not a repository-wide durable development rule.`,
+      category: candidate.category || null,
+    });
+  }
+  if (AUTO_ONE_OFF_EVENT_PATTERN.test(searchableText)) {
+    warnings.push({
+      code: 'auto_one_off_event',
+      message:
+        'Candidate appears to describe a one-off PR, CI, review, release, branch, or smoke-test event rather than a durable repository-wide development rule.',
+    });
+  }
+  if (AUTO_ENVIRONMENT_SPECIFIC_PATTERN.test(searchableText)) {
+    warnings.push({
+      code: 'auto_environment_specific',
+      message:
+        'Candidate appears tied to a specific machine, local path, port, service, or deployment environment and is not safe for automatic durable promotion.',
+    });
+  }
   if (!policy.allowedCategories.has(category)) {
     warnings.push({
       code: category === 'preference' ? 'preference_auto_excluded' : 'auto_disallowed_category',
@@ -1105,6 +1173,53 @@ function autoPromotionWarnings(store, scope, indexedCandidate, policy) {
   }
   return warnings;
 }
+
+function auditCandidateWarnings(store, scope, indexedCandidate, policy) {
+  const candidate = indexedCandidate.candidate || {};
+  const warnings = autoPromotionWarnings(store, scope, indexedCandidate, {
+    minConfidence: policy.minConfidence,
+    minStability: policy.minStability,
+    allowedCategories: policy.allowedCategories,
+  }).filter(
+    (warning) =>
+      !['auto_disallowed_category', 'auto_low_confidence', 'auto_low_stability'].includes(warning.code),
+  );
+  const category = normalizeToken(candidate.category);
+  if (!policy.allowedCategories.has(category)) {
+    warnings.push({
+      code: 'audit_disallowed_category',
+      message: `Candidate category "${candidate.category}" is not a repository-wide development rule, contract, policy, architecture decision, failure mode, or runbook.`,
+      category: candidate.category || null,
+    });
+  }
+  if (Number(candidate.confidence || 0) < policy.minConfidence) {
+    warnings.push({
+      code: 'audit_low_confidence',
+      message: `Candidate confidence must be at least ${policy.minConfidence} to spend audit budget.`,
+      confidence: candidate.confidence ?? null,
+      minConfidence: policy.minConfidence,
+    });
+  }
+  if (Number(candidate.stability || 0) < policy.minStability) {
+    warnings.push({
+      code: 'audit_low_stability',
+      message: `Candidate stability must be at least ${policy.minStability} to spend audit budget.`,
+      stability: candidate.stability ?? null,
+      minStability: policy.minStability,
+    });
+  }
+  return warnings;
+}
+
+const AUDIT_CANDIDATE_SKIP_WARNING_CODES = new Set([
+  ...AUTO_SKIP_WARNING_CODES,
+  'audit_disallowed_category',
+  'audit_low_confidence',
+  'audit_low_stability',
+  'auto_environment_specific',
+  'auto_one_off_event',
+  'auto_transient_category',
+]);
 
 function autoPromotionWouldPromote(indexedCandidate, warnings, rank) {
   const proposal = promotionProposal(indexedCandidate, warnings, rank);
@@ -2859,15 +2974,15 @@ export function createContextForge(options = {}) {
               },
             ]
           : [];
-      const minConfidence = Number(options.minConfidence ?? 0.85);
-      const minStability = Number(options.minStability ?? 0.85);
+      const minConfidence = Number(options.minConfidence ?? 0.7);
+      const minStability = Number(options.minStability ?? 0.7);
       if (!Number.isFinite(minConfidence) || minConfidence < 0 || minConfidence > 1) {
         throw new Error('minConfidence must be between 0 and 1.');
       }
       if (!Number.isFinite(minStability) || minStability < 0 || minStability > 1) {
         throw new Error('minStability must be between 0 and 1.');
       }
-      const categoryPolicy = normalizeAllowedCategories(options.allowedCategories);
+      const categoryPolicy = normalizeAllowedCategories(options.allowedCategories, AUDIT_CANDIDATE_CATEGORIES);
       const allowedCategories = categoryPolicy.allowedCategories;
       if (categoryPolicy.strippedPreference) {
         requestWarnings.push({
@@ -2875,8 +2990,8 @@ export function createContextForge(options = {}) {
           message: 'Preference candidates cannot be audited for automatic-style promotion until occurrence/merge tracking exists.',
         });
       }
-      const scanLimit = positiveNumber(options.scanLimit == null ? 10 : Number(options.scanLimit), 'scanLimit');
-      const promotionRecommendation = options.promotionRecommendation || 'promote';
+      const scanLimit = positiveNumber(options.scanLimit == null ? 50 : Number(options.scanLimit), 'scanLimit');
+      const promotionRecommendation = options.promotionRecommendation || null;
       if (!options.sessionId && !options.checkpointId) {
         return {
           kind: 'memory_candidate_audit_suggestions',
@@ -2965,7 +3080,6 @@ export function createContextForge(options = {}) {
           };
         }
 
-        const policy = { minConfidence, minStability, allowedCategories };
         const allCandidates = store.listMemoryCandidates({
           ...scope,
           sessionId: options.sessionId || null,
@@ -3014,9 +3128,14 @@ export function createContextForge(options = {}) {
             ],
           };
         }
+        const candidateAuditPolicy = {
+          minConfidence,
+          minStability,
+          allowedCategories,
+        };
         const assessed = candidates.map((candidate) => {
-          const warnings = autoPromotionWarnings(store, scope, candidate, policy);
-          const score = scorePromotionCandidate(candidate, warnings, AUTO_PROMOTE_SKIP_WARNING_CODES);
+          const warnings = auditCandidateWarnings(store, scope, candidate, candidateAuditPolicy);
+          const score = scorePromotionCandidate(candidate, warnings, AUDIT_CANDIDATE_SKIP_WARNING_CODES);
           return { candidate, warnings, score };
         });
         const selected = assessed
@@ -4238,7 +4357,6 @@ export function createContextForge(options = {}) {
               ...scope,
               sessionId: options.sessionId,
               status: 'pending',
-              promotionRecommendation: 'promote',
               sort: 'recommendation',
               limit: scanLimit,
             })
@@ -4275,13 +4393,13 @@ export function createContextForge(options = {}) {
             };
           } else {
             const policy = {
-              minConfidence: 0.85,
-              minStability: 0.85,
-              allowedCategories: SAFE_AUTO_PROMOTE_CATEGORIES,
+              minConfidence: 0.7,
+              minStability: 0.7,
+              allowedCategories: AUDIT_CANDIDATE_CATEGORIES,
             };
             const assessed = unauditedPending.map((candidate) => {
-              const warnings = autoPromotionWarnings(store, scope, candidate, policy);
-              const score = scorePromotionCandidate(candidate, warnings, AUTO_PROMOTE_SKIP_WARNING_CODES);
+              const warnings = auditCandidateWarnings(store, scope, candidate, policy);
+              const score = scorePromotionCandidate(candidate, warnings, AUDIT_CANDIDATE_SKIP_WARNING_CODES);
               return { candidate, warnings, score };
             });
             const selected = assessed
@@ -4322,11 +4440,24 @@ export function createContextForge(options = {}) {
               });
               auditedCount += 1;
               if (config.autoPromote.enabled && auditor && audit.approved === true) {
-                const reason =
-                  'Auto-promoted after automatic batched candidate audit approved this strict safe candidate.';
-                const memory = autoPromoteIndexedCandidate(store, scope, auditedCandidate, item.warnings, reason, audit);
-                enqueueEmbeddingSources(store, [store.embeddingSourceForMemory(memory)]);
-                promotedCount += 1;
+                const autoPolicy = {
+                  minConfidence: 0.85,
+                  minStability: 0.85,
+                  allowedCategories: SAFE_AUTO_PROMOTE_CATEGORIES,
+                };
+                const autoWarnings = autoPromotionWarnings(store, scope, auditedCandidate, autoPolicy);
+                const autoScore = scorePromotionCandidate(
+                  auditedCandidate,
+                  autoWarnings,
+                  AUTO_PROMOTE_SKIP_WARNING_CODES,
+                );
+                if (autoScore > 0) {
+                  const reason =
+                    'Auto-promoted after automatic batched candidate audit approved this strict safe candidate.';
+                  const memory = autoPromoteIndexedCandidate(store, scope, auditedCandidate, autoWarnings, reason, audit);
+                  enqueueEmbeddingSources(store, [store.embeddingSourceForMemory(memory)]);
+                  promotedCount += 1;
+                }
               }
             }
             candidateAudit = {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -6171,6 +6171,232 @@ test('auditMemoryCandidates returns audited read-only recommendations', async ()
   assert.equal(pendingCandidates[0].candidate.key, 'audited-readonly-runbook');
 });
 
+test('auditMemoryCandidates audits review candidates and skips noisy events before runner', async () => {
+  const dataDir = await makeTempDir();
+  const auditInvocations = [];
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'audit_review_selection_provider',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_MIN_BATCH_CANDIDATES: '99',
+    },
+    cwd: process.cwd(),
+    autoPromoteAuditor: async ({ candidate }) => {
+      auditInvocations.push(candidate.candidate.key);
+      return {
+        approved: false,
+        decision: 'needs_review',
+        reason: `Reviewed ${candidate.candidate.key}.`,
+        riskCodes: [],
+        metadata: {
+          provider: 'codex_sdk_python',
+          model: 'gpt-5.5',
+        },
+      };
+    },
+    distillProviders: {
+      audit_review_selection_provider: async () => ({
+        summaryShort: 'Audit review selection checkpoint.',
+        summaryText: 'Closeout produced review and noisy candidates.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'review-worthy-policy',
+            content: 'Agents must verify mutable live state before using structured checkpoint liveState values.',
+            category: 'policy',
+            candidateType: 'policy',
+            confidence: 0.82,
+            stability: 0.82,
+            sensitivity: 'low',
+            promotionRecommendation: 'review',
+          },
+          {
+            key: 'review-worthy-api-contract',
+            content: 'GET /healthz must return 200 for the server health contract.',
+            category: 'api_contract',
+            candidateType: 'api_contract',
+            confidence: 0.83,
+            stability: 0.83,
+            sensitivity: 'low',
+            promotionRecommendation: 'review',
+          },
+          {
+            key: 'review-worthy-ci-policy',
+            content: 'CI must run lint and tests on every PR before merge.',
+            category: 'policy',
+            candidateType: 'policy',
+            confidence: 0.84,
+            stability: 0.84,
+            sensitivity: 'low',
+            promotionRecommendation: 'review',
+          },
+          {
+            key: 'review-worthy-draft-policy',
+            content: 'Open work as a draft PR until checks are ready for review.',
+            category: 'policy',
+            candidateType: 'policy',
+            confidence: 0.81,
+            stability: 0.81,
+            sensitivity: 'low',
+            promotionRecommendation: 'review',
+          },
+          {
+            key: 'pr-status-noise',
+            content: 'PR #126 passed npm test 142/142 and CI was green.',
+            category: 'project_status',
+            candidateType: 'fact',
+            confidence: 0.98,
+            stability: 0.9,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+          {
+            key: 'local-runtime-noise',
+            content: 'Restart `/home/ubuntu/contextforge` with systemctl on this host.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.97,
+            stability: 0.91,
+            sensitivity: 'low',
+            promotionRecommendation: 'review',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'audit-review-selection-repo',
+    sessionId: 'audit-review-selection-session',
+    role: 'assistant',
+    content: 'Review candidates should be filtered before audit.',
+  });
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'audit-review-selection-repo',
+    sessionId: 'audit-review-selection-session',
+  });
+
+  const result = await app.auditMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'audit-review-selection-repo',
+    checkpointId: checkpoint.id,
+    trigger: 'manual_closeout',
+    limit: 5,
+  });
+
+  assert.deepEqual(auditInvocations.sort(), [
+    'review-worthy-api-contract',
+    'review-worthy-ci-policy',
+    'review-worthy-draft-policy',
+    'review-worthy-policy',
+  ]);
+  assert.equal(result.policy.audit.executed, true);
+  assert.deepEqual(
+    result.proposals.map((proposal) => proposal.key).sort(),
+    [
+      'review-worthy-api-contract',
+      'review-worthy-ci-policy',
+      'review-worthy-draft-policy',
+      'review-worthy-policy',
+    ],
+  );
+  assert.ok(result.skipped.some((item) => item.reason.includes('auto_transient_category')));
+  assert.ok(result.skipped.some((item) => item.reason.includes('auto_one_off_event')));
+  assert.ok(result.skipped.some((item) => item.reason.includes('auto_environment_specific')));
+  assert.equal(
+    app.getMemory({ scope: 'repo', scopeKey: 'audit-review-selection-repo', key: 'review-worthy-policy' }),
+    null,
+  );
+});
+
+test('auditMemoryCandidates honors narrowed allowedCategories', async () => {
+  const dataDir = await makeTempDir();
+  const auditInvocations = [];
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'audit_allowed_categories_provider',
+    },
+    cwd: process.cwd(),
+    autoPromoteAuditor: async ({ candidate }) => {
+      auditInvocations.push(candidate.candidate.key);
+      return {
+        approved: false,
+        decision: 'needs_review',
+        reason: `Reviewed ${candidate.candidate.key}.`,
+        riskCodes: [],
+        metadata: {
+          provider: 'codex_sdk_python',
+          model: 'gpt-5.5',
+        },
+      };
+    },
+    distillProviders: {
+      audit_allowed_categories_provider: async () => ({
+        summaryShort: 'Audit allowed categories checkpoint.',
+        summaryText: 'Closeout produced candidates in different durable categories.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'allowed-runbook',
+            content: 'Use scoped bootstrap before editing ContextForge runtime code.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.9,
+            stability: 0.9,
+            sensitivity: 'low',
+            promotionRecommendation: 'review',
+          },
+          {
+            key: 'blocked-policy',
+            content: 'Agents must verify mutable live state before using checkpoint liveState.',
+            category: 'policy',
+            candidateType: 'policy',
+            confidence: 0.9,
+            stability: 0.9,
+            sensitivity: 'low',
+            promotionRecommendation: 'review',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'audit-allowed-categories-repo',
+    sessionId: 'audit-allowed-categories-session',
+    role: 'assistant',
+    content: 'Allowed categories should narrow audit candidate selection.',
+  });
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'audit-allowed-categories-repo',
+    sessionId: 'audit-allowed-categories-session',
+  });
+
+  const result = await app.auditMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'audit-allowed-categories-repo',
+    checkpointId: checkpoint.id,
+    trigger: 'manual_closeout',
+    allowedCategories: ['runbook'],
+    limit: 5,
+  });
+
+  assert.deepEqual(auditInvocations, ['allowed-runbook']);
+  assert.deepEqual(result.policy.allowedCategories, ['runbook']);
+  assert.deepEqual(
+    result.proposals.map((proposal) => proposal.key),
+    ['allowed-runbook'],
+  );
+  assert.ok(result.skipped.some((item) => item.reason.includes('audit_disallowed_category')));
+});
+
 test('distillCheckpoint automatically audits session candidate batches', async () => {
   const dataDir = await makeTempDir();
   const auditInvocations = [];
@@ -6267,6 +6493,82 @@ test('distillCheckpoint automatically audits session candidate batches', async (
   assert.equal(storedAudit.proposals.length, 2);
   assert.equal(storedAudit.proposals[0].audit.metadata.model, 'gpt-5.5');
   assert.equal(auditInvocations.length, 2);
+});
+
+test('distillCheckpoint automatically audits review-worthy non-promote candidate batches', async () => {
+  const dataDir = await makeTempDir();
+  const auditInvocations = [];
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'review_batch_audit_provider',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_MIN_BATCH_CANDIDATES: '2',
+      CONTEXTFORGE_AUTO_PROMOTE_AUDIT_BATCH_LIMIT: '2',
+    },
+    cwd: process.cwd(),
+    autoPromoteAuditor: async ({ candidate }) => {
+      auditInvocations.push(candidate.candidate.key);
+      return {
+        approved: false,
+        decision: 'needs_review',
+        reason: `Audited review candidate ${candidate.candidate.key}.`,
+        riskCodes: [],
+        metadata: {
+          provider: 'codex_sdk_python',
+          model: 'gpt-5.5',
+        },
+      };
+    },
+    distillProviders: {
+      review_batch_audit_provider: async () => ({
+        summaryShort: 'Review batch audit checkpoint.',
+        summaryText: 'The checkpoint produced review-worthy candidates for batched audit.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'review-batch-policy',
+            content: 'Agents must verify mutable live state before relying on checkpoint liveState values.',
+            category: 'policy',
+            candidateType: 'policy',
+            confidence: 0.82,
+            stability: 0.82,
+            sensitivity: 'low',
+            promotionRecommendation: 'review',
+          },
+          {
+            key: 'review-batch-architecture',
+            content: 'Structured checkpoint handoff should be exposed separately from ordinary search results.',
+            category: 'architecture',
+            candidateType: 'decision',
+            confidence: 0.81,
+            stability: 0.8,
+            sensitivity: 'low',
+            promotionRecommendation: 'review',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'review-batch-audit-repo',
+    sessionId: 'review-batch-audit-session',
+    role: 'assistant',
+    content: 'Create enough review candidates for batch audit.',
+  });
+
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'review-batch-audit-repo',
+    sessionId: 'review-batch-audit-session',
+  });
+
+  assert.equal(checkpoint.candidateAudit.executed, true);
+  assert.equal(checkpoint.candidateAudit.reason, 'batch_threshold');
+  assert.equal(checkpoint.candidateAudit.audited, 2);
+  assert.deepEqual(auditInvocations.sort(), ['review-batch-architecture', 'review-batch-policy']);
 });
 
 test('distillCheckpoint audits new candidates even when audited pending candidates fill the first window', async () => {
@@ -6746,6 +7048,107 @@ test('autoPromoteMemoryCandidates promotes only strict safe candidates when enab
   );
   assert.ok(safeApiMemoryResult, 'expected safe-api-contract memory result');
   assert.equal(safeApiMemoryResult.retrieval.vectorModel, 'test-embedding');
+});
+
+test('autoPromoteMemoryCandidates rejects one-off and environment-specific candidates before audit', async () => {
+  const dataDir = await makeTempDir();
+  let auditCount = 0;
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'auto_strict_durability_provider',
+      CONTEXTFORGE_AUTO_PROMOTE_ENABLED: 'true',
+    },
+    cwd: process.cwd(),
+    autoPromoteAuditor: async () => {
+      auditCount += 1;
+      return {
+        approved: true,
+        decision: 'approve',
+        reason: 'The test auditor would approve if local policy allowed it.',
+        riskCodes: [],
+        metadata: {
+          provider: 'codex_exec',
+          model: 'gpt-5.5',
+        },
+      };
+    },
+    distillProviders: {
+      auto_strict_durability_provider: async () => ({
+        summaryShort: 'Strict durability checkpoint.',
+        summaryText: 'Closeout produced candidates with mixed durability.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'repo-common-api-contract',
+            content: 'The API contract requires idempotent delete retries.',
+            category: 'api-contract',
+            candidateType: 'api-contract',
+            confidence: 0.96,
+            stability: 0.96,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+          {
+            key: 'pr-ci-snapshot',
+            content: 'PR #126 passed npm test 142/142 and CI was green.',
+            category: 'project_state',
+            candidateType: 'fact',
+            confidence: 0.98,
+            stability: 0.9,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+          {
+            key: 'local-service-restart',
+            content: 'Restart `/home/ubuntu/contextforge` service with systemctl after this local deployment.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.97,
+            stability: 0.91,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'auto-strict-durability-repo',
+    sessionId: 'auto-strict-durability-session',
+    role: 'assistant',
+    content: 'Mixed strict durability candidates.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'auto-strict-durability-repo',
+    sessionId: 'auto-strict-durability-session',
+  });
+
+  const result = await app.autoPromoteMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'auto-strict-durability-repo',
+    sessionId: 'auto-strict-durability-session',
+    trigger: 'manual_closeout',
+    dryRun: false,
+  });
+
+  assert.deepEqual(
+    result.promoted.map((item) => item.key),
+    ['repo-common-api-contract'],
+  );
+  assert.equal(auditCount, 1);
+  assert.equal(app.getMemory({ scope: 'repo', scopeKey: 'auto-strict-durability-repo', key: 'pr-ci-snapshot' }), null);
+  assert.equal(
+    app.getMemory({ scope: 'repo', scopeKey: 'auto-strict-durability-repo', key: 'local-service-restart' }),
+    null,
+  );
+  assert.ok(result.skipped.some((item) => item.candidateId && item.reason.includes('auto_transient_category')));
+  assert.ok(result.skipped.some((item) => item.candidateId && item.reason.includes('auto_one_off_event')));
+  assert.ok(result.skipped.some((item) => item.candidateId && item.reason.includes('auto_environment_specific')));
 });
 
 test('autoPromoteMemoryCandidates skips candidates rejected by the audit runner', async () => {


### PR DESCRIPTION
## Summary
- audit review-worthy pending candidates, including `promotionRecommendation: review`, instead of only `promote`
- filter noisy one-off PR/CI/test/release snapshots and environment-specific runtime candidates before spending GPT audit budget
- keep automatic durable promotion stricter than audit by re-checking approved audit results with the strict auto-promotion policy
- tighten the audit prompt so GPT approval is limited to repository-wide development rules, contracts, recurring failure modes, or durable runbooks

## Verification
- `npm test` 145/145
- `git diff --check`