### PR TITLE
Add multi-agent ingest adapter registry

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -40,6 +40,9 @@ live source > durable memory > checkpoint handoff > memory_candidate
   `evidenceRefs`, `suggestedAction`을 보존한다.
 - 자동승격 감사는 distill 모델과 분리된다. `codex_exec` 또는
   `codex_sdk_python` 감사 provider를 사용할 수 있다.
+- agent adapter registry가 Codex, Claude Code, OpenCode, Grok, Cursor CLI
+  5종 built-in adapter를 제공한다. 새 에이전트는 registry에 추가하는
+  방식으로 확장한다.
 
 ## 권장 구조
 
@@ -47,7 +50,7 @@ live source > durable memory > checkpoint handoff > memory_candidate
 권장한다.
 
 ```text
-Codex / Claude Code / OpenClaw
+Codex / Claude Code / OpenCode / Grok / Cursor CLI
           |
       MCP tools / CLI
           |
@@ -59,6 +62,50 @@ Codex / Claude Code / OpenClaw
 ```
 
 단일 머신에서만 쓸 때는 `project-local` 또는 `local` storage로 충분하다.
+
+## Multi-Agent Ingest
+
+현재 built-in adapter는 5종이다.
+
+```text
+codex, claude_code, opencode, grok, cursor_cli
+```
+
+확인:
+
+```bash
+node src/cli.js listAgentAdapters
+```
+
+여러 에이전트 session store를 한 번에 repo registry로 라우팅할 수 있다.
+
+```bash
+node src/cli.js ingestAgentRoutedSessions \
+  --adapters codex,claude_code,opencode,grok,cursor_cli \
+  --codexSessionsDir ~/.codex/sessions \
+  --claudeCodeProjectsDir ~/.claude/projects \
+  --opencodeDb ~/.local/share/opencode/opencode.db \
+  --grokSessionsDir ~/.grok/sessions \
+  --cursorProjectsDir ~/.cursor/projects \
+  --repoRegistry ~/.config/contextforge/repos.json \
+  --sinceMinutes 1440 \
+  --distill auto
+```
+
+핵심 규칙:
+
+- 구별은 `sourceAgent`, `sourceAdapter`, `nativeSessionId`, prefixed
+  `sessionId`로 한다.
+- 참고는 repo `scopeKey` 기준으로 한다. 같은 repo scope의 durable memory와
+  checkpoint handoff는 에이전트 간 공유된다.
+- `rawTail`, working context, closeout/audit source는 exact `sessionId` 기준으로
+  유지한다. 이 부분은 cross-agent로 섞지 않는다.
+- memory candidate와 감사 UI도 같은 source provenance를 보여준다. 후보를
+  승격하기 전에 어느 agent가 만든 후보인지 확인할 수 있다.
+
+`ingestAgentRoutedSessions --watch`는 registry 기반 supervisor loop로 쓸 수
+있다. 다만 1차 구현은 idempotent 재스캔 방식이고, Codex/Claude 전용 watcher의
+incremental byte cursor 공통화는 별도 후속 작업이다.
 
 ## 빠른 시작
 
@@ -269,6 +316,9 @@ node src/cli.js bootstrapContext \
 
 - `handoff.latestHandoff`: 최신 checkpoint handoff. 검색 결과와 분리되어
   deterministic하게 제공된다.
+- `handoff.latestByAgent`: 같은 repo scope에서 agent별 최신 checkpoint.
+  Codex, Claude Code, OpenCode, Grok, Cursor CLI가 섞여 작업할 때 각 원천의
+  최신 handoff를 구분해 볼 수 있다.
 - `handoff.latestCheckpoints`: 최근 checkpoint 목록.
 - `results`: durable memory, checkpoint, memory candidate 검색 결과.
 - `workingSummary`: sessionId를 알 때 가져오는 현재 세션 resume state.
@@ -368,9 +418,10 @@ ContextForge MCP는 repo/shared/local scope를 명시적으로 다룬다.
 3. `suggest_memory_promotions` 또는 `list_memory_candidates`로 후보를 검토한다.
 4. stable하고 비밀이 아닌 사실만 `promote_memory_candidate`로 승격한다.
 
-`bootstrap_context`는 세션을 만들지 않는다. Codex/Claude adapter가 ingest한
-세션을 닫을 때는 새 `cf_...` 세션을 만들지 말고 기존 `codex:<id>` 또는
-`claude_code:<id>`를 사용해야 한다.
+`bootstrap_context`는 세션을 만들지 않는다. adapter가 ingest한 세션을 닫을
+때는 새 `cf_...` 세션을 만들지 말고 기존 `codex:<id>`,
+`claude_code:<id>`, `opencode:<id>`, `grok:<id>`, `cursor_cli:<id>` 같은
+adapter-prefixed session id를 사용해야 한다.
 
 ## Embeddings
 

--- a/README.md
+++ b/README.md
@@ -859,6 +859,51 @@ The older repo-specific watcher remains supported for simple single-repo
 setups, but one router per agent adapter is the recommended operating shape for
 suite-style workspaces and other multi-repo environments.
 
+ContextForge also exposes an extensible multi-agent adapter registry. The
+built-in adapter ids are `codex`, `claude_code`, `opencode`, `grok`, and
+`cursor_cli`; future adapters should register the same normalized contract
+instead of adding another copy of the router. Use `listAgentAdapters` to inspect
+the available set:
+
+```bash
+node src/cli.js listAgentAdapters
+```
+
+For a bounded multi-agent routed scan, use `ingestAgentRoutedSessions`. Each
+adapter keeps its own source provenance and session id prefix while writing
+matched records into the same repo `scopeKey`.
+
+```bash
+CONTEXTFORGE_STORAGE_MODE=remote \
+CONTEXTFORGE_REMOTE_URL=https://memory.example.com \
+CONTEXTFORGE_REMOTE_TOKEN=change-me \
+node src/cli.js ingestAgentRoutedSessions \
+  --adapters codex,claude_code,opencode,grok,cursor_cli \
+  --codexSessionsDir ~/.codex/sessions \
+  --claudeCodeProjectsDir ~/.claude/projects \
+  --opencodeDb ~/.local/share/opencode/opencode.db \
+  --grokSessionsDir ~/.grok/sessions \
+  --cursorProjectsDir ~/.cursor/projects \
+  --repoRegistry ~/.config/contextforge/repos.json \
+  --sinceMinutes 1440 \
+  --distill auto
+```
+
+`--watch` is supported for the multi-agent command as an idempotent supervisor
+loop. The existing per-agent Codex and Claude Code watchers remain the
+incremental byte-cursor production path; the multi-agent watch loop is the
+compatibility surface for registry-driven supervision until the shared
+incremental runner is fully generalized.
+
+Cross-agent visibility is intentional: durable repo memory and checkpoint
+handoff are read by `scopeKey`, not by the originating agent. Origin is still
+preserved with `sourceAgent`, `sourceRuntime`, `sourceAdapter`,
+`nativeSessionId`, and a prefixed `sessionId` such as `codex:<id>` or
+`opencode:<id>`. Raw tails, working context, and closeout/audit review stay
+exact-session scoped to prevent cross-agent evidence pollution.
+Memory candidate and audit surfaces carry the same source provenance so users
+can see which agent produced a candidate before deciding whether to promote it.
+
 For local TUI use, the same command can stay resident and poll for new rollout
 events:
 
@@ -1093,6 +1138,9 @@ only when last-mile transcript continuity is needed.
 
 The bootstrap response keeps these channels separate:
 
+- `handoff.latestByAgent`: latest visible checkpoint per `sourceAgent`, useful
+  when Codex, Claude Code, OpenCode, Grok, and Cursor CLI are all contributing
+  to the same repo scope.
 - `handoff.latestCheckpoints`: latest recent handoff checkpoints loaded
   independently of query ranking; read these before durable memory for current
   work status, recent decisions, open todos, branch/PR/CI flow, and next

--- a/src/admin-ui/app.js
+++ b/src/admin-ui/app.js
@@ -590,13 +590,15 @@ $('#loadCandidates').addEventListener('click', async (event) => {
 function candidateItem(candidate, index) {
   const action = auditedActionLabel(candidate.recommendedAction);
   const decision = auditDecisionLabel(candidate.audit);
+  const sourceAgent = candidate.evidence?.sourceAgent || candidate.evidence?.sourceProvenance?.sourceAgent || '';
+  const sourceText = sourceAgent ? ` · ${sourceAgent}` : '';
   const risks = Array.isArray(candidate.audit?.riskCodes) && candidate.audit.riskCodes.length
     ? ` · 위험 ${candidate.audit.riskCodes.join(', ')}`
     : '';
   return `<article class="item">
     <header><span class="item-title"><input type="checkbox" data-candidate-select="${index}" aria-label="후보 선택" /><strong>${escapeHtml(candidate.key)}</strong></span><span class="muted">${escapeHtml(action)} · ${escapeHtml(decision)}</span></header>
     <p>${escapeHtml(candidate.content.slice(0, 220))}</p>
-    <p class="muted">GPT 감사 후보 · ${escapeHtml(candidate.category || 'note')} · ${escapeHtml(candidate.auditReason || candidate.whyDurable || '')}${escapeHtml(risks)}</p>
+    <p class="muted">GPT 감사 후보${escapeHtml(sourceText)} · ${escapeHtml(candidate.category || 'note')} · ${escapeHtml(candidate.auditReason || candidate.whyDurable || '')}${escapeHtml(risks)}</p>
     <div class="actions">
       <button data-candidate="${index}">상세</button>
       <button data-promote="${index}" ${candidate.recommendedAction === 'promote' ? '' : 'disabled'}>승격</button>

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,6 +14,12 @@ import {
   watchCodexRoutedSessions,
   watchCodexSessions,
 } from './ingest/codex.js';
+import {
+  ingestAgentRoutedSessions,
+  ingestAgentSessions,
+  listAgentAdapters,
+  watchAgentRoutedSessions,
+} from './ingest/agents.js';
 import { startContextForgeServer } from './server.js';
 
 function parseArgs(argv) {
@@ -127,8 +133,14 @@ function toCoreOptions(options) {
     ttlDays: options.ttlDays == null ? undefined : Number(options.ttlDays),
     file: options.file,
     repoRegistry: options.repoRegistry || options.registry || options.repoRegistryFile,
+    adapters: options.adapters || options.adapter,
     sessionsDir: options.sessionsDir,
+    codexSessionsDir: options.codexSessionsDir,
+    grokSessionsDir: options.grokSessionsDir,
     projectsDir: options.projectsDir,
+    claudeCodeProjectsDir: options.claudeCodeProjectsDir,
+    cursorProjectsDir: options.cursorProjectsDir,
+    opencodeDb: options.opencodeDb || options.db,
     distill: options.distill,
     maxContentChars: options.maxContentChars == null ? undefined : Number(options.maxContentChars),
     sinceMinutes: options.sinceMinutes == null ? undefined : Number(options.sinceMinutes),
@@ -281,6 +293,17 @@ async function main() {
             },
           })
         : ingestClaudeCodeRoutedSessions(app, coreOptions),
+    listAgentAdapters: () => listAgentAdapters(),
+    ingestAgentSessions: (app, coreOptions) => ingestAgentSessions(app, coreOptions),
+    ingestAgentRoutedSessions: (app, coreOptions) =>
+      coreOptions.watch
+        ? watchAgentRoutedSessions(app, {
+            ...coreOptions,
+            onResult: (result) => {
+              console.log(JSON.stringify(result));
+            },
+          })
+        : ingestAgentRoutedSessions(app, coreOptions),
   };
 
   if (!command || command === 'help' || command === '--help') {

--- a/src/core.js
+++ b/src/core.js
@@ -431,6 +431,7 @@ function bootstrapResultSummary(result) {
     };
   }
   if (result.candidate) {
+    const sourceProvenance = result.candidate.source?.sourceProvenance || null;
     return {
       key: result.candidate.candidate.key,
       category: result.candidate.candidate.category,
@@ -438,6 +439,8 @@ function bootstrapResultSummary(result) {
       candidateId: result.candidate.id,
       status: result.candidate.status,
       checkpointId: result.candidate.checkpointId,
+      sourceAgent: sourceProvenance?.sourceAgent || result.candidate.source?.sourceAgent || null,
+      sourceProvenance,
     };
   }
   return {
@@ -562,6 +565,8 @@ function structuredLiveStateWarnings(structured) {
 
 function checkpointHandoffCompact(checkpoint, scope) {
   const sourceEventWindow = checkpoint.metadata?.sourceEventWindow || null;
+  const sourceProvenance = checkpoint.metadata?.sourceProvenance || null;
+  const sourceAgent = sourceProvenance?.sourceAgent || null;
   const structured = structuredForCheckpoint(checkpoint);
   const structuredWarnings = structuredLiveStateWarnings(structured);
   return {
@@ -587,6 +592,8 @@ function checkpointHandoffCompact(checkpoint, scope) {
     openQuestions: checkpoint.openQuestions || [],
     sourceEventCount: checkpoint.sourceEventCount,
     provider: checkpoint.provider,
+    sourceAgent,
+    sourceProvenance,
     structured,
     ...(structuredWarnings.length ? { structuredWarnings } : {}),
     ...(sourceEventWindow
@@ -600,6 +607,20 @@ function checkpointHandoffCompact(checkpoint, scope) {
         }
       : {}),
   };
+}
+
+function latestHandoffByAgent(checkpoints) {
+  const byAgent = {};
+  for (const checkpoint of checkpoints) {
+    // listRecentCheckpoints returns newest first; keep the first checkpoint
+    // seen for each source agent.
+    const agent = checkpoint.sourceAgent || checkpoint.sourceProvenance?.sourceAgent || null;
+    if (!agent || byAgent[agent]) {
+      continue;
+    }
+    byAgent[agent] = checkpoint;
+  }
+  return byAgent;
 }
 
 function normalizeRelatedScopeKeys(value) {
@@ -634,6 +655,8 @@ function bootstrapResult(result, group) {
     ...(summary.candidateId ? { candidateId: summary.candidateId } : {}),
     ...(summary.status ? { status: summary.status } : {}),
     ...(summary.checkpointId ? { checkpointId: summary.checkpointId } : {}),
+    ...(summary.sourceAgent ? { sourceAgent: summary.sourceAgent } : {}),
+    ...(summary.sourceProvenance ? { sourceProvenance: summary.sourceProvenance } : {}),
   };
 }
 
@@ -851,12 +874,15 @@ function compactBootstrapCandidate(result) {
     content: truncateText(result.content, 240),
     status: result.status || null,
     checkpointId: result.checkpointId || null,
+    sourceAgent: result.sourceAgent || null,
+    sourceProvenance: result.sourceProvenance || null,
     trust: 'review_material',
     useHint: 'Useful context and review material, not durable truth or a promotion proposal.',
   };
 }
 
 function compactIndexedCandidate(indexedCandidate) {
+  const sourceProvenance = indexedCandidate.source?.sourceProvenance || null;
   return {
     candidateId: indexedCandidate.id,
     key: indexedCandidate.candidate?.key || null,
@@ -864,6 +890,8 @@ function compactIndexedCandidate(indexedCandidate) {
     content: truncateText(indexedCandidate.candidate?.content, 240),
     status: indexedCandidate.status || null,
     checkpointId: indexedCandidate.checkpointId || null,
+    sourceAgent: sourceProvenance?.sourceAgent || indexedCandidate.source?.sourceAgent || null,
+    sourceProvenance,
     trust: 'review_material',
     useHint: 'Useful context and review material, not durable truth or a promotion proposal.',
   };
@@ -949,6 +977,7 @@ function checkpointBasisResult(checkpoint) {
 }
 
 function indexedCandidateBasisResult(indexedCandidate) {
+  const sourceProvenance = indexedCandidate.source?.sourceProvenance || null;
   return {
     type: 'memory_candidate',
     key: indexedCandidate.candidate?.key || null,
@@ -972,6 +1001,8 @@ function indexedCandidateBasisResult(indexedCandidate) {
     candidateId: indexedCandidate.id,
     checkpointId: indexedCandidate.checkpointId,
     status: indexedCandidate.status,
+    sourceAgent: sourceProvenance?.sourceAgent || indexedCandidate.source?.sourceAgent || null,
+    sourceProvenance,
   };
 }
 
@@ -1007,6 +1038,7 @@ function scorePromotionCandidate(indexedCandidate, warnings, skipWarningCodes = 
 
 function promotionProposal(indexedCandidate, warnings, rank) {
   const candidate = indexedCandidate.candidate || {};
+  const sourceProvenance = indexedCandidate.source?.sourceProvenance || null;
   const proposal = {
     rank,
     candidateId: indexedCandidate.id,
@@ -1022,6 +1054,8 @@ function promotionProposal(indexedCandidate, warnings, rank) {
       sourceEventIds: candidate.sourceEventIds || [],
       checkpointId: indexedCandidate.checkpointId,
       sessionId: indexedCandidate.sessionId,
+      sourceAgent: sourceProvenance?.sourceAgent || indexedCandidate.source?.sourceAgent || null,
+      sourceProvenance,
       ...(Array.isArray(candidate.evidenceRefs) && candidate.evidenceRefs.length
         ? { evidenceRefs: candidate.evidenceRefs }
         : {}),
@@ -2162,19 +2196,26 @@ export function createContextForge(options = {}) {
             scopeKey,
           })),
         ];
-        const latestCheckpoints =
-          latestCheckpointLimit > 0
-            ? handoffScopes.flatMap((handoffScope) =>
+        // Fetch extra recent checkpoints so latestByAgent can surface multiple
+        // active adapters even when one agent produced several recent handoffs.
+        const handoffFetchLimit = latestCheckpointLimit > 0 ? Math.max(latestCheckpointLimit, 10) : 0;
+        const fetchedLatestCheckpoints =
+          handoffFetchLimit > 0
+            ? handoffScopes.map((handoffScope) =>
                 store
                   .listRecentCheckpoints({
                     ...handoffScope,
                     level: 0,
-                    limit: latestCheckpointLimit,
+                    limit: handoffFetchLimit,
                   })
                   .map((checkpoint) => checkpointHandoffCompact(checkpoint, handoffScope)),
               )
             : [];
+        const latestCheckpoints = fetchedLatestCheckpoints.flatMap((checkpoints) =>
+          checkpoints.slice(0, latestCheckpointLimit),
+        );
         const latestHandoff = latestCheckpoints[0] || null;
+        const latestByAgent = latestHandoffByAgent(fetchedLatestCheckpoints.flat());
         const workingSummary = sessionId
           ? bootstrapWorkingSummary(store.getWorkingSummary({ ...scope, sessionId }))
           : null;
@@ -2194,6 +2235,7 @@ export function createContextForge(options = {}) {
           sharedLimit: includeShared ? sharedLimit : null,
           handoff: {
             latestHandoff,
+            latestByAgent,
             latestCheckpoints,
             latestCheckpointLimit,
             relatedScopeKeys,

--- a/src/ingest/agents.js
+++ b/src/ingest/agents.js
@@ -1,0 +1,686 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import {
+  addWatchTotals,
+  createInterruptibleSleep,
+  createWatchTotals,
+  discoverFiles,
+  ingestParsedSession,
+  loadRepoRegistry,
+  matchRepoForCwd,
+  shouldSkipOutsideRepo,
+  summarizeResults,
+  truncate,
+} from './common.js';
+import { discoverClaudeCodeFiles, parseClaudeCodeFile } from './claude_code.js';
+import { discoverCodexRolloutFiles, parseCodexRolloutFile } from './codex.js';
+
+const DEFAULT_MAX_CONTENT_CHARS = 8000;
+
+function stripSessionPrefix(prefix, sessionId) {
+  const text = String(sessionId || '');
+  return text.startsWith(`${prefix}:`) ? text.slice(prefix.length + 1) : text;
+}
+
+function prefixedSessionId(prefix, nativeSessionId) {
+  const native = stripSessionPrefix(prefix, nativeSessionId);
+  return native ? `${prefix}:${native}` : null;
+}
+
+function textFromContent(content) {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return '';
+  }
+  return content
+    .map((item) => {
+      if (!item || typeof item !== 'object') return '';
+      return item.text || item.input_text || item.output_text || '';
+    })
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function parseJsonLineFile(filePath, text, normalizeRecord, options = {}, initialContext = {}) {
+  const lines = text.split(/\r?\n/);
+  const events = [];
+  const warnings = [];
+  const context = {
+    filePath,
+    lineNumber: 0,
+    ...initialContext,
+  };
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line.trim()) continue;
+    let record;
+    try {
+      record = JSON.parse(line);
+    } catch (error) {
+      // Agent CLIs often append JSONL records while a watcher is reading. Treat
+      // only the trailing write window as partial; malformed earlier records
+      // still fail loudly.
+      if (index === lines.length - 1 || index === lines.length - 2) {
+        warnings.push({
+          type: 'partial_json_line',
+          lineNumber: index + 1,
+          message: error.message,
+        });
+        continue;
+      }
+      throw error;
+    }
+    context.lineNumber += 1;
+    const event = normalizeRecord(record, context, options);
+    if (event) {
+      events.push(event);
+    }
+  }
+
+  return { context, events, warnings };
+}
+
+function encodedCwdFromGrokChatHistory(filePath) {
+  const sessionDir = path.dirname(filePath);
+  const encodedCwd = path.basename(path.dirname(sessionDir));
+  try {
+    return decodeURIComponent(encodedCwd);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeGrokRecord(record, context, options = {}) {
+  if (record.type !== 'user' && record.type !== 'assistant') {
+    return null;
+  }
+  const content = truncate(textFromContent(record.content), options.maxContentChars || DEFAULT_MAX_CONTENT_CHARS);
+  if (!content.text) {
+    return null;
+  }
+  return {
+    role: record.type,
+    content: content.text,
+    metadata: {
+      source: 'grok_chat_history_jsonl',
+      sourceAgent: 'grok',
+      sourceRuntime: 'grok_cli',
+      sourceAdapter: 'grok_chat_history_jsonl',
+      nativeSessionId: context.nativeSessionId,
+      ingestId: `grok:${context.nativeSessionId || 'unknown'}:${context.lineNumber}`,
+      recordType: record.type,
+      modelId: record.model_id || null,
+      truncated: content.truncated,
+      sourceFile: context.filePath,
+    },
+  };
+}
+
+export async function parseGrokChatHistoryFile(filePath, options = {}) {
+  const text = await fs.readFile(filePath, 'utf8');
+  const nativeSessionId = path.basename(path.dirname(filePath));
+  const sessionId = prefixedSessionId('grok', options.sessionId || nativeSessionId);
+  const parsed = parseJsonLineFile(filePath, text, normalizeGrokRecord, options, {
+    nativeSessionId: stripSessionPrefix('grok', options.sessionId || nativeSessionId),
+    sessionId,
+    conversationId: sessionId,
+    cwd: options.cwd || encodedCwdFromGrokChatHistory(filePath),
+  });
+  return {
+    nativeSessionId: parsed.context.nativeSessionId,
+    sessionId: parsed.context.sessionId,
+    conversationId: parsed.context.conversationId,
+    cwd: parsed.context.cwd,
+    events: parsed.events,
+    warnings: parsed.warnings,
+  };
+}
+
+function defaultGrokSessionsDir() {
+  return path.join(os.homedir(), '.grok', 'sessions');
+}
+
+export async function discoverGrokChatHistoryFiles(options = {}) {
+  const sessionsDir = path.resolve(options.grokSessionsDir || options.sessionsDir || defaultGrokSessionsDir());
+  return discoverFiles(sessionsDir, options, (file) => path.basename(file) === 'chat_history.jsonl');
+}
+
+function cursorProjectNameFromTranscript(filePath) {
+  const marker = `${path.sep}agent-transcripts${path.sep}`;
+  const index = filePath.indexOf(marker);
+  if (index < 0) {
+    return null;
+  }
+  return path.basename(filePath.slice(0, index)) || null;
+}
+
+function cursorProjectCwd(filePath, options = {}) {
+  if (options.cwd) {
+    return options.cwd;
+  }
+  return null;
+}
+
+function cursorProjectNameForRepoPath(repoPath) {
+  return path
+    .resolve(repoPath)
+    .split(path.sep)
+    .filter(Boolean)
+    .join('-');
+}
+
+function matchCursorRepo(unit, parsed, repos) {
+  const matched = matchRepoForCwd(parsed.cwd, repos);
+  if (matched) {
+    return matched;
+  }
+  const projectName = unit.cursorProjectName || (unit.file ? cursorProjectNameFromTranscript(unit.file) : null);
+  if (!projectName) {
+    return null;
+  }
+  const matches = repos.filter((repo) => cursorProjectNameForRepoPath(repo.repoPath) === projectName);
+  matches.sort((a, b) => b.repoPath.length - a.repoPath.length || a.name.localeCompare(b.name));
+  return matches[0] || null;
+}
+
+function normalizeCursorRecord(record, context, options = {}) {
+  const role = record.role;
+  if (role !== 'user' && role !== 'assistant') {
+    return null;
+  }
+  const content = truncate(textFromContent(record.message?.content ?? record.content), options.maxContentChars || DEFAULT_MAX_CONTENT_CHARS);
+  if (!content.text) {
+    return null;
+  }
+  return {
+    role,
+    content: content.text,
+    metadata: {
+      source: 'cursor_agent_transcript_jsonl',
+      sourceAgent: 'cursor_cli',
+      sourceRuntime: 'cursor_cli',
+      sourceAdapter: 'cursor_agent_transcript_jsonl',
+      nativeSessionId: context.nativeSessionId,
+      ingestId: `cursor-cli:${context.nativeSessionId || 'unknown'}:${record.id || context.lineNumber}`,
+      recordType: record.type || null,
+      cursorRole: role,
+      truncated: content.truncated,
+      sourceFile: context.filePath,
+    },
+  };
+}
+
+export async function parseCursorTranscriptFile(filePath, options = {}) {
+  const text = await fs.readFile(filePath, 'utf8');
+  const nativeSessionId = path.basename(path.dirname(filePath)) || path.basename(filePath, '.jsonl');
+  const sessionId = prefixedSessionId('cursor_cli', options.sessionId || nativeSessionId);
+  const parsed = parseJsonLineFile(filePath, text, normalizeCursorRecord, options, {
+    nativeSessionId: stripSessionPrefix('cursor_cli', options.sessionId || nativeSessionId),
+    sessionId,
+    conversationId: sessionId,
+    cwd: cursorProjectCwd(filePath, options),
+    cursorProjectName: cursorProjectNameFromTranscript(filePath),
+  });
+  return {
+    nativeSessionId: parsed.context.nativeSessionId,
+    sessionId: parsed.context.sessionId,
+    conversationId: parsed.context.conversationId,
+    cwd: parsed.context.cwd,
+    cursorProjectName: parsed.context.cursorProjectName,
+    events: parsed.events,
+    warnings: parsed.warnings,
+  };
+}
+
+function defaultCursorProjectsDir() {
+  return path.join(os.homedir(), '.cursor', 'projects');
+}
+
+export async function discoverCursorTranscriptFiles(options = {}) {
+  const projectsDir = path.resolve(options.cursorProjectsDir || options.projectsDir || defaultCursorProjectsDir());
+  return discoverFiles(projectsDir, options, (file) => file.endsWith('.jsonl') && file.includes(`${path.sep}agent-transcripts${path.sep}`));
+}
+
+function defaultOpenCodeDbPath() {
+  return path.join(os.homedir(), '.local', 'share', 'opencode', 'opencode.db');
+}
+
+function parseMaybeJson(value, fallback = null) {
+  if (value == null) return fallback;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function opencodeMessageCwd(sessionRow, messageData) {
+  return messageData?.path?.cwd || messageData?.path?.root || sessionRow.directory || sessionRow.path || null;
+}
+
+function textFromOpenCodeParts(parts) {
+  return parts
+    .map((part) => parseMaybeJson(part.data, {}))
+    .filter((part) => part.type === 'text')
+    .map((part) => part.text || '')
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+export async function discoverOpenCodeSessions(options = {}) {
+  const dbPath = path.resolve(options.opencodeDb || options.db || defaultOpenCodeDbPath());
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  try {
+    const sinceMs = options.sinceMinutes == null ? null : Date.now() - Number(options.sinceMinutes) * 60 * 1000;
+    const limitSql = options.scanLimit == null ? '' : ' limit ?';
+    const params = sinceMs == null ? [] : [sinceMs];
+    const rows = db
+      .prepare(
+        `select id, directory, title, agent, model, time_created, time_updated from session${
+          sinceMs == null ? '' : ' where time_updated >= ?'
+        } order by time_updated asc${limitSql}`,
+      )
+      .all(...(options.scanLimit == null ? params : [...params, Number(options.scanLimit)]));
+    return rows.map((row) => ({
+      dbPath,
+      nativeSessionId: row.id,
+      cwd: row.directory || null,
+      title: row.title || null,
+    }));
+  } finally {
+    db.close();
+  }
+}
+
+export async function parseOpenCodeSession(unit, options = {}) {
+  const db = new Database(unit.dbPath, { readonly: true, fileMustExist: true });
+  try {
+    const sessionRow = db.prepare('select * from session where id = ?').get(unit.nativeSessionId);
+    if (!sessionRow) {
+      throw new Error(`OpenCode session not found: ${unit.nativeSessionId}`);
+    }
+    const nativeSessionId = stripSessionPrefix('opencode', options.sessionId || sessionRow.id);
+    const sessionId = prefixedSessionId('opencode', nativeSessionId);
+    const messageRows = db
+      .prepare('select id, data, time_created, time_updated from message where session_id = ? order by time_created asc, id asc')
+      .all(sessionRow.id);
+    const partStmt = db.prepare('select data from part where message_id = ? order by time_created asc, id asc');
+    const events = [];
+    let cwd = options.cwd || sessionRow.directory || sessionRow.path || null;
+
+    for (const messageRow of messageRows) {
+      const messageData = parseMaybeJson(messageRow.data, {});
+      const role = messageData.role;
+      if (role !== 'user' && role !== 'assistant') {
+        continue;
+      }
+      cwd = cwd || opencodeMessageCwd(sessionRow, messageData);
+      const content = truncate(textFromOpenCodeParts(partStmt.all(messageRow.id)), options.maxContentChars || DEFAULT_MAX_CONTENT_CHARS);
+      if (!content.text) {
+        continue;
+      }
+      events.push({
+        role,
+        content: content.text,
+        metadata: {
+          source: 'opencode_sqlite',
+          sourceAgent: 'opencode',
+          sourceRuntime: 'opencode_cli',
+          sourceAdapter: 'opencode_sqlite',
+          nativeSessionId,
+          ingestId: `opencode:${nativeSessionId}:${messageRow.id}`,
+          messageId: messageRow.id,
+          agent: messageData.agent || sessionRow.agent || null,
+          modelId: messageData.modelID || parseMaybeJson(sessionRow.model, {})?.id || null,
+          providerId: messageData.providerID || parseMaybeJson(sessionRow.model, {})?.providerID || null,
+          truncated: content.truncated,
+          sourceFile: unit.dbPath,
+        },
+      });
+    }
+
+    return {
+      nativeSessionId,
+      sessionId,
+      conversationId: sessionId,
+      cwd,
+      events,
+      warnings: [],
+    };
+  } finally {
+    db.close();
+  }
+}
+
+export const AGENT_ADAPTERS = Object.freeze({
+  codex: {
+    id: 'codex',
+    displayName: 'Codex',
+    source: 'codex_rollout_jsonl',
+    summarySource: 'codex_sessions',
+    routerSource: 'codex_sessions_router',
+    rootSummaryKey: 'sessionsDir',
+    rootPath: (options = {}) => path.resolve(options.codexSessionsDir || options.sessionsDir || path.join(os.homedir(), '.codex', 'sessions')),
+    discover: async (options = {}) => (await discoverCodexRolloutFiles({ ...options, sessionsDir: options.codexSessionsDir || options.sessionsDir })).map((file) => ({ file })),
+    parse: (unit, options = {}) => parseCodexRolloutFile(unit.file, options),
+    missingSessionMessage: 'Codex rollout session id could not be determined.',
+  },
+  claude_code: {
+    id: 'claude_code',
+    displayName: 'Claude Code',
+    source: 'claude_code_jsonl',
+    summarySource: 'claude_code_sessions',
+    routerSource: 'claude_code_sessions_router',
+    rootSummaryKey: 'projectsDir',
+    rootPath: (options = {}) => path.resolve(options.claudeCodeProjectsDir || options.projectsDir || options.sessionsDir || path.join(os.homedir(), '.claude', 'projects')),
+    discover: async (options = {}) =>
+      (await discoverClaudeCodeFiles({ ...options, projectsDir: options.claudeCodeProjectsDir || options.projectsDir || options.sessionsDir })).map((file) => ({ file })),
+    parse: (unit, options = {}) => parseClaudeCodeFile(unit.file, options),
+    missingSessionMessage: 'Claude Code session id could not be determined.',
+  },
+  opencode: {
+    id: 'opencode',
+    displayName: 'OpenCode',
+    source: 'opencode_sqlite',
+    summarySource: 'opencode_sessions',
+    routerSource: 'opencode_sessions_router',
+    rootSummaryKey: 'dbPath',
+    rootPath: (options = {}) => path.resolve(options.opencodeDb || options.db || defaultOpenCodeDbPath()),
+    discover: discoverOpenCodeSessions,
+    parse: parseOpenCodeSession,
+    missingSessionMessage: 'OpenCode session id could not be determined.',
+  },
+  grok: {
+    id: 'grok',
+    displayName: 'Grok',
+    source: 'grok_chat_history_jsonl',
+    summarySource: 'grok_sessions',
+    routerSource: 'grok_sessions_router',
+    rootSummaryKey: 'sessionsDir',
+    rootPath: (options = {}) => path.resolve(options.grokSessionsDir || options.sessionsDir || defaultGrokSessionsDir()),
+    discover: async (options = {}) => (await discoverGrokChatHistoryFiles(options)).map((file) => ({ file })),
+    parse: (unit, options = {}) => parseGrokChatHistoryFile(unit.file, options),
+    missingSessionMessage: 'Grok session id could not be determined.',
+  },
+  cursor_cli: {
+    id: 'cursor_cli',
+    displayName: 'Cursor CLI',
+    source: 'cursor_agent_transcript_jsonl',
+    summarySource: 'cursor_cli_sessions',
+    routerSource: 'cursor_cli_sessions_router',
+    rootSummaryKey: 'projectsDir',
+    rootPath: (options = {}) => path.resolve(options.cursorProjectsDir || options.projectsDir || defaultCursorProjectsDir()),
+    discover: async (options = {}) =>
+      (await discoverCursorTranscriptFiles(options)).map((file) => ({
+        file,
+        cursorProjectName: cursorProjectNameFromTranscript(file),
+      })),
+    parse: (unit, options = {}) => parseCursorTranscriptFile(unit.file, options),
+    matchRepo: matchCursorRepo,
+    missingSessionMessage: 'Cursor CLI session id could not be determined.',
+  },
+});
+
+export function listAgentAdapters() {
+  return Object.values(AGENT_ADAPTERS).map((adapter) => ({
+    id: adapter.id,
+    displayName: adapter.displayName,
+    source: adapter.source,
+    summarySource: adapter.summarySource,
+  }));
+}
+
+export function normalizeAgentAdapterIds(value) {
+  if (value == null || value === true) {
+    return Object.keys(AGENT_ADAPTERS);
+  }
+  const items = Array.isArray(value) ? value : String(value).split(',');
+  const ids = [...new Set(items.map((item) => String(item).trim()).filter(Boolean))];
+  for (const id of ids) {
+    if (!AGENT_ADAPTERS[id]) {
+      throw new Error(`Unknown agent adapter: ${id}`);
+    }
+  }
+  return ids;
+}
+
+async function ingestParsedForAdapter(app, adapter, unit, parsed, options = {}) {
+  if (!parsed.sessionId) {
+    throw new Error(adapter.missingSessionMessage);
+  }
+  if (shouldSkipOutsideRepo(parsed, options)) {
+    return {
+      source: adapter.source,
+      file: unit.file,
+      dbPath: unit.dbPath,
+      sessionId: parsed.sessionId,
+      conversationId: parsed.conversationId,
+      parsedEvents: parsed.events.length,
+      appendedEvents: 0,
+      skippedEvents: parsed.events.length,
+      warnings: parsed.warnings,
+      skipped: true,
+      skippedReason: 'cwd_outside_repo_path',
+      cwd: parsed.cwd,
+      repoPath: path.resolve(options.repoPath),
+      status: null,
+      checkpoint: null,
+    };
+  }
+  const result = await ingestParsedSession(app, parsed, options, {
+    missingSessionMessage: adapter.missingSessionMessage,
+  });
+  return {
+    source: adapter.source,
+    file: unit.file,
+    dbPath: unit.dbPath,
+    sessionId: parsed.sessionId,
+    conversationId: parsed.conversationId,
+    warnings: parsed.warnings,
+    ...result,
+  };
+}
+
+function summarizeAdapterResult(adapter, rootPath, results) {
+  return {
+    source: adapter.summarySource,
+    adapter: adapter.id,
+    [adapter.rootSummaryKey]: rootPath,
+    filesScanned: results.length,
+    parsedEvents: results.reduce((total, result) => total + result.parsedEvents, 0),
+    appendedEvents: results.reduce((total, result) => total + result.appendedEvents, 0),
+    skippedEvents: results.reduce((total, result) => total + result.skippedEvents, 0),
+    checkpointsCreated: results.filter((result) => result.checkpoint).length,
+    fileResults: results,
+  };
+}
+
+export async function ingestAgentSessions(app, options = {}) {
+  const adapterIds = normalizeAgentAdapterIds(options.adapters || options.adapter);
+  const adapterResults = [];
+  for (const adapterId of adapterIds) {
+    const adapter = AGENT_ADAPTERS[adapterId];
+    if (options.file && adapter.rootSummaryKey !== 'sessionsDir' && adapter.rootSummaryKey !== 'projectsDir') {
+      throw new Error(`--file is not supported for ${adapter.id}; use the adapter-specific root option instead.`);
+    }
+    const rootPath = adapter.rootPath(options);
+    const units = options.file ? [{ file: options.file }] : await adapter.discover(options);
+    const results = [];
+    for (const unit of units) {
+      const parsed = await adapter.parse(unit, options);
+      results.push(await ingestParsedForAdapter(app, adapter, unit, parsed, options));
+    }
+    adapterResults.push(summarizeAdapterResult(adapter, rootPath, results));
+  }
+  const totals = summarizeResults(adapterResults);
+  return {
+    source: 'agent_sessions',
+    adapters: adapterIds,
+    adapterResults,
+    ...totals,
+    checkpointsCreated: adapterResults.reduce((total, result) => total + result.checkpointsCreated, 0),
+  };
+}
+
+async function ingestRoutedAdapter(app, adapter, options = {}) {
+  const repos = await loadRepoRegistry(options, { adapter: adapter.id, label: adapter.displayName });
+  const rootPath = adapter.rootPath(options);
+  if (options.file && adapter.rootSummaryKey !== 'sessionsDir' && adapter.rootSummaryKey !== 'projectsDir') {
+    throw new Error(`--file is not supported for ${adapter.id}; use the adapter-specific root option instead.`);
+  }
+  const units = options.file ? [{ file: options.file }] : await adapter.discover(options);
+  const results = [];
+  for (const unit of units) {
+    const parsed = await adapter.parse(unit, options);
+    const matchedRepo = adapter.matchRepo ? adapter.matchRepo(unit, parsed, repos) : matchRepoForCwd(parsed.cwd, repos);
+    if (!matchedRepo) {
+      results.push({
+        source: adapter.source,
+        file: unit.file,
+        dbPath: unit.dbPath,
+        sessionId: parsed.sessionId,
+        conversationId: parsed.conversationId,
+        parsedEvents: parsed.events.length,
+        appendedEvents: 0,
+        skippedEvents: parsed.events.length,
+        warnings: parsed.warnings,
+        skipped: true,
+        skippedReason: parsed.cwd ? 'unmatched_repo_cwd' : 'missing_cwd',
+        cwd: parsed.cwd,
+        matchedRepo: null,
+        status: null,
+        checkpoint: null,
+      });
+      continue;
+    }
+    const result = await ingestParsedSession(
+      app,
+      parsed,
+      {
+        ...options,
+        scope: 'repo',
+        scopeKey: matchedRepo.scopeKey,
+        repoPath: undefined,
+        cwd: undefined,
+      },
+      { missingSessionMessage: adapter.missingSessionMessage },
+    );
+    results.push({
+      source: adapter.source,
+      file: unit.file,
+      dbPath: unit.dbPath,
+      sessionId: parsed.sessionId,
+      conversationId: parsed.conversationId,
+      warnings: parsed.warnings,
+      matchedRepo: {
+        name: matchedRepo.name,
+        repoPath: matchedRepo.repoPath,
+        scopeKey: matchedRepo.scopeKey,
+      },
+      ...result,
+    });
+  }
+  return {
+    source: adapter.routerSource,
+    adapter: adapter.id,
+    [adapter.rootSummaryKey]: rootPath,
+    registry: path.resolve(options.repoRegistry || options.registry || options.repoRegistryFile),
+    repos: repos.map((repo) => ({
+      name: repo.name,
+      repoPath: repo.repoPath,
+      scopeKey: repo.scopeKey,
+    })),
+    filesScanned: units.length,
+    parsedEvents: results.reduce((total, result) => total + result.parsedEvents, 0),
+    appendedEvents: results.reduce((total, result) => total + result.appendedEvents, 0),
+    skippedEvents: results.reduce((total, result) => total + result.skippedEvents, 0),
+    checkpointsCreated: results.filter((result) => result.checkpoint).length,
+    routedFiles: results.filter((result) => result.matchedRepo).length,
+    skippedFiles: results.filter((result) => result.skipped).length,
+    fileResults: results,
+  };
+}
+
+export async function ingestAgentRoutedSessions(app, options = {}) {
+  const adapterIds = normalizeAgentAdapterIds(options.adapters || options.adapter);
+  const adapterResults = [];
+  for (const adapterId of adapterIds) {
+    adapterResults.push(await ingestRoutedAdapter(app, AGENT_ADAPTERS[adapterId], options));
+  }
+  return {
+    source: 'agent_sessions_router',
+    adapters: adapterIds,
+    registry: path.resolve(options.repoRegistry || options.registry || options.repoRegistryFile),
+    adapterResults,
+    filesScanned: adapterResults.reduce((total, result) => total + result.filesScanned, 0),
+    parsedEvents: adapterResults.reduce((total, result) => total + result.parsedEvents, 0),
+    appendedEvents: adapterResults.reduce((total, result) => total + result.appendedEvents, 0),
+    skippedEvents: adapterResults.reduce((total, result) => total + result.skippedEvents, 0),
+    checkpointsCreated: adapterResults.reduce((total, result) => total + result.checkpointsCreated, 0),
+    routedFiles: adapterResults.reduce((total, result) => total + result.routedFiles, 0),
+    skippedFiles: adapterResults.reduce((total, result) => total + result.skippedFiles, 0),
+  };
+}
+
+export async function watchAgentRoutedSessions(app, options = {}) {
+  const intervalMs = options.intervalMs == null ? 30000 : Math.max(0, Number(options.intervalMs));
+  const maxIterations = options.iterations == null ? null : Math.max(0, Number(options.iterations));
+  const startedAt = new Date().toISOString();
+  const results = [];
+  const totals = createWatchTotals();
+  let iterations = 0;
+  let stopped = false;
+  const sleeper = createInterruptibleSleep();
+
+  const stop = () => {
+    stopped = true;
+    sleeper.stop();
+  };
+
+  process.once('SIGINT', stop);
+  process.once('SIGTERM', stop);
+
+  try {
+    while (!stopped && (maxIterations == null || iterations < maxIterations)) {
+      iterations += 1;
+      const result = await ingestAgentRoutedSessions(app, options);
+      const iterationResult = {
+        ...result,
+        source: 'agent_sessions_router_watch_iteration',
+        iteration: iterations,
+        intervalMs,
+        watchedAt: new Date().toISOString(),
+      };
+      addWatchTotals(totals, iterationResult);
+      if (maxIterations != null) {
+        results.push(options.watchVerbose ? iterationResult : { ...iterationResult, adapterResults: undefined });
+      }
+      if (options.onResult) {
+        await options.onResult(iterationResult);
+      }
+      if (!stopped && (maxIterations == null || iterations < maxIterations)) {
+        await sleeper.sleep(intervalMs);
+      }
+    }
+  } finally {
+    process.removeListener('SIGINT', stop);
+    process.removeListener('SIGTERM', stop);
+  }
+
+  return {
+    source: 'agent_sessions_router_watch',
+    adapters: normalizeAgentAdapterIds(options.adapters || options.adapter),
+    intervalMs,
+    iterations,
+    stopped,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    totals,
+    results,
+  };
+}

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -168,6 +168,8 @@ function hydrateMemoryCandidate(row) {
   if (!row) return null;
   const candidateJson = parseJson(row.candidate_json, {});
   const tags = parseJson(row.tags_json, []);
+  const checkpointMetadata = parseJson(row.checkpoint_metadata_json, {});
+  const sourceProvenance = checkpointMetadata.sourceProvenance || null;
   return {
     type: 'memory_candidate',
     id: row.id,
@@ -198,6 +200,8 @@ function hydrateMemoryCandidate(row) {
       distillRunId: row.distill_run_id,
       sourceEventCount: row.source_event_count,
       checkpointCreatedAt: row.checkpoint_created_at,
+      sourceAgent: sourceProvenance?.sourceAgent || null,
+      sourceProvenance,
     },
     reviewedAt: row.reviewed_at,
     reviewReason: row.review_reason,
@@ -1065,6 +1069,7 @@ export class ContextForgeStore {
           checkpoints.provider,
           checkpoints.distill_run_id,
           checkpoints.source_event_count,
+          checkpoints.metadata_json AS checkpoint_metadata_json,
           checkpoints.created_at AS checkpoint_created_at,
           embedding_index.content_hash AS embedding_content_hash
         FROM memory_candidate_index
@@ -1493,6 +1498,7 @@ export class ContextForgeStore {
           checkpoints.provider,
           checkpoints.distill_run_id,
           checkpoints.source_event_count,
+          checkpoints.metadata_json AS checkpoint_metadata_json,
           checkpoints.created_at AS checkpoint_created_at,
           embedding_vec.distance AS vector_distance,
           embedding_index.model AS embedding_model,
@@ -1601,6 +1607,7 @@ export class ContextForgeStore {
       .prepare(`
         SELECT
           memory_candidate_index.*,
+          checkpoints.metadata_json AS checkpoint_metadata_json,
           checkpoints.created_at AS checkpoint_created_at
         FROM memory_candidate_index
         JOIN checkpoints ON checkpoints.id = memory_candidate_index.checkpoint_id
@@ -2419,6 +2426,7 @@ export class ContextForgeStore {
           checkpoints.provider,
           checkpoints.distill_run_id,
           checkpoints.source_event_count,
+          checkpoints.metadata_json AS checkpoint_metadata_json,
           checkpoints.created_at AS checkpoint_created_at
         FROM memory_candidate_index
         JOIN checkpoints ON checkpoints.id = memory_candidate_index.checkpoint_id
@@ -2724,6 +2732,7 @@ export class ContextForgeStore {
           checkpoints.provider,
           checkpoints.distill_run_id,
           checkpoints.source_event_count,
+          checkpoints.metadata_json AS checkpoint_metadata_json,
           checkpoints.created_at AS checkpoint_created_at
         FROM memory_candidate_index
         JOIN checkpoints ON checkpoints.id = memory_candidate_index.checkpoint_id
@@ -2743,6 +2752,7 @@ export class ContextForgeStore {
           checkpoints.provider,
           checkpoints.distill_run_id,
           checkpoints.source_event_count,
+          checkpoints.metadata_json AS checkpoint_metadata_json,
           checkpoints.created_at AS checkpoint_created_at
         FROM memory_candidate_index
         JOIN checkpoints ON checkpoints.id = memory_candidate_index.checkpoint_id

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -18,6 +18,7 @@ import { createOpenAiEmbeddingProvider } from '../src/embeddings/index.js';
 import { createInterruptibleSleep, shouldSkipRecentFailedAutoDistill } from '../src/ingest/common.js';
 import { watchClaudeCodeSessions } from '../src/ingest/claude_code.js';
 import { ingestCodexRolloutFile, watchCodexSessions } from '../src/ingest/codex.js';
+import { ingestAgentRoutedSessions, ingestAgentSessions, listAgentAdapters } from '../src/ingest/agents.js';
 import { searchMemories } from '../src/retrieval/search.js';
 import { REMOTE_METHODS } from '../src/remote/client.js';
 import { startContextForgeServer } from '../src/server.js';
@@ -173,6 +174,142 @@ async function writeSyntheticClaudeCodeTranscript(filePath, sessionId = 'claude-
     },
   ];
   await fs.writeFile(filePath, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`);
+}
+
+async function writeSyntheticGrokChatHistory(
+  sessionsDir,
+  sessionId = 'grok-session',
+  cwd = path.dirname(sessionsDir),
+) {
+  const sessionDir = path.join(sessionsDir, encodeURIComponent(cwd), sessionId);
+  const file = path.join(sessionDir, 'chat_history.jsonl');
+  const records = [
+    {
+      type: 'system',
+      content: 'System prompts should not be captured as raw dialogue.',
+    },
+    {
+      type: 'user',
+      content: [{ type: 'text', text: 'Continue the ContextForge Grok ingest work.' }],
+    },
+    {
+      type: 'reasoning',
+      summary: ['Reasoning should not be captured as raw dialogue.'],
+    },
+    {
+      type: 'assistant',
+      content: 'I added Grok chat history ingestion.',
+      model_id: 'grok-test',
+    },
+  ];
+  await fs.mkdir(sessionDir, { recursive: true });
+  await fs.writeFile(file, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`);
+  return file;
+}
+
+async function writeSyntheticCursorTranscript(
+  projectsDir,
+  sessionId = 'cursor-session',
+  projectName = 'home-ubuntu',
+) {
+  const sessionDir = path.join(projectsDir, projectName, 'agent-transcripts', sessionId);
+  const file = path.join(sessionDir, `${sessionId}.jsonl`);
+  const records = [
+    {
+      role: 'user',
+      message: {
+        content: [{ type: 'text', text: 'Continue the ContextForge Cursor CLI ingest work.' }],
+      },
+    },
+    {
+      role: 'assistant',
+      message: {
+        content: [{ type: 'text', text: 'I added Cursor CLI transcript ingestion.' }],
+      },
+    },
+  ];
+  await fs.mkdir(sessionDir, { recursive: true });
+  await fs.writeFile(file, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`);
+  return file;
+}
+
+async function writeSyntheticOpenCodeDb(dbPath, sessionId = 'opencode-session', cwd = path.dirname(dbPath)) {
+  await fs.mkdir(path.dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath);
+  try {
+    db.exec(`
+      create table session (
+        id text primary key,
+        directory text not null,
+        title text not null,
+        agent text,
+        model text,
+        time_created integer not null,
+        time_updated integer not null
+      );
+      create table message (
+        id text primary key,
+        session_id text not null,
+        time_created integer not null,
+        time_updated integer not null,
+        data text not null
+      );
+      create table part (
+        id text primary key,
+        message_id text not null,
+        session_id text not null,
+        time_created integer not null,
+        time_updated integer not null,
+        data text not null
+      );
+    `);
+    db.prepare(
+      'insert into session (id, directory, title, agent, model, time_created, time_updated) values (?, ?, ?, ?, ?, ?, ?)',
+    ).run(
+      sessionId,
+      cwd,
+      'Synthetic OpenCode ingest test',
+      'build',
+      JSON.stringify({ id: 'test-model', providerID: 'test-provider' }),
+      1,
+      4,
+    );
+    const messages = [
+      {
+        id: 'opencode-user-1',
+        role: 'user',
+        content: 'Continue the ContextForge OpenCode ingest work.',
+        time: 2,
+      },
+      {
+        id: 'opencode-assistant-1',
+        role: 'assistant',
+        content: 'I added OpenCode SQLite ingestion.',
+        time: 3,
+      },
+    ];
+    for (const message of messages) {
+      db.prepare('insert into message (id, session_id, time_created, time_updated, data) values (?, ?, ?, ?, ?)').run(
+        message.id,
+        sessionId,
+        message.time,
+        message.time,
+        JSON.stringify({ role: message.role, path: { cwd, root: cwd }, agent: 'build', modelID: 'test-model' }),
+      );
+      db.prepare(
+        'insert into part (id, message_id, session_id, time_created, time_updated, data) values (?, ?, ?, ?, ?, ?)',
+      ).run(
+        `${message.id}-part`,
+        message.id,
+        sessionId,
+        message.time,
+        message.time,
+        JSON.stringify({ type: 'text', text: message.content }),
+      );
+    }
+  } finally {
+    db.close();
+  }
 }
 
 async function appendSyntheticCodexAssistantMessage(filePath, text) {
@@ -2555,6 +2692,255 @@ test('CLI routes Claude Code global transcripts through a repo registry', async 
       sessionId: 'claude_code:claude-frontend',
     }).length,
     0,
+  );
+});
+
+test('agent adapter registry exposes the built-in multi-agent ingest set', () => {
+  assert.deepEqual(
+    listAgentAdapters()
+      .map((adapter) => adapter.id)
+      .sort(),
+    ['claude_code', 'codex', 'cursor_cli', 'grok', 'opencode'],
+  );
+});
+
+test('multi-agent routed ingest shares repo scope while preserving source provenance', async () => {
+  const dataDir = await makeTempDir();
+  const root = await makeTempDir();
+  const repo = await makeTempDir();
+  const codexSessionsDir = path.join(root, 'codex');
+  const claudeCodeProjectsDir = path.join(root, 'claude');
+  const grokSessionsDir = path.join(root, 'grok');
+  const cursorProjectsDir = path.join(root, 'cursor');
+  const opencodeDb = path.join(root, 'opencode', 'opencode.db');
+
+  await fs.mkdir(path.join(codexSessionsDir, '2026', '06', '04'), { recursive: true });
+  await writeSyntheticCodexRollout(
+    path.join(codexSessionsDir, '2026', '06', '04', 'rollout-codex.jsonl'),
+    'registry-codex',
+    repo,
+  );
+  await fs.mkdir(path.join(claudeCodeProjectsDir, 'project-a'), { recursive: true });
+  await writeSyntheticClaudeCodeTranscript(
+    path.join(claudeCodeProjectsDir, 'project-a', 'claude.jsonl'),
+    'registry-claude',
+    repo,
+  );
+  await writeSyntheticGrokChatHistory(grokSessionsDir, 'registry-grok', repo);
+  await writeSyntheticCursorTranscript(cursorProjectsDir, 'registry-cursor');
+  await writeSyntheticOpenCodeDb(opencodeDb, 'registry-opencode', repo);
+
+  const registryPath = path.join(root, 'repos.json');
+  await fs.writeFile(
+    registryPath,
+    JSON.stringify({
+      repos: [
+        {
+          name: 'shared-repo',
+          repoPath: repo,
+          scopeKey: 'github.com/example/shared-repo',
+        },
+      ],
+    }),
+  );
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'candidate_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      candidate_provider: async (input) => ({
+        provider: 'candidate_provider',
+        summaryShort: `Candidate checkpoint for ${input.session.sessionId}.`,
+        summaryText: `Multi-agent candidate checkpoint for ${input.session.sessionId}.`,
+        workingSummary: `Working summary for ${input.session.sessionId}.`,
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: `multi_agent.${input.session.sessionId.replace(/[^a-z0-9]+/gi, '_')}`,
+            content: 'ContextForge multi-agent ingest keeps origin provenance while sharing repo-scoped handoff.',
+            reason: 'This is a stable cross-agent ingest contract.',
+            category: 'architecture',
+            tags: ['multi-agent', 'ingest'],
+            importance: 1,
+            candidateType: 'architecture_decision',
+            confidence: 0.9,
+            stability: 0.9,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+        sourceEventCount: input.rawEvents.length,
+        metadata: {},
+      }),
+    },
+  });
+
+  const result = await ingestAgentRoutedSessions(app, {
+    adapters: 'codex,claude_code,grok,cursor_cli,opencode',
+    codexSessionsDir,
+    claudeCodeProjectsDir,
+    grokSessionsDir,
+    cursorProjectsDir,
+    opencodeDb,
+    repoRegistry: registryPath,
+    cwd: repo,
+    distill: 'always',
+  });
+
+  assert.equal(result.source, 'agent_sessions_router');
+  assert.deepEqual(result.adapters, ['codex', 'claude_code', 'grok', 'cursor_cli', 'opencode']);
+  assert.equal(result.filesScanned, 5);
+  assert.equal(result.routedFiles, 5);
+  assert.equal(result.appendedEvents, 10);
+  assert.equal(result.checkpointsCreated, 5);
+  assert.deepEqual(
+    result.adapterResults.map((adapterResult) => [adapterResult.adapter, adapterResult.routedFiles]).sort(),
+    [
+      ['claude_code', 1],
+      ['codex', 1],
+      ['cursor_cli', 1],
+      ['grok', 1],
+      ['opencode', 1],
+    ],
+  );
+
+  for (const [sessionId, sourceAgent] of [
+    ['codex:registry-codex', 'codex'],
+    ['claude_code:registry-claude', 'claude_code'],
+    ['grok:registry-grok', 'grok'],
+    ['cursor_cli:registry-cursor', 'cursor_cli'],
+    ['opencode:registry-opencode', 'opencode'],
+  ]) {
+    const events = app.listRawEvents({
+      scope: 'repo',
+      scopeKey: 'github.com/example/shared-repo',
+      sessionId,
+    });
+    assert.equal(events.length, 2, sessionId);
+    assert.ok(events.every((event) => event.metadata.sourceAgent === sourceAgent), sessionId);
+    assert.ok(events.every((event) => event.metadata.nativeSessionId), sessionId);
+  }
+
+  const opencodeCandidates = app.listMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'github.com/example/shared-repo',
+    sessionId: 'opencode:registry-opencode',
+    status: 'pending',
+  });
+  assert.equal(opencodeCandidates.length, 1);
+  assert.equal(opencodeCandidates[0].source.sourceAgent, 'opencode');
+  assert.equal(opencodeCandidates[0].source.sourceProvenance.sourceAdapter, 'opencode_sqlite');
+
+  const suggestions = await app.suggestMemoryPromotions({
+    scope: 'repo',
+    scopeKey: 'github.com/example/shared-repo',
+    sessionId: 'opencode:registry-opencode',
+    trigger: 'manual_closeout',
+  });
+  assert.equal(suggestions.proposals.length, 1);
+  assert.equal(suggestions.proposals[0].evidence.sourceAgent, 'opencode');
+  assert.equal(suggestions.proposals[0].evidence.sourceProvenance.sourceRuntime, 'opencode_cli');
+
+  const bootstrap = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'github.com/example/shared-repo',
+    query: 'multi agent handoff',
+    latestCheckpointLimit: 1,
+  });
+  assert.deepEqual(Object.keys(bootstrap.handoff.latestByAgent).sort(), [
+    'claude_code',
+    'codex',
+    'cursor_cli',
+    'grok',
+    'opencode',
+  ]);
+  assert.equal(bootstrap.handoff.latestByAgent.codex.sourceProvenance.sourceAgent, 'codex');
+  assert.equal(bootstrap.handoff.latestByAgent.opencode.sourceProvenance.sourceAdapter, 'opencode_sqlite');
+  assert.equal(bootstrap.handoff.latestCheckpoints.length, 1);
+  const resume = await app.syncResumeContext({
+    scope: 'repo',
+    scopeKey: 'github.com/example/shared-repo',
+    sessionId: 'opencode:registry-opencode',
+    query: 'multi agent handoff',
+  });
+  assert.equal(resume.handoff.memoryCandidates.items[0].sourceAgent, 'opencode');
+  assert.equal(resume.handoff.memoryCandidates.items[0].sourceProvenance.sourceAdapter, 'opencode_sqlite');
+});
+
+test('Cursor CLI routed ingest matches project names without lossy path decoding', async () => {
+  const dataDir = await makeTempDir();
+  const root = await makeTempDir();
+  const repo = path.join(root, 'repo-with-hyphen');
+  await fs.mkdir(repo, { recursive: true });
+  const cursorProjectsDir = path.join(root, 'cursor');
+  const cursorProjectName = repo
+    .split(path.sep)
+    .filter(Boolean)
+    .join('-');
+  await writeSyntheticCursorTranscript(cursorProjectsDir, 'cursor-hyphen-session', cursorProjectName);
+  const registryPath = path.join(root, 'repos.json');
+  await fs.writeFile(
+    registryPath,
+    JSON.stringify({
+      repos: [
+        {
+          name: 'hyphen-repo',
+          repoPath: repo,
+          scopeKey: 'github.com/example/repo-with-hyphen',
+          adapters: ['cursor_cli'],
+        },
+      ],
+    }),
+  );
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+    },
+    cwd: process.cwd(),
+  });
+
+  const result = await ingestAgentRoutedSessions(app, {
+    adapters: 'cursor_cli',
+    cursorProjectsDir,
+    repoRegistry: registryPath,
+    distill: 'never',
+  });
+
+  assert.equal(result.routedFiles, 1);
+  assert.equal(result.skippedFiles, 0);
+  assert.equal(result.appendedEvents, 2);
+  assert.equal(result.adapterResults[0].fileResults[0].matchedRepo.scopeKey, 'github.com/example/repo-with-hyphen');
+  const events = app.listRawEvents({
+    scope: 'repo',
+    scopeKey: 'github.com/example/repo-with-hyphen',
+    sessionId: 'cursor_cli:cursor-hyphen-session',
+  });
+  assert.equal(events.length, 2);
+});
+
+test('OpenCode adapter rejects ambiguous --file ingest', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+    },
+    cwd: process.cwd(),
+  });
+
+  await assert.rejects(
+    () =>
+      ingestAgentSessions(app, {
+        adapters: 'opencode',
+        file: '/tmp/not-a-session-file',
+        scope: 'repo',
+        scopeKey: 'github.com/example/opencode-file',
+        distill: 'never',
+      }),
+    /--file is not supported for opencode/,
   );
 });
 


### PR DESCRIPTION
## Summary

- add a multi-agent ingest adapter registry with built-in adapters for Codex, Claude Code, OpenCode, Grok, and Cursor CLI
- add `listAgentAdapters`, `ingestAgentSessions`, and `ingestAgentRoutedSessions` CLI surfaces, including an idempotent multi-agent routed watch loop
- expose checkpoint and memory-candidate source provenance, plus `handoff.latestByAgent`, so cross-agent handoff stays distinguishable while repo-scoped retrieval remains shared
- show candidate source agent in the admin audit candidate list
- document cross-agent visibility rules in the English and Korean READMEs

## Scope Notes

This PR completes the extensible adapter-registry and cross-agent handoff visibility work for #128.

Codex and Claude Code still keep their existing production incremental watcher commands. The new multi-agent `--watch` path is a registry-driven supervisor loop that relies on idempotent ingest/dedupe; fully shared byte-cursor incremental watch remains a #75 follow-up.

## Review Follow-up

- replace Cursor CLI's lossy hyphen-to-path cwd reconstruction with repo-registry project-name matching
- document the latest-by-agent ordering assumption, extra handoff fetch window, and partial JSONL trailing-line behavior
- reject ambiguous `--file` ingest for non-file-backed adapters such as OpenCode

## Tests

- `node src/cli.js listAgentAdapters`
- `git diff --check`
- `node --check src/ingest/agents.js && node --check src/cli.js && node --check src/core.js`
- `node --check src/storage/sqlite.js && node --check src/core.js && node --check src/admin-ui/app.js`
- `node --check src/ingest/agents.js && node --check src/core.js && node --check test/core.test.js`
- `node --test test/core.test.js --test-name-pattern "multi-agent routed ingest|Cursor CLI routed ingest|OpenCode adapter"` (150/150 pass; Node test runner executed the full file)
- `npm test` (150/150 pass)

Closes #128
Refs #75
