### PR TITLE
Unify multi-agent routed watch

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -96,6 +96,9 @@ node src/cli.js ingestAgentRoutedSessions \
 `adapters` 필드는 선택 사항이며, 특정 repo가 특정 agent 기록만 받게 좁히고 싶을
 때만 쓴다. 새 agent runtime을 나중에 설치했다면 service를 재시작해서 active set에
 들어오게 하면 된다.
+세션 `cwd`가 등록된 `repoPath` 밖에 있더라도, 예를 들어 PR 리뷰용 임시 checkout인
+경우 router는 해당 checkout의 Git `origin` remote를 읽어 registry `scopeKey`와
+비교한다. path와 Git remote 둘 다 맞지 않는 세션만 unmatched로 건너뛴다.
 
 systemd user service로는 통합 router 하나를 설치하는 것이 기본 권장 형태다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -81,7 +81,6 @@ node src/cli.js listAgentAdapters
 
 ```bash
 node src/cli.js ingestAgentRoutedSessions \
-  --adapters codex,claude_code,opencode,grok,cursor_cli \
   --codexSessionsDir ~/.codex/sessions \
   --claudeCodeProjectsDir ~/.claude/projects \
   --opencodeDb ~/.local/share/opencode/opencode.db \
@@ -89,6 +88,23 @@ node src/cli.js ingestAgentRoutedSessions \
   --cursorProjectsDir ~/.cursor/projects \
   --repoRegistry ~/.config/contextforge/repos.json \
   --sinceMinutes 1440 \
+  --distill auto
+```
+
+`--adapters`를 생략하면 현재 머신에 실제로 있는 adapter store만 자동 감지한다.
+환경마다 설치되지 않은 agent 경로를 따로 비활성화할 필요는 없다. repo registry의
+`adapters` 필드는 선택 사항이며, 특정 repo가 특정 agent 기록만 받게 좁히고 싶을
+때만 쓴다. 새 agent runtime을 나중에 설치했다면 service를 재시작해서 active set에
+들어오게 하면 된다.
+
+systemd user service로는 통합 router 하나를 설치하는 것이 기본 권장 형태다.
+
+```bash
+CONTEXTFORGE_REMOTE_URL=https://memory.example.com \
+scripts/install-agent-router-service.sh \
+  --name all-agents \
+  --repo-registry ~/.config/contextforge/repos.json \
+  --token-env-file ~/.config/contextforge/server.env \
   --distill auto
 ```
 
@@ -103,9 +119,12 @@ node src/cli.js ingestAgentRoutedSessions \
 - memory candidate와 감사 UI도 같은 source provenance를 보여준다. 후보를
   승격하기 전에 어느 agent가 만든 후보인지 확인할 수 있다.
 
-`ingestAgentRoutedSessions --watch`는 registry 기반 supervisor loop로 쓸 수
-있다. 다만 1차 구현은 idempotent 재스캔 방식이고, Codex/Claude 전용 watcher의
-incremental byte cursor 공통화는 별도 후속 작업이다.
+`ingestAgentRoutedSessions --watch`는 기본 단일 router watcher로 쓸 수 있다.
+`--adapters`를 생략하면 각 adapter의 root directory 또는 DB 존재 여부를 보고
+설치된 것만 자동 활성화한다. 없는 런타임은 non-existent tree를 계속 걷지 않고
+`inactiveAdapters`에 남긴다. `--adapters cursor_cli`처럼 명시한 adapter가 없으면
+스캔하지 않고 결과에 `missing_root`로 표시한다. JSONL 기반 adapter는 공통
+incremental byte cursor를 쓰고, OpenCode는 설정된 SQLite DB가 있을 때만 읽는다.
 
 ## 빠른 시작
 

--- a/README.md
+++ b/README.md
@@ -786,11 +786,11 @@ pick it up when complete. When `--repoPath` is set, files whose recorded TUI
 cwd is outside that repo path are skipped so a global sessions directory can be
 watched safely by a repo-specific service.
 
-For machines that use several repositories, prefer one ingest router per agent
-adapter over one watcher per repository. A `codex` router scans the global
-Codex sessions tree once; a `claude_code` router does the same for Claude
-Code's transcript store. Each router matches file metadata such as `cwd`
-against a repo registry and writes to the matched repo's canonical `scopeKey`.
+For machines that use several repositories, prefer one unified ingest router
+over one watcher per repository or per agent. The multi-agent router
+auto-detects installed adapter stores on the machine, skips missing runtimes,
+matches file metadata such as `cwd` against a repo registry, and writes to the
+matched repo's canonical `scopeKey`.
 
 Example repo registry:
 
@@ -801,26 +801,28 @@ Example repo registry:
       "name": "suite",
       "repoPath": "/home/ginis/wastelite-suite",
       "scopeKey": "github.com/ginishuh-dev/wastelite-suite",
-      "adapters": ["codex"]
+      "adapters": ["codex", "claude_code", "opencode", "grok", "cursor_cli"]
     },
     {
       "name": "frontend",
       "repoPath": "/home/ginis/wastelite-suite/wastelite_frontend",
       "scopeKey": "github.com/ginishuh-dev/wastelite_frontend",
-      "adapters": ["codex"]
+      "adapters": ["codex", "claude_code", "cursor_cli"]
     }
   ]
 }
 ```
 
-Run the `codex` agent router once:
+The `adapters` field is optional. Omit it when all installed adapters may route
+to a repo; include it only to narrow which agents can write that repo scope.
+
+Run the unified agent router:
 
 ```bash
 CONTEXTFORGE_STORAGE_MODE=remote \
 CONTEXTFORGE_REMOTE_URL=https://memory.example.com \
 CONTEXTFORGE_REMOTE_TOKEN=change-me \
-node src/cli.js ingestCodexRoutedSessions \
-  --sessionsDir ~/.codex/sessions \
+node src/cli.js ingestAgentRoutedSessions \
   --repoRegistry ~/.config/contextforge/repos.json \
   --sinceMinutes 1440 \
   --distill auto \
@@ -833,31 +835,21 @@ are skipped by default; the router does not silently write unmatched sessions to
 `shared` or `local` memory. Each routed file result logs the matched repo name,
 repo path, and `scopeKey`, or a skipped reason such as `unmatched_repo_cwd`.
 
-Install the `codex` agent router as a systemd user service:
+Install the unified agent router as a systemd user service:
 
 ```bash
 CONTEXTFORGE_REMOTE_URL=https://memory.example.com \
-scripts/install-codex-router-service.sh \
-  --name codex \
-  --repo-registry ~/.config/contextforge/repos.json \
-  --token-env-file ~/.config/contextforge/server.env \
-  --distill auto
-```
-
-Install the `claude_code` agent router as a systemd user service:
-
-```bash
-CONTEXTFORGE_REMOTE_URL=https://memory.example.com \
-scripts/install-claude-code-router-service.sh \
-  --name claude-code \
+scripts/install-agent-router-service.sh \
+  --name all-agents \
   --repo-registry ~/.config/contextforge/repos.json \
   --token-env-file ~/.config/contextforge/server.env \
   --distill auto
 ```
 
 The older repo-specific watcher remains supported for simple single-repo
-setups, but one router per agent adapter is the recommended operating shape for
-suite-style workspaces and other multi-repo environments.
+setups, and the older per-agent router installers remain available for
+compatibility. For suite-style workspaces and mixed agent environments, the
+unified router is the recommended operating shape.
 
 ContextForge also exposes an extensible multi-agent adapter registry. The
 built-in adapter ids are `codex`, `claude_code`, `opencode`, `grok`, and
@@ -889,11 +881,15 @@ node src/cli.js ingestAgentRoutedSessions \
   --distill auto
 ```
 
-`--watch` is supported for the multi-agent command as an idempotent supervisor
-loop. The existing per-agent Codex and Claude Code watchers remain the
-incremental byte-cursor production path; the multi-agent watch loop is the
-compatibility surface for registry-driven supervision until the shared
-incremental runner is fully generalized.
+`--watch` is supported for the multi-agent command as the default unified
+router. When `--adapters` is omitted, the watcher auto-detects installed
+adapters at startup by checking each adapter root or database and skips missing
+runtimes instead of walking non-existent trees. Restart the service after
+installing a new agent runtime so it can join the active set. Explicit
+`--adapters` keeps the requested adapter in the result and reports
+`missing_root` when its store is absent. JSONL-backed adapters use the shared
+incremental byte cursor; OpenCode uses its SQLite store only when the configured
+DB exists.
 
 Cross-agent visibility is intentional: durable repo memory and checkpoint
 handoff are read by `scopeKey`, not by the originating agent. Origin is still

--- a/README.md
+++ b/README.md
@@ -800,14 +800,12 @@ Example repo registry:
     {
       "name": "suite",
       "repoPath": "/home/ginis/wastelite-suite",
-      "scopeKey": "github.com/ginishuh-dev/wastelite-suite",
-      "adapters": ["codex", "claude_code", "opencode", "grok", "cursor_cli"]
+      "scopeKey": "github.com/ginishuh-dev/wastelite-suite"
     },
     {
       "name": "frontend",
       "repoPath": "/home/ginis/wastelite-suite/wastelite_frontend",
-      "scopeKey": "github.com/ginishuh-dev/wastelite_frontend",
-      "adapters": ["codex", "claude_code", "cursor_cli"]
+      "scopeKey": "github.com/ginishuh-dev/wastelite_frontend"
     }
   ]
 }
@@ -815,6 +813,9 @@ Example repo registry:
 
 The `adapters` field is optional. Omit it when all installed adapters may route
 to a repo; include it only to narrow which agents can write that repo scope.
+When a session `cwd` is outside the registered `repoPath`, for example a
+temporary PR review checkout, the router falls back to the checkout's Git
+`origin` remote and matches it against the registry `scopeKey`.
 
 Run the unified agent router:
 
@@ -831,8 +832,9 @@ node src/cli.js ingestAgentRoutedSessions \
 ```
 
 Nested repo paths are matched by most-specific path first. Unknown `cwd` values
-are skipped by default; the router does not silently write unmatched sessions to
-`shared` or `local` memory. Each routed file result logs the matched repo name,
+that cannot be matched by path or Git remote are skipped by default; the router
+does not silently write unmatched sessions to `shared` or `local` memory. Each
+routed file result logs the matched repo name,
 repo path, and `scopeKey`, or a skipped reason such as `unmatched_repo_cwd`.
 
 Install the unified agent router as a systemd user service:

--- a/scripts/install-agent-router-service.sh
+++ b/scripts/install-agent-router-service.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+name="agent-router"
+repo_registry=""
+remote_url="${CONTEXTFORGE_REMOTE_URL:-}"
+token_env_file="${CONTEXTFORGE_TOKEN_ENV_FILE:-$HOME/.config/contextforge/server.env}"
+adapters="${CONTEXTFORGE_AGENT_ROUTER_ADAPTERS:-}"
+codex_sessions_dir="${CONTEXTFORGE_CODEX_SESSIONS_DIR:-$HOME/.codex/sessions}"
+claude_code_projects_dir="${CONTEXTFORGE_CLAUDE_CODE_PROJECTS_DIR:-$HOME/.claude/projects}"
+opencode_db="${CONTEXTFORGE_OPENCODE_DB:-$HOME/.local/share/opencode/opencode.db}"
+grok_sessions_dir="${CONTEXTFORGE_GROK_SESSIONS_DIR:-$HOME/.grok/sessions}"
+cursor_projects_dir="${CONTEXTFORGE_CURSOR_PROJECTS_DIR:-$HOME/.cursor/projects}"
+interval_ms="${CONTEXTFORGE_AGENT_ROUTER_INTERVAL_MS:-30000}"
+since_minutes="${CONTEXTFORGE_AGENT_ROUTER_SINCE_MINUTES:-1440}"
+distill="${CONTEXTFORGE_AGENT_ROUTER_DISTILL:-auto}"
+node_bin="${NODE:-node}"
+
+systemd_quote() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '"%s"' "$value"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --name)
+      name="$2"
+      shift 2
+      ;;
+    --repo-registry|--repoRegistry)
+      repo_registry="$2"
+      shift 2
+      ;;
+    --remote-url)
+      remote_url="$2"
+      shift 2
+      ;;
+    --token-env-file)
+      token_env_file="$2"
+      shift 2
+      ;;
+    --adapters)
+      adapters="$2"
+      shift 2
+      ;;
+    --codex-sessions-dir|--codexSessionsDir)
+      codex_sessions_dir="$2"
+      shift 2
+      ;;
+    --claude-code-projects-dir|--claudeCodeProjectsDir)
+      claude_code_projects_dir="$2"
+      shift 2
+      ;;
+    --opencode-db|--opencodeDb)
+      opencode_db="$2"
+      shift 2
+      ;;
+    --grok-sessions-dir|--grokSessionsDir)
+      grok_sessions_dir="$2"
+      shift 2
+      ;;
+    --cursor-projects-dir|--cursorProjectsDir)
+      cursor_projects_dir="$2"
+      shift 2
+      ;;
+    --interval-ms)
+      interval_ms="$2"
+      shift 2
+      ;;
+    --since-minutes)
+      since_minutes="$2"
+      shift 2
+      ;;
+    --distill)
+      distill="$2"
+      shift 2
+      ;;
+    --node)
+      node_bin="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$repo_registry" ]; then
+  echo "--repo-registry is required." >&2
+  exit 2
+fi
+
+if [ -z "$remote_url" ]; then
+  echo "--remote-url or CONTEXTFORGE_REMOTE_URL is required." >&2
+  exit 2
+fi
+
+safe_name="$(printf '%s' "$name" | tr -c 'A-Za-z0-9_.@-' '-')"
+unit_dir="$HOME/.config/systemd/user"
+unit_name="contextforge-agent-router-${safe_name}.service"
+unit_path="$unit_dir/$unit_name"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cli_path="${repo_root}/src/cli.js"
+
+repo_count="$("$node_bin" --input-type=module -e 'const registry = JSON.parse(await import("node:fs/promises").then((fs) => fs.readFile(process.argv[1], "utf8"))); const repos = Array.isArray(registry) ? registry : registry.repos; if (!Array.isArray(repos)) throw new Error("Repo registry must be a JSON array or an object with a repos array."); console.log(repos.filter((repo) => repo && repo.enabled !== false).length);' "$repo_registry")"
+
+adapter_args=""
+if [ -n "$adapters" ]; then
+  adapter_args=" --adapters $(systemd_quote "$adapters")"
+fi
+
+mkdir -p "$unit_dir"
+
+cat >"$unit_path" <<EOF
+[Unit]
+Description=ContextForge unified agent ingest router (${name})
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$(systemd_quote "$repo_root")
+Environment=CONTEXTFORGE_STORAGE_MODE=remote
+Environment=CONTEXTFORGE_REMOTE_URL=${remote_url}
+Environment=CONTEXTFORGE_WATCH_STATE_DIR=%h/.local/state/contextforge/watch
+EnvironmentFile=-$(systemd_quote "$token_env_file")
+ExecStart=$(systemd_quote "$node_bin") $(systemd_quote "$cli_path") ingestAgentRoutedSessions${adapter_args} --codexSessionsDir $(systemd_quote "$codex_sessions_dir") --claudeCodeProjectsDir $(systemd_quote "$claude_code_projects_dir") --opencodeDb $(systemd_quote "$opencode_db") --grokSessionsDir $(systemd_quote "$grok_sessions_dir") --cursorProjectsDir $(systemd_quote "$cursor_projects_dir") --repoRegistry $(systemd_quote "$repo_registry") --sinceMinutes $(systemd_quote "$since_minutes") --distill $(systemd_quote "$distill") --watch --intervalMs $(systemd_quote "$interval_ms")
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+EOF
+
+echo "Installed unified agent router unit: ${unit_path}"
+echo "Repo registry: ${repo_registry}"
+echo "Enabled repos: ${repo_count}"
+if [ -n "$adapters" ]; then
+  echo "Requested adapters: ${adapters}"
+else
+  echo "Requested adapters: auto-detect installed adapters"
+fi
+
+systemctl --user daemon-reload
+systemctl --user enable --now "$unit_name"
+systemctl --user --no-pager status "$unit_name"

--- a/scripts/install-agent-router-service.sh
+++ b/scripts/install-agent-router-service.sh
@@ -20,6 +20,7 @@ systemd_quote() {
   local value="$1"
   value="${value//\\/\\\\}"
   value="${value//\"/\\\"}"
+  value="${value//\$/\$\$}"
   printf '"%s"' "$value"
 }
 
@@ -123,7 +124,7 @@ After=network-online.target
 Type=simple
 WorkingDirectory=$(systemd_quote "$repo_root")
 Environment=CONTEXTFORGE_STORAGE_MODE=remote
-Environment=CONTEXTFORGE_REMOTE_URL=${remote_url}
+Environment=$(systemd_quote "CONTEXTFORGE_REMOTE_URL=$remote_url")
 Environment=CONTEXTFORGE_WATCH_STATE_DIR=%h/.local/state/contextforge/watch
 EnvironmentFile=-$(systemd_quote "$token_env_file")
 ExecStart=$(systemd_quote "$node_bin") $(systemd_quote "$cli_path") ingestAgentRoutedSessions${adapter_args} --codexSessionsDir $(systemd_quote "$codex_sessions_dir") --claudeCodeProjectsDir $(systemd_quote "$claude_code_projects_dir") --opencodeDb $(systemd_quote "$opencode_db") --grokSessionsDir $(systemd_quote "$grok_sessions_dir") --cursorProjectsDir $(systemd_quote "$cursor_projects_dir") --repoRegistry $(systemd_quote "$repo_registry") --sinceMinutes $(systemd_quote "$since_minutes") --distill $(systemd_quote "$distill") --watch --intervalMs $(systemd_quote "$interval_ms")

--- a/src/ingest/agents.js
+++ b/src/ingest/agents.js
@@ -205,18 +205,20 @@ function cursorProjectNameForRepoPath(repoPath) {
     .join('-');
 }
 
-function matchCursorRepo(unit, parsed, repos) {
+async function matchCursorRepo(unit, parsed, repos, options = {}) {
   const matched = matchRepoForCwd(parsed.cwd, repos);
   if (matched) {
     return matched;
   }
   const projectName = unit.cursorProjectName || (unit.file ? cursorProjectNameFromTranscript(unit.file) : null);
-  if (!projectName) {
-    return null;
+  if (projectName) {
+    const matches = repos.filter((repo) => cursorProjectNameForRepoPath(repo.repoPath) === projectName);
+    matches.sort((a, b) => b.repoPath.length - a.repoPath.length || a.name.localeCompare(b.name));
+    if (matches[0]) {
+      return matches[0];
+    }
   }
-  const matches = repos.filter((repo) => cursorProjectNameForRepoPath(repo.repoPath) === projectName);
-  matches.sort((a, b) => b.repoPath.length - a.repoPath.length || a.name.localeCompare(b.name));
-  return matches[0] || null;
+  return matchRepoForCwdOrGitRemote(parsed.cwd, repos, options);
 }
 
 function normalizeCursorRecord(record, context, options = {}) {
@@ -761,6 +763,9 @@ async function ingestRoutedAdapter(app, adapter, options = {}) {
     checkpointsCreated: results.filter((result) => result.checkpoint).length,
     routedFiles: results.filter((result) => result.matchedRepo).length,
     skippedFiles: results.filter((result) => result.skipped).length,
+    stateLoaded: false,
+    stateUpdated: false,
+    corruptStateFile: null,
     fileResults: results,
   };
 }
@@ -784,7 +789,7 @@ function partialLineWarning(chunk) {
 
 async function ingestParsedRoutedForAdapter(app, adapter, unit, parsed, options, repos) {
   const matchedRepo = adapter.matchRepo
-    ? adapter.matchRepo(unit, parsed, repos)
+    ? await adapter.matchRepo(unit, parsed, repos, options)
     : await matchRepoForCwdOrGitRemote(parsed.cwd, repos, options);
   if (!matchedRepo) {
     return {

--- a/src/ingest/agents.js
+++ b/src/ingest/agents.js
@@ -4,20 +4,26 @@ import path from 'node:path';
 import Database from 'better-sqlite3';
 import {
   addWatchTotals,
+  buildWatchStateDescriptor,
   createInterruptibleSleep,
+  createWatchSummary,
   createWatchTotals,
   discoverFiles,
   ingestParsedSession,
   loadRepoRegistry,
+  loadWatchState,
   matchRepoForCwd,
+  readIncrementalJsonl,
+  saveWatchState,
   shouldSkipOutsideRepo,
   summarizeResults,
   truncate,
 } from './common.js';
-import { discoverClaudeCodeFiles, parseClaudeCodeFile } from './claude_code.js';
-import { discoverCodexRolloutFiles, parseCodexRolloutFile } from './codex.js';
+import { discoverClaudeCodeFiles, parseClaudeCodeFile, parseClaudeCodeLines } from './claude_code.js';
+import { discoverCodexRolloutFiles, parseCodexRolloutFile, parseCodexRolloutLines } from './codex.js';
 
 const DEFAULT_MAX_CONTENT_CHARS = 8000;
+const DEFAULT_WATCH_INTERVAL_MS = 30000;
 
 function stripSessionPrefix(prefix, sessionId) {
   const text = String(sessionId || '');
@@ -45,8 +51,7 @@ function textFromContent(content) {
     .join('\n\n');
 }
 
-function parseJsonLineFile(filePath, text, normalizeRecord, options = {}, initialContext = {}) {
-  const lines = text.split(/\r?\n/);
+function parseJsonLines(filePath, lines, normalizeRecord, options = {}, initialContext = {}) {
   const events = [];
   const warnings = [];
   const context = {
@@ -62,6 +67,14 @@ function parseJsonLineFile(filePath, text, normalizeRecord, options = {}, initia
     try {
       record = JSON.parse(line);
     } catch (error) {
+      if (options.recoverMalformedJsonl) {
+        warnings.push({
+          type: 'malformed_json_line',
+          lineNumber: (initialContext.lineNumber || 0) + index + 1,
+          message: error.message,
+        });
+        continue;
+      }
       // Agent CLIs often append JSONL records while a watcher is reading. Treat
       // only the trailing write window as partial; malformed earlier records
       // still fail loudly.
@@ -83,6 +96,10 @@ function parseJsonLineFile(filePath, text, normalizeRecord, options = {}, initia
   }
 
   return { context, events, warnings };
+}
+
+function parseJsonLineFile(filePath, text, normalizeRecord, options = {}, initialContext = {}) {
+  return parseJsonLines(filePath, text.split(/\r?\n/), normalizeRecord, options, initialContext);
 }
 
 function encodedCwdFromGrokChatHistory(filePath) {
@@ -123,13 +140,26 @@ function normalizeGrokRecord(record, context, options = {}) {
 
 export async function parseGrokChatHistoryFile(filePath, options = {}) {
   const text = await fs.readFile(filePath, 'utf8');
+  const parsed = parseGrokChatHistoryLines(filePath, text.split(/\r?\n/), options);
+  return {
+    nativeSessionId: parsed.nativeSessionId,
+    sessionId: parsed.sessionId,
+    conversationId: parsed.conversationId,
+    cwd: parsed.cwd,
+    events: parsed.events,
+    warnings: parsed.warnings,
+  };
+}
+
+function parseGrokChatHistoryLines(filePath, lines, options = {}, initialContext = {}) {
   const nativeSessionId = path.basename(path.dirname(filePath));
   const sessionId = prefixedSessionId('grok', options.sessionId || nativeSessionId);
-  const parsed = parseJsonLineFile(filePath, text, normalizeGrokRecord, options, {
-    nativeSessionId: stripSessionPrefix('grok', options.sessionId || nativeSessionId),
-    sessionId,
-    conversationId: sessionId,
-    cwd: options.cwd || encodedCwdFromGrokChatHistory(filePath),
+  const parsed = parseJsonLines(filePath, lines, normalizeGrokRecord, options, {
+    nativeSessionId: initialContext.nativeSessionId || stripSessionPrefix('grok', options.sessionId || nativeSessionId),
+    sessionId: initialContext.sessionId || sessionId,
+    conversationId: initialContext.conversationId || sessionId,
+    cwd: initialContext.cwd || options.cwd || encodedCwdFromGrokChatHistory(filePath),
+    lineNumber: initialContext.lineNumber || 0,
   });
   return {
     nativeSessionId: parsed.context.nativeSessionId,
@@ -217,14 +247,28 @@ function normalizeCursorRecord(record, context, options = {}) {
 
 export async function parseCursorTranscriptFile(filePath, options = {}) {
   const text = await fs.readFile(filePath, 'utf8');
+  const parsed = parseCursorTranscriptLines(filePath, text.split(/\r?\n/), options);
+  return {
+    nativeSessionId: parsed.nativeSessionId,
+    sessionId: parsed.sessionId,
+    conversationId: parsed.conversationId,
+    cwd: parsed.cwd,
+    cursorProjectName: parsed.cursorProjectName,
+    events: parsed.events,
+    warnings: parsed.warnings,
+  };
+}
+
+function parseCursorTranscriptLines(filePath, lines, options = {}, initialContext = {}) {
   const nativeSessionId = path.basename(path.dirname(filePath)) || path.basename(filePath, '.jsonl');
   const sessionId = prefixedSessionId('cursor_cli', options.sessionId || nativeSessionId);
-  const parsed = parseJsonLineFile(filePath, text, normalizeCursorRecord, options, {
-    nativeSessionId: stripSessionPrefix('cursor_cli', options.sessionId || nativeSessionId),
-    sessionId,
-    conversationId: sessionId,
-    cwd: cursorProjectCwd(filePath, options),
-    cursorProjectName: cursorProjectNameFromTranscript(filePath),
+  const parsed = parseJsonLines(filePath, lines, normalizeCursorRecord, options, {
+    nativeSessionId: initialContext.nativeSessionId || stripSessionPrefix('cursor_cli', options.sessionId || nativeSessionId),
+    sessionId: initialContext.sessionId || sessionId,
+    conversationId: initialContext.conversationId || sessionId,
+    cwd: initialContext.cwd || cursorProjectCwd(filePath, options),
+    cursorProjectName: initialContext.cursorProjectName || cursorProjectNameFromTranscript(filePath),
+    lineNumber: initialContext.lineNumber || 0,
   });
   return {
     nativeSessionId: parsed.context.nativeSessionId,
@@ -368,6 +412,8 @@ export const AGENT_ADAPTERS = Object.freeze({
     rootPath: (options = {}) => path.resolve(options.codexSessionsDir || options.sessionsDir || path.join(os.homedir(), '.codex', 'sessions')),
     discover: async (options = {}) => (await discoverCodexRolloutFiles({ ...options, sessionsDir: options.codexSessionsDir || options.sessionsDir })).map((file) => ({ file })),
     parse: (unit, options = {}) => parseCodexRolloutFile(unit.file, options),
+    parseLines: (unit, lines, options = {}, initialContext = {}) =>
+      parseCodexRolloutLines(unit.file, lines, options, initialContext),
     missingSessionMessage: 'Codex rollout session id could not be determined.',
   },
   claude_code: {
@@ -381,6 +427,8 @@ export const AGENT_ADAPTERS = Object.freeze({
     discover: async (options = {}) =>
       (await discoverClaudeCodeFiles({ ...options, projectsDir: options.claudeCodeProjectsDir || options.projectsDir || options.sessionsDir })).map((file) => ({ file })),
     parse: (unit, options = {}) => parseClaudeCodeFile(unit.file, options),
+    parseLines: (unit, lines, options = {}, initialContext = {}) =>
+      parseClaudeCodeLines(unit.file, lines, options, initialContext),
     missingSessionMessage: 'Claude Code session id could not be determined.',
   },
   opencode: {
@@ -405,6 +453,8 @@ export const AGENT_ADAPTERS = Object.freeze({
     rootPath: (options = {}) => path.resolve(options.grokSessionsDir || options.sessionsDir || defaultGrokSessionsDir()),
     discover: async (options = {}) => (await discoverGrokChatHistoryFiles(options)).map((file) => ({ file })),
     parse: (unit, options = {}) => parseGrokChatHistoryFile(unit.file, options),
+    parseLines: (unit, lines, options = {}, initialContext = {}) =>
+      parseGrokChatHistoryLines(unit.file, lines, options, initialContext),
     missingSessionMessage: 'Grok session id could not be determined.',
   },
   cursor_cli: {
@@ -421,6 +471,8 @@ export const AGENT_ADAPTERS = Object.freeze({
         cursorProjectName: cursorProjectNameFromTranscript(file),
       })),
     parse: (unit, options = {}) => parseCursorTranscriptFile(unit.file, options),
+    parseLines: (unit, lines, options = {}, initialContext = {}) =>
+      parseCursorTranscriptLines(unit.file, lines, options, initialContext),
     matchRepo: matchCursorRepo,
     missingSessionMessage: 'Cursor CLI session id could not be determined.',
   },
@@ -447,6 +499,139 @@ export function normalizeAgentAdapterIds(value) {
     }
   }
   return ids;
+}
+
+function hasExplicitAdapterSelection(options = {}) {
+  return options.adapters != null || options.adapter != null;
+}
+
+async function inspectAdapterAvailability(adapter, options = {}) {
+  const rootPath = adapter.rootPath(options);
+  if (options.file && adapter.rootSummaryKey !== 'dbPath') {
+    return {
+      adapter: adapter.id,
+      available: true,
+      rootPath,
+      rootSummaryKey: adapter.rootSummaryKey,
+      reason: null,
+    };
+  }
+
+  let stat = null;
+  try {
+    stat = await fs.stat(rootPath);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+    return {
+      adapter: adapter.id,
+      available: false,
+      rootPath,
+      rootSummaryKey: adapter.rootSummaryKey,
+      reason: 'missing_root',
+    };
+  }
+
+  const available = adapter.rootSummaryKey === 'dbPath' ? stat.isFile() : stat.isDirectory();
+  return {
+    adapter: adapter.id,
+    available,
+    rootPath,
+    rootSummaryKey: adapter.rootSummaryKey,
+    reason: available ? null : 'invalid_root_type',
+  };
+}
+
+async function resolveAdapterSelection(options = {}, { autoDetect = false } = {}) {
+  const explicit = hasExplicitAdapterSelection(options);
+  const requestedIds = normalizeAgentAdapterIds(options.adapters || options.adapter);
+  const availability = [];
+  const activeIds = [];
+  const inactiveAdapters = [];
+
+  for (const adapterId of requestedIds) {
+    const adapter = AGENT_ADAPTERS[adapterId];
+    const status = await inspectAdapterAvailability(adapter, options);
+    availability.push(status);
+    if (status.available || explicit || !autoDetect) {
+      activeIds.push(adapterId);
+    } else {
+      inactiveAdapters.push(status);
+    }
+  }
+
+  return {
+    explicit,
+    activeIds,
+    availability,
+    inactiveAdapters,
+  };
+}
+
+function adapterUnavailableResult(adapter, availability, options = {}, { routed = false } = {}) {
+  return {
+    source: routed ? adapter.routerSource : adapter.summarySource,
+    adapter: adapter.id,
+    [adapter.rootSummaryKey]: availability.rootPath || adapter.rootPath(options),
+    filesScanned: 0,
+    filesChanged: 0,
+    parsedEvents: 0,
+    appendedEvents: 0,
+    skippedEvents: 0,
+    checkpointsCreated: 0,
+    routedFiles: 0,
+    skippedFiles: 0,
+    skippedAdapter: true,
+    skippedReason: availability.reason || 'missing_root',
+    fileResults: [],
+  };
+}
+
+function errorSummaryResult(adapter, error, options = {}, { routed = false } = {}) {
+  return {
+    source: routed ? adapter.routerSource : adapter.summarySource,
+    adapter: adapter.id,
+    [adapter.rootSummaryKey]: adapter.rootPath(options),
+    filesScanned: 0,
+    filesChanged: 0,
+    parsedEvents: 0,
+    appendedEvents: 0,
+    skippedEvents: 0,
+    checkpointsCreated: 0,
+    routedFiles: 0,
+    skippedFiles: 1,
+    skippedAdapter: true,
+    skippedReason: 'adapter_error',
+    error: {
+      name: error.name,
+      message: error.message,
+    },
+    fileResults: [],
+  };
+}
+
+function errorUnitResult(adapter, unit, error) {
+  return {
+    source: adapter.source,
+    file: unit.file,
+    dbPath: unit.dbPath,
+    sessionId: null,
+    conversationId: null,
+    parsedEvents: 0,
+    appendedEvents: 0,
+    skippedEvents: 0,
+    warnings: [],
+    skipped: true,
+    skippedReason: 'unit_error',
+    matchedRepo: null,
+    status: null,
+    checkpoint: null,
+    error: {
+      name: error.name,
+      message: error.message,
+    },
+  };
 }
 
 async function ingestParsedForAdapter(app, adapter, unit, parsed, options = {}) {
@@ -501,26 +686,36 @@ function summarizeAdapterResult(adapter, rootPath, results) {
 }
 
 export async function ingestAgentSessions(app, options = {}) {
-  const adapterIds = normalizeAgentAdapterIds(options.adapters || options.adapter);
+  const selection = await resolveAdapterSelection(options, { autoDetect: !hasExplicitAdapterSelection(options) });
   const adapterResults = [];
-  for (const adapterId of adapterIds) {
+  for (const adapterId of selection.activeIds) {
     const adapter = AGENT_ADAPTERS[adapterId];
     if (options.file && adapter.rootSummaryKey !== 'sessionsDir' && adapter.rootSummaryKey !== 'projectsDir') {
       throw new Error(`--file is not supported for ${adapter.id}; use the adapter-specific root option instead.`);
+    }
+    const availability = await inspectAdapterAvailability(adapter, options);
+    if (!availability.available) {
+      adapterResults.push(adapterUnavailableResult(adapter, availability, options));
+      continue;
     }
     const rootPath = adapter.rootPath(options);
     const units = options.file ? [{ file: options.file }] : await adapter.discover(options);
     const results = [];
     for (const unit of units) {
-      const parsed = await adapter.parse(unit, options);
-      results.push(await ingestParsedForAdapter(app, adapter, unit, parsed, options));
+      try {
+        const parsed = await adapter.parse(unit, options);
+        results.push(await ingestParsedForAdapter(app, adapter, unit, parsed, options));
+      } catch (error) {
+        results.push(errorUnitResult(adapter, unit, error));
+      }
     }
     adapterResults.push(summarizeAdapterResult(adapter, rootPath, results));
   }
   const totals = summarizeResults(adapterResults);
   return {
     source: 'agent_sessions',
-    adapters: adapterIds,
+    adapters: selection.activeIds,
+    inactiveAdapters: selection.inactiveAdapters,
     adapterResults,
     ...totals,
     checkpointsCreated: adapterResults.reduce((total, result) => total + result.checkpointsCreated, 0),
@@ -528,6 +723,10 @@ export async function ingestAgentSessions(app, options = {}) {
 }
 
 async function ingestRoutedAdapter(app, adapter, options = {}) {
+  const availability = await inspectAdapterAvailability(adapter, options);
+  if (!availability.available) {
+    return adapterUnavailableResult(adapter, availability, options, { routed: true });
+  }
   const repos = await loadRepoRegistry(options, { adapter: adapter.id, label: adapter.displayName });
   const rootPath = adapter.rootPath(options);
   if (options.file && adapter.rootSummaryKey !== 'sessionsDir' && adapter.rootSummaryKey !== 'projectsDir') {
@@ -536,54 +735,12 @@ async function ingestRoutedAdapter(app, adapter, options = {}) {
   const units = options.file ? [{ file: options.file }] : await adapter.discover(options);
   const results = [];
   for (const unit of units) {
-    const parsed = await adapter.parse(unit, options);
-    const matchedRepo = adapter.matchRepo ? adapter.matchRepo(unit, parsed, repos) : matchRepoForCwd(parsed.cwd, repos);
-    if (!matchedRepo) {
-      results.push({
-        source: adapter.source,
-        file: unit.file,
-        dbPath: unit.dbPath,
-        sessionId: parsed.sessionId,
-        conversationId: parsed.conversationId,
-        parsedEvents: parsed.events.length,
-        appendedEvents: 0,
-        skippedEvents: parsed.events.length,
-        warnings: parsed.warnings,
-        skipped: true,
-        skippedReason: parsed.cwd ? 'unmatched_repo_cwd' : 'missing_cwd',
-        cwd: parsed.cwd,
-        matchedRepo: null,
-        status: null,
-        checkpoint: null,
-      });
-      continue;
+    try {
+      const parsed = await adapter.parse(unit, options);
+      results.push(await ingestParsedRoutedForAdapter(app, adapter, unit, parsed, options, repos));
+    } catch (error) {
+      results.push(errorUnitResult(adapter, unit, error));
     }
-    const result = await ingestParsedSession(
-      app,
-      parsed,
-      {
-        ...options,
-        scope: 'repo',
-        scopeKey: matchedRepo.scopeKey,
-        repoPath: undefined,
-        cwd: undefined,
-      },
-      { missingSessionMessage: adapter.missingSessionMessage },
-    );
-    results.push({
-      source: adapter.source,
-      file: unit.file,
-      dbPath: unit.dbPath,
-      sessionId: parsed.sessionId,
-      conversationId: parsed.conversationId,
-      warnings: parsed.warnings,
-      matchedRepo: {
-        name: matchedRepo.name,
-        repoPath: matchedRepo.repoPath,
-        scopeKey: matchedRepo.scopeKey,
-      },
-      ...result,
-    });
   }
   return {
     source: adapter.routerSource,
@@ -596,6 +753,7 @@ async function ingestRoutedAdapter(app, adapter, options = {}) {
       scopeKey: repo.scopeKey,
     })),
     filesScanned: units.length,
+    filesChanged: results.filter((result) => !result.unchanged).length,
     parsedEvents: results.reduce((total, result) => total + result.parsedEvents, 0),
     appendedEvents: results.reduce((total, result) => total + result.appendedEvents, 0),
     skippedEvents: results.reduce((total, result) => total + result.skippedEvents, 0),
@@ -606,15 +764,265 @@ async function ingestRoutedAdapter(app, adapter, options = {}) {
   };
 }
 
-export async function ingestAgentRoutedSessions(app, options = {}) {
-  const adapterIds = normalizeAgentAdapterIds(options.adapters || options.adapter);
+function incrementalInitialContext(currentEntry, chunk) {
+  return {
+    nativeSessionId: currentEntry.nativeSessionId,
+    sessionId: currentEntry.sessionId,
+    conversationId: currentEntry.conversationId,
+    cwd: currentEntry.cwd,
+    cursorProjectName: currentEntry.cursorProjectName,
+    lineNumber: chunk.reset ? 0 : currentEntry.lineNumber || 0,
+  };
+}
+
+function partialLineWarning(chunk) {
+  return chunk.hasPartialLine
+    ? [{ type: 'partial_json_line', lineNumber: chunk.nextLineNumber + 1, message: 'Incomplete trailing JSONL record.' }]
+    : [];
+}
+
+async function ingestParsedRoutedForAdapter(app, adapter, unit, parsed, options, repos) {
+  const matchedRepo = adapter.matchRepo ? adapter.matchRepo(unit, parsed, repos) : matchRepoForCwd(parsed.cwd, repos);
+  if (!matchedRepo) {
+    return {
+      source: adapter.source,
+      file: unit.file,
+      dbPath: unit.dbPath,
+      sessionId: parsed.sessionId,
+      conversationId: parsed.conversationId,
+      parsedEvents: parsed.events.length,
+      appendedEvents: 0,
+      skippedEvents: parsed.events.length,
+      warnings: parsed.warnings,
+      skipped: true,
+      skippedReason: parsed.cwd ? 'unmatched_repo_cwd' : 'missing_cwd',
+      cwd: parsed.cwd,
+      matchedRepo: null,
+      status: null,
+      checkpoint: null,
+    };
+  }
+
+  const result = await ingestParsedSession(
+    app,
+    parsed,
+    {
+      ...options,
+      scope: 'repo',
+      scopeKey: matchedRepo.scopeKey,
+      repoPath: undefined,
+      cwd: undefined,
+    },
+    { missingSessionMessage: adapter.missingSessionMessage },
+  );
+  return {
+    source: adapter.source,
+    file: unit.file,
+    dbPath: unit.dbPath,
+    sessionId: parsed.sessionId,
+    conversationId: parsed.conversationId,
+    warnings: parsed.warnings,
+    matchedRepo: {
+      name: matchedRepo.name,
+      repoPath: matchedRepo.repoPath,
+      scopeKey: matchedRepo.scopeKey,
+    },
+    ...result,
+  };
+}
+
+async function processIncrementalRoutedAdapterUnit(app, adapter, unit, options, repos, state) {
+  const stateKey = unit.file;
+  const currentEntry = state.entries[stateKey] || {};
+  const chunk = await readIncrementalJsonl(unit.file, currentEntry);
+  if (!chunk.changed) {
+    return {
+      result: {
+        source: adapter.source,
+        file: unit.file,
+        sessionId: currentEntry.sessionId || null,
+        conversationId: currentEntry.conversationId || null,
+        parsedEvents: 0,
+        appendedEvents: 0,
+        skippedEvents: 0,
+        warnings: [],
+        skipped: false,
+        unchanged: true,
+        matchedRepo: currentEntry.matchedRepo || null,
+        checkpoint: null,
+      },
+      stateUpdated: false,
+    };
+  }
+
+  if (chunk.lines.length === 0) {
+    return {
+      result: {
+        source: adapter.source,
+        file: unit.file,
+        sessionId: currentEntry.sessionId || null,
+        conversationId: currentEntry.conversationId || null,
+        parsedEvents: 0,
+        appendedEvents: 0,
+        skippedEvents: 0,
+        warnings: partialLineWarning(chunk),
+        skipped: false,
+        matchedRepo: currentEntry.matchedRepo || null,
+        checkpoint: null,
+      },
+      stateUpdated: false,
+    };
+  }
+
+  const parsed = adapter.parseLines(
+    unit,
+    chunk.lines,
+    { ...options, recoverMalformedJsonl: true },
+    incrementalInitialContext(currentEntry, chunk),
+  );
+  parsed.warnings = [...(parsed.warnings || []), ...partialLineWarning(chunk)];
+  if (!parsed.sessionId) {
+    throw new Error(adapter.missingSessionMessage);
+  }
+  const result = await ingestParsedRoutedForAdapter(app, adapter, unit, parsed, options, repos);
+
+  state.entries[stateKey] = {
+    offset: chunk.nextOffset,
+    lineNumber: chunk.nextLineNumber,
+    sessionId: parsed.sessionId,
+    conversationId: parsed.conversationId,
+    nativeSessionId: parsed.nativeSessionId,
+    cwd: parsed.cwd,
+    cursorProjectName: parsed.cursorProjectName || unit.cursorProjectName || currentEntry.cursorProjectName || null,
+    size: chunk.stat.size,
+    mtimeMs: chunk.stat.mtimeMs,
+    matchedRepo: result.matchedRepo || null,
+    updatedAt: new Date().toISOString(),
+  };
+  return { result, stateUpdated: true };
+}
+
+async function ingestIncrementalRoutedAdapter(app, adapter, options = {}) {
+  const rootPath = adapter.rootPath(options);
+  const availability = await inspectAdapterAvailability(adapter, options);
+  if (!availability.available) {
+    return adapterUnavailableResult(adapter, availability, options, { routed: true });
+  }
+  const repos = await loadRepoRegistry(options, { adapter: adapter.id, label: adapter.displayName });
+  if (repos.length === 0) {
+    return {
+      ...adapterUnavailableResult(
+        adapter,
+        { ...availability, reason: 'no_registered_repos' },
+        options,
+        { routed: true },
+      ),
+      skippedReason: 'no_registered_repos',
+      registry: path.resolve(options.repoRegistry || options.registry || options.repoRegistryFile),
+      repos: [],
+    };
+  }
+
+  if (!adapter.parseLines) {
+    return ingestRoutedAdapter(app, adapter, options);
+  }
+
+  const descriptor = await buildWatchStateDescriptor({
+    adapter: adapter.id,
+    routed: true,
+    rootDir: rootPath,
+    options,
+    registry: repos,
+  });
+  const { state, stateLoaded, corruptFile } = await loadWatchState(descriptor);
+  const units = options.file ? [{ file: options.file }] : await adapter.discover(options);
+  const results = [];
+  let stateUpdated = false;
+
+  for (const unit of units) {
+    try {
+      const processed = await processIncrementalRoutedAdapterUnit(app, adapter, unit, options, repos, state);
+      results.push(processed.result);
+      stateUpdated = stateUpdated || processed.stateUpdated;
+    } catch (error) {
+      results.push(errorUnitResult(adapter, unit, error));
+    }
+  }
+  if (stateUpdated) {
+    await saveWatchState(descriptor, state);
+  }
+
+  return {
+    source: adapter.routerSource,
+    adapter: adapter.id,
+    [adapter.rootSummaryKey]: rootPath,
+    registry: path.resolve(options.repoRegistry || options.registry || options.repoRegistryFile),
+    repos: repos.map((repo) => ({
+      name: repo.name,
+      repoPath: repo.repoPath,
+      scopeKey: repo.scopeKey,
+    })),
+    filesScanned: units.length,
+    filesChanged: results.filter((result) => !result.unchanged).length,
+    parsedEvents: results.reduce((total, result) => total + result.parsedEvents, 0),
+    appendedEvents: results.reduce((total, result) => total + result.appendedEvents, 0),
+    skippedEvents: results.reduce((total, result) => total + result.skippedEvents, 0),
+    checkpointsCreated: results.filter((result) => result.checkpoint).length,
+    routedFiles: results.filter((result) => result.matchedRepo).length,
+    skippedFiles: results.filter((result) => result.skipped).length,
+    stateFile: descriptor.stateFile,
+    stateLoaded,
+    stateUpdated,
+    corruptStateFile: corruptFile,
+    fileResults: results,
+  };
+}
+
+export async function ingestAgentRoutedSessionsIncremental(app, options = {}) {
+  const selection =
+    options.resolvedAdapterSelection ||
+    (await resolveAdapterSelection(options, { autoDetect: !hasExplicitAdapterSelection(options) }));
   const adapterResults = [];
-  for (const adapterId of adapterIds) {
-    adapterResults.push(await ingestRoutedAdapter(app, AGENT_ADAPTERS[adapterId], options));
+  for (const adapterId of selection.activeIds) {
+    const adapter = AGENT_ADAPTERS[adapterId];
+    try {
+      adapterResults.push(await ingestIncrementalRoutedAdapter(app, adapter, options));
+    } catch (error) {
+      adapterResults.push(errorSummaryResult(adapter, error, options, { routed: true }));
+    }
   }
   return {
     source: 'agent_sessions_router',
-    adapters: adapterIds,
+    adapters: selection.activeIds,
+    inactiveAdapters: selection.inactiveAdapters,
+    registry: path.resolve(options.repoRegistry || options.registry || options.repoRegistryFile),
+    adapterResults,
+    filesScanned: adapterResults.reduce((total, result) => total + result.filesScanned, 0),
+    filesChanged: adapterResults.reduce((total, result) => total + (result.filesChanged || 0), 0),
+    parsedEvents: adapterResults.reduce((total, result) => total + result.parsedEvents, 0),
+    appendedEvents: adapterResults.reduce((total, result) => total + result.appendedEvents, 0),
+    skippedEvents: adapterResults.reduce((total, result) => total + result.skippedEvents, 0),
+    checkpointsCreated: adapterResults.reduce((total, result) => total + result.checkpointsCreated, 0),
+    routedFiles: adapterResults.reduce((total, result) => total + result.routedFiles, 0),
+    skippedFiles: adapterResults.reduce((total, result) => total + result.skippedFiles, 0),
+  };
+}
+
+export async function ingestAgentRoutedSessions(app, options = {}) {
+  const selection = await resolveAdapterSelection(options, { autoDetect: !hasExplicitAdapterSelection(options) });
+  const adapterResults = [];
+  for (const adapterId of selection.activeIds) {
+    const adapter = AGENT_ADAPTERS[adapterId];
+    try {
+      adapterResults.push(await ingestRoutedAdapter(app, adapter, options));
+    } catch (error) {
+      adapterResults.push(errorSummaryResult(adapter, error, options, { routed: true }));
+    }
+  }
+  return {
+    source: 'agent_sessions_router',
+    adapters: selection.activeIds,
+    inactiveAdapters: selection.inactiveAdapters,
     registry: path.resolve(options.repoRegistry || options.registry || options.repoRegistryFile),
     adapterResults,
     filesScanned: adapterResults.reduce((total, result) => total + result.filesScanned, 0),
@@ -628,11 +1036,22 @@ export async function ingestAgentRoutedSessions(app, options = {}) {
 }
 
 export async function watchAgentRoutedSessions(app, options = {}) {
-  const intervalMs = options.intervalMs == null ? 30000 : Math.max(0, Number(options.intervalMs));
+  const intervalMs = options.intervalMs == null ? DEFAULT_WATCH_INTERVAL_MS : Math.max(0, Number(options.intervalMs));
   const maxIterations = options.iterations == null ? null : Math.max(0, Number(options.iterations));
   const startedAt = new Date().toISOString();
   const results = [];
   const totals = createWatchTotals();
+  const resolvedAdapterSelection = options.watchFullScan
+    ? null
+    : await resolveAdapterSelection(options, { autoDetect: !hasExplicitAdapterSelection(options) });
+  const iterationOptions = resolvedAdapterSelection
+    ? {
+        ...options,
+        adapters: resolvedAdapterSelection.activeIds,
+        resolvedAdapterSelection,
+      }
+    : options;
+  let lastIterationResult = null;
   let iterations = 0;
   let stopped = false;
   const sleeper = createInterruptibleSleep();
@@ -648,17 +1067,28 @@ export async function watchAgentRoutedSessions(app, options = {}) {
   try {
     while (!stopped && (maxIterations == null || iterations < maxIterations)) {
       iterations += 1;
-      const result = await ingestAgentRoutedSessions(app, options);
-      const iterationResult = {
-        ...result,
-        source: 'agent_sessions_router_watch_iteration',
-        iteration: iterations,
-        intervalMs,
-        watchedAt: new Date().toISOString(),
-      };
+      const result = options.watchFullScan
+        ? await ingestAgentRoutedSessions(app, iterationOptions)
+        : await ingestAgentRoutedSessionsIncremental(app, iterationOptions);
+      const iterationResult = createWatchSummary(
+        {
+          ...result,
+          source: 'agent_sessions_router_watch_iteration',
+          iteration: iterations,
+          intervalMs,
+          watchedAt: new Date().toISOString(),
+        },
+        options,
+      );
+      iterationResult.adapters = result.adapters;
+      iterationResult.inactiveAdapters = result.inactiveAdapters || [];
+      if (options.watchVerbose) {
+        iterationResult.adapterResults = result.adapterResults;
+      }
+      lastIterationResult = iterationResult;
       addWatchTotals(totals, iterationResult);
       if (maxIterations != null) {
-        results.push(options.watchVerbose ? iterationResult : { ...iterationResult, adapterResults: undefined });
+        results.push(iterationResult);
       }
       if (options.onResult) {
         await options.onResult(iterationResult);
@@ -674,7 +1104,8 @@ export async function watchAgentRoutedSessions(app, options = {}) {
 
   return {
     source: 'agent_sessions_router_watch',
-    adapters: normalizeAgentAdapterIds(options.adapters || options.adapter),
+    adapters: lastIterationResult?.adapters || resolvedAdapterSelection?.activeIds || normalizeAgentAdapterIds(options.adapters || options.adapter),
+    inactiveAdapters: lastIterationResult?.inactiveAdapters || resolvedAdapterSelection?.inactiveAdapters || [],
     intervalMs,
     iterations,
     stopped,

--- a/src/ingest/agents.js
+++ b/src/ingest/agents.js
@@ -13,6 +13,7 @@ import {
   loadRepoRegistry,
   loadWatchState,
   matchRepoForCwd,
+  matchRepoForCwdOrGitRemote,
   readIncrementalJsonl,
   saveWatchState,
   shouldSkipOutsideRepo,
@@ -782,7 +783,9 @@ function partialLineWarning(chunk) {
 }
 
 async function ingestParsedRoutedForAdapter(app, adapter, unit, parsed, options, repos) {
-  const matchedRepo = adapter.matchRepo ? adapter.matchRepo(unit, parsed, repos) : matchRepoForCwd(parsed.cwd, repos);
+  const matchedRepo = adapter.matchRepo
+    ? adapter.matchRepo(unit, parsed, repos)
+    : await matchRepoForCwdOrGitRemote(parsed.cwd, repos, options);
   if (!matchedRepo) {
     return {
       source: adapter.source,

--- a/src/ingest/claude_code.js
+++ b/src/ingest/claude_code.js
@@ -102,7 +102,7 @@ export function normalizeClaudeCodeRecord(record, context, options = {}) {
   };
 }
 
-function parseClaudeCodeLines(filePath, lines, options = {}, initialContext = {}) {
+export function parseClaudeCodeLines(filePath, lines, options = {}, initialContext = {}) {
   const nativeSessionId =
     initialContext.nativeSessionId ||
     (options.sessionId ? stripClaudeCodeSessionPrefix(options.sessionId) : null);
@@ -123,7 +123,20 @@ function parseClaudeCodeLines(filePath, lines, options = {}, initialContext = {}
   for (const line of lines) {
     context.lineNumber += 1;
     if (!line.trim()) continue;
-    const record = JSON.parse(line);
+    let record;
+    try {
+      record = JSON.parse(line);
+    } catch (error) {
+      if (!options.recoverMalformedJsonl) {
+        throw error;
+      }
+      warnings.push({
+        type: 'malformed_json_line',
+        lineNumber: context.lineNumber,
+        message: error.message,
+      });
+      continue;
+    }
     const event = normalizeClaudeCodeRecord(record, context, options);
     if (event) {
       events.push(event);

--- a/src/ingest/claude_code.js
+++ b/src/ingest/claude_code.js
@@ -11,7 +11,7 @@ import {
   ingestParsedSession,
   loadRepoRegistry,
   loadWatchState,
-  matchRepoForCwd,
+  matchRepoForCwdOrGitRemote,
   readIncrementalJsonl,
   saveWatchState,
   shouldSkipOutsideRepo,
@@ -269,7 +269,7 @@ export async function ingestClaudeCodeRoutedSessions(app, options = {}) {
 
   for (const file of files) {
     const parsed = await parseClaudeCodeFile(file, options);
-    const matchedRepo = matchRepoForCwd(parsed.cwd, repos);
+    const matchedRepo = await matchRepoForCwdOrGitRemote(parsed.cwd, repos, options);
     if (!matchedRepo) {
       results.push({
         source: 'claude_code_jsonl',
@@ -521,7 +521,7 @@ async function processIncrementalRoutedClaudeCodeFile(app, file, options, repos,
           lineNumber: currentEntry.lineNumber || 0,
         },
   );
-  const matchedRepo = matchRepoForCwd(parsed.cwd, repos);
+  const matchedRepo = await matchRepoForCwdOrGitRemote(parsed.cwd, repos, options);
   let result;
   if (!matchedRepo) {
     result = {

--- a/src/ingest/claude_code.js
+++ b/src/ingest/claude_code.js
@@ -27,6 +27,16 @@ const CLAUDE_CODE_PROVENANCE = {
   sourceAdapter: 'claude_code_jsonl',
 };
 
+function incrementalClaudeCodeInitialContext(currentEntry = {}, chunk) {
+  return {
+    nativeSessionId: currentEntry.nativeSessionId,
+    sessionId: currentEntry.sessionId,
+    conversationId: currentEntry.conversationId,
+    cwd: currentEntry.cwd,
+    lineNumber: chunk.reset ? 0 : currentEntry.lineNumber || 0,
+  };
+}
+
 function stripClaudeCodeSessionPrefix(sessionId) {
   const text = String(sessionId || '');
   return text.startsWith('claude_code:') ? text.slice('claude_code:'.length) : text;
@@ -375,16 +385,8 @@ async function processIncrementalClaudeCodeFile(app, file, options, state) {
   const parsed = parseClaudeCodeLines(
     file,
     chunk.lines,
-    options,
-    chunk.reset
-      ? { lineNumber: 0 }
-      : {
-          nativeSessionId: currentEntry.nativeSessionId,
-          sessionId: currentEntry.sessionId,
-          conversationId: currentEntry.conversationId,
-          cwd: currentEntry.cwd,
-          lineNumber: currentEntry.lineNumber || 0,
-        },
+    { ...options, recoverMalformedJsonl: true },
+    incrementalClaudeCodeInitialContext(currentEntry, chunk),
   );
   if (!parsed.sessionId) {
     throw new Error('Claude Code session id could not be determined.');
@@ -510,16 +512,8 @@ async function processIncrementalRoutedClaudeCodeFile(app, file, options, repos,
   const parsed = parseClaudeCodeLines(
     file,
     chunk.lines,
-    options,
-    chunk.reset
-      ? { lineNumber: 0 }
-      : {
-          nativeSessionId: currentEntry.nativeSessionId,
-          sessionId: currentEntry.sessionId,
-          conversationId: currentEntry.conversationId,
-          cwd: currentEntry.cwd,
-          lineNumber: currentEntry.lineNumber || 0,
-        },
+    { ...options, recoverMalformedJsonl: true },
+    incrementalClaudeCodeInitialContext(currentEntry, chunk),
   );
   const matchedRepo = await matchRepoForCwdOrGitRemote(parsed.cwd, repos, options);
   let result;

--- a/src/ingest/codex.js
+++ b/src/ingest/codex.js
@@ -27,6 +27,16 @@ const CODEX_AGENT_PROVENANCE = {
   sourceAdapter: 'codex_rollout_jsonl',
 };
 
+function incrementalCodexInitialContext(currentEntry = {}, chunk) {
+  return {
+    nativeSessionId: currentEntry.nativeSessionId,
+    sessionId: currentEntry.sessionId,
+    conversationId: currentEntry.conversationId,
+    cwd: currentEntry.cwd,
+    lineNumber: chunk.reset ? 0 : currentEntry.lineNumber || 0,
+  };
+}
+
 function stripCodexSessionPrefix(sessionId) {
   const text = String(sessionId || '');
   return text.startsWith('codex:') ? text.slice('codex:'.length) : text;
@@ -378,16 +388,8 @@ async function processIncrementalCodexFile(app, file, options, state) {
   const parsed = parseCodexRolloutLines(
     file,
     chunk.lines,
-    options,
-    chunk.reset
-      ? { lineNumber: 0 }
-      : {
-          nativeSessionId: currentEntry.nativeSessionId,
-          sessionId: currentEntry.sessionId,
-          conversationId: currentEntry.conversationId,
-          cwd: currentEntry.cwd,
-          lineNumber: currentEntry.lineNumber || 0,
-        },
+    { ...options, recoverMalformedJsonl: true },
+    incrementalCodexInitialContext(currentEntry, chunk),
   );
 
   if (!parsed.sessionId) {
@@ -518,16 +520,8 @@ async function processIncrementalRoutedCodexFile(app, file, options, repos, stat
   const parsed = parseCodexRolloutLines(
     file,
     chunk.lines,
-    options,
-    chunk.reset
-      ? { lineNumber: 0 }
-      : {
-          nativeSessionId: currentEntry.nativeSessionId,
-          sessionId: currentEntry.sessionId,
-          conversationId: currentEntry.conversationId,
-          cwd: currentEntry.cwd,
-          lineNumber: currentEntry.lineNumber || 0,
-        },
+    { ...options, recoverMalformedJsonl: true },
+    incrementalCodexInitialContext(currentEntry, chunk),
   );
   const matchedRepo = await matchRepoForCwdOrGitRemote(parsed.cwd, repos, options);
   let result;

--- a/src/ingest/codex.js
+++ b/src/ingest/codex.js
@@ -101,7 +101,7 @@ export function normalizeCodexRolloutRecord(record, context, options = {}) {
   };
 }
 
-function parseCodexRolloutLines(filePath, lines, options = {}, initialContext = {}) {
+export function parseCodexRolloutLines(filePath, lines, options = {}, initialContext = {}) {
   const nativeSessionId =
     initialContext.nativeSessionId || (options.sessionId ? stripCodexSessionPrefix(options.sessionId) : null);
   const sessionId = initialContext.sessionId || (nativeSessionId ? codexSessionId(nativeSessionId) : null);
@@ -120,7 +120,20 @@ function parseCodexRolloutLines(filePath, lines, options = {}, initialContext = 
   for (const line of lines) {
     context.lineNumber += 1;
     if (!line.trim()) continue;
-    const record = JSON.parse(line);
+    let record;
+    try {
+      record = JSON.parse(line);
+    } catch (error) {
+      if (!options.recoverMalformedJsonl) {
+        throw error;
+      }
+      warnings.push({
+        type: 'malformed_json_line',
+        lineNumber: context.lineNumber,
+        message: error.message,
+      });
+      continue;
+    }
     const event = normalizeCodexRolloutRecord(record, context, options);
     if (event) {
       events.push(event);

--- a/src/ingest/codex.js
+++ b/src/ingest/codex.js
@@ -11,7 +11,7 @@ import {
   ingestParsedSession,
   loadRepoRegistry,
   loadWatchState,
-  matchRepoForCwd,
+  matchRepoForCwdOrGitRemote,
   readIncrementalJsonl,
   saveWatchState,
   shouldSkipOutsideRepo,
@@ -270,7 +270,7 @@ export async function ingestCodexRoutedSessions(app, options = {}) {
 
   for (const file of files) {
     const parsed = await parseCodexRolloutFile(file, options);
-    const matchedRepo = matchRepoForCwd(parsed.cwd, repos);
+    const matchedRepo = await matchRepoForCwdOrGitRemote(parsed.cwd, repos, options);
     if (!matchedRepo) {
       results.push({
         source: 'codex_rollout_jsonl',
@@ -529,7 +529,7 @@ async function processIncrementalRoutedCodexFile(app, file, options, repos, stat
           lineNumber: currentEntry.lineNumber || 0,
         },
   );
-  const matchedRepo = matchRepoForCwd(parsed.cwd, repos);
+  const matchedRepo = await matchRepoForCwdOrGitRemote(parsed.cwd, repos, options);
   let result;
   if (!matchedRepo) {
     result = {

--- a/src/ingest/common.js
+++ b/src/ingest/common.js
@@ -1,7 +1,11 @@
 import fs from 'node:fs/promises';
+import { execFile } from 'node:child_process';
 import crypto from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
 
 export function isPathWithin(parentPath, childPath) {
   const parent = path.resolve(parentPath);
@@ -63,6 +67,70 @@ export function matchRepoForCwd(cwd, repos) {
     return null;
   }
   const matches = repos.filter((repo) => isPathWithin(repo.repoPath, cwd));
+  matches.sort((a, b) => b.repoPath.length - a.repoPath.length || a.name.localeCompare(b.name));
+  return matches[0] || null;
+}
+
+export function normalizeRepoIdentity(value) {
+  if (!value) {
+    return null;
+  }
+  let text = String(value).trim();
+  if (!text) {
+    return null;
+  }
+
+  try {
+    const url = new URL(text);
+    text = `${url.hostname}${url.pathname}`;
+  } catch {
+    const scpLike = text.match(/^(?:[^@\s]+@)?([^:\s]+):(.+)$/);
+    if (scpLike) {
+      text = `${scpLike[1]}/${scpLike[2]}`;
+    } else {
+      text = text.replace(/^(?:https?:\/\/|git:\/\/)([^/]+)\//i, '$1/');
+      text = text.replace(/^ssh:\/\/(?:[^@/]+@)?([^/]+)\//i, '$1/');
+    }
+  }
+
+  text = text.replace(/^\/+/, '').replace(/\/+$/, '');
+  text = text.replace(/\.git$/i, '');
+  const parts = text.split('/').filter(Boolean);
+  if (parts.length < 3 || !parts[0].includes('.')) {
+    return null;
+  }
+  return parts.slice(0, 3).join('/').toLowerCase();
+}
+
+export async function gitRemoteRepoIdentity(cwd, options = {}) {
+  if (!cwd) {
+    return null;
+  }
+  try {
+    const { stdout } = await execFileAsync(
+      options.gitBin || 'git',
+      ['-C', cwd, 'remote', 'get-url', options.remoteName || 'origin'],
+      {
+        timeout: Number(options.gitRemoteTimeoutMs || 1500),
+        maxBuffer: 64 * 1024,
+      },
+    );
+    return normalizeRepoIdentity(stdout);
+  } catch {
+    return null;
+  }
+}
+
+export async function matchRepoForCwdOrGitRemote(cwd, repos, options = {}) {
+  const pathMatch = matchRepoForCwd(cwd, repos);
+  if (pathMatch) {
+    return pathMatch;
+  }
+  const remoteIdentity = await gitRemoteRepoIdentity(cwd, options);
+  if (!remoteIdentity) {
+    return null;
+  }
+  const matches = repos.filter((repo) => normalizeRepoIdentity(repo.scopeKey) === remoteIdentity);
   matches.sort((a, b) => b.repoPath.length - a.repoPath.length || a.name.localeCompare(b.name));
   return matches[0] || null;
 }

--- a/src/ingest/common.js
+++ b/src/ingest/common.js
@@ -99,7 +99,7 @@ export function normalizeRepoIdentity(value) {
   if (parts.length < 3 || !parts[0].includes('.')) {
     return null;
   }
-  return parts.slice(0, 3).join('/').toLowerCase();
+  return parts.join('/').toLowerCase();
 }
 
 export async function gitRemoteRepoIdentity(cwd, options = {}) {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -2417,6 +2417,32 @@ test('Codex incremental watch keeps trailing partial JSON uncommitted until comp
   });
   assert.equal(events.length, 3);
   assert.equal(events.at(-1).content, 'partial append');
+
+  await fs.appendFile(file, '{"malformed":\n');
+  await appendSyntheticCodexAssistantMessage(file, 'Recovered after a malformed complete JSONL line.');
+  const third = await watchCodexSessions(app, {
+    sessionsDir,
+    scope: 'repo',
+    scopeKey: 'codex-partial-repo',
+    distill: 'never',
+    iterations: 1,
+    intervalMs: 1,
+    watchStateDir,
+    watchVerbose: true,
+  });
+  assert.equal(third.totals.appendedEvents, 1);
+  assert.equal(
+    third.results[0].fileResults[0].warnings.some((warning) => warning.type === 'malformed_json_line'),
+    true,
+  );
+
+  const recoveredEvents = app.listRawEvents({
+    scope: 'repo',
+    scopeKey: 'codex-partial-repo',
+    sessionId: 'codex:codex-partial-session',
+  });
+  assert.equal(recoveredEvents.length, 4);
+  assert.equal(recoveredEvents.at(-1).content, 'Recovered after a malformed complete JSONL line.');
 });
 
 test('CLI Codex sessions scan is not capped by search limit defaults', async () => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -18,7 +18,7 @@ import { createOpenAiEmbeddingProvider } from '../src/embeddings/index.js';
 import { createInterruptibleSleep, shouldSkipRecentFailedAutoDistill } from '../src/ingest/common.js';
 import { watchClaudeCodeSessions } from '../src/ingest/claude_code.js';
 import { ingestCodexRolloutFile, watchCodexSessions } from '../src/ingest/codex.js';
-import { ingestAgentRoutedSessions, ingestAgentSessions, listAgentAdapters } from '../src/ingest/agents.js';
+import { ingestAgentRoutedSessions, ingestAgentSessions, listAgentAdapters, watchAgentRoutedSessions } from '../src/ingest/agents.js';
 import { searchMemories } from '../src/retrieval/search.js';
 import { REMOTE_METHODS } from '../src/remote/client.js';
 import { startContextForgeServer } from '../src/server.js';
@@ -1800,6 +1800,81 @@ test('Claude Code router service installer creates an agent-level router unit', 
   assert.doesNotMatch(unit, /--repoPath/);
 });
 
+test('unified agent router service installer creates one auto-detecting router unit', async () => {
+  const homeRoot = await makeTempDir();
+  const home = path.join(homeRoot, 'home with spaces');
+  await fs.mkdir(home, { recursive: true });
+  const registryPath = path.join(home, 'repos.json');
+  const fakeBin = path.join(home, 'bin');
+  const systemctlLog = path.join(home, 'systemctl.log');
+  await fs.mkdir(fakeBin, { recursive: true });
+  await fs.writeFile(
+    registryPath,
+    JSON.stringify({
+      repos: [
+        {
+          name: 'repo-a',
+          repoPath: '/work/repo-a',
+          scopeKey: 'github.com/example/repo-a',
+        },
+        {
+          name: 'repo-b',
+          repoPath: '/work/repo-b',
+          scopeKey: 'github.com/example/repo-b',
+          adapters: ['cursor_cli'],
+        },
+      ],
+    }),
+  );
+  await fs.writeFile(
+    path.join(fakeBin, 'systemctl'),
+    `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> ${JSON.stringify(systemctlLog)}\n`,
+    { mode: 0o755 },
+  );
+
+  const result = await execFileAsync(
+    'bash',
+    [
+      'scripts/install-agent-router-service.sh',
+      '--name',
+      'all-agents',
+      '--repo-registry',
+      registryPath,
+      '--remote-url',
+      'https://memory.example.com',
+      '--token-env-file',
+      path.join(home, 'token.env'),
+      '--distill',
+      'false',
+    ],
+    {
+      env: {
+        ...process.env,
+        HOME: home,
+        PATH: `${fakeBin}:${process.env.PATH}`,
+      },
+    },
+  );
+
+  const unit = await fs.readFile(
+    path.join(home, '.config', 'systemd', 'user', 'contextforge-agent-router-all-agents.service'),
+    'utf8',
+  );
+  assert.match(result.stdout, /Installed unified agent router unit:/);
+  assert.match(result.stdout, /Enabled repos: 2/);
+  assert.match(result.stdout, /Requested adapters: auto-detect installed adapters/);
+  assert.match(unit, /ingestAgentRoutedSessions/);
+  assert.doesNotMatch(unit, /--adapters/);
+  assert.match(unit, /WorkingDirectory="/);
+  assert.match(unit, /--codexSessionsDir/);
+  assert.match(unit, /--claudeCodeProjectsDir/);
+  assert.match(unit, /--opencodeDb/);
+  assert.match(unit, /--grokSessionsDir/);
+  assert.match(unit, /--cursorProjectsDir/);
+  assert.match(unit, /Environment=CONTEXTFORGE_WATCH_STATE_DIR=%h\/\.local\/state\/contextforge\/watch/);
+  assert.match(unit, new RegExp(`--repoRegistry "${registryPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
+});
+
 test('CLI reports invalid metadata JSON clearly', async () => {
   const dataDir = await makeTempDir();
   const env = { ...process.env, CONTEXTFORGE_DATA_DIR: dataDir };
@@ -2922,6 +2997,50 @@ test('Cursor CLI routed ingest matches project names without lossy path decoding
   assert.equal(events.length, 2);
 });
 
+test('multi-agent routed ingest auto-detects installed adapters for one-shot scans', async () => {
+  const dataDir = await makeTempDir();
+  const root = await makeTempDir();
+  const repo = await makeTempDir();
+  const codexSessionsDir = path.join(root, 'codex');
+  const rolloutDir = path.join(codexSessionsDir, '2026', '06', '04');
+  await fs.mkdir(rolloutDir, { recursive: true });
+  await writeSyntheticCodexRollout(path.join(rolloutDir, 'rollout-one-shot.jsonl'), 'one-shot-codex', repo);
+  const registryPath = path.join(root, 'repos.json');
+  await fs.writeFile(
+    registryPath,
+    JSON.stringify({
+      repos: [
+        {
+          name: 'one-shot-repo',
+          repoPath: repo,
+          scopeKey: 'github.com/example/one-shot-repo',
+        },
+      ],
+    }),
+  );
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+    },
+    cwd: process.cwd(),
+  });
+
+  const result = await ingestAgentRoutedSessions(app, {
+    codexSessionsDir,
+    claudeCodeProjectsDir: path.join(root, 'missing-claude'),
+    grokSessionsDir: path.join(root, 'missing-grok'),
+    cursorProjectsDir: path.join(root, 'missing-cursor'),
+    opencodeDb: path.join(root, 'missing-opencode', 'opencode.db'),
+    repoRegistry: registryPath,
+    distill: 'never',
+  });
+
+  assert.deepEqual(result.adapters, ['codex']);
+  assert.equal(result.inactiveAdapters.length, 4);
+  assert.equal(result.filesScanned, 1);
+  assert.equal(result.appendedEvents, 2);
+});
+
 test('OpenCode adapter rejects ambiguous --file ingest', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({
@@ -2942,6 +3061,229 @@ test('OpenCode adapter rejects ambiguous --file ingest', async () => {
       }),
     /--file is not supported for opencode/,
   );
+});
+
+test('multi-agent routed watch isolates bad units and continues ingesting good files', async () => {
+  const dataDir = await makeTempDir();
+  const root = await makeTempDir();
+  const repo = await makeTempDir();
+  const watchStateDir = await makeTempDir();
+  const codexSessionsDir = path.join(root, 'codex');
+  const rolloutDir = path.join(codexSessionsDir, '2026', '06', '04');
+  await fs.mkdir(rolloutDir, { recursive: true });
+  await writeSyntheticCodexRollout(path.join(rolloutDir, 'rollout-good.jsonl'), 'isolated-good-codex', repo);
+  await fs.writeFile(
+    path.join(rolloutDir, 'rollout-bad.jsonl'),
+    `${JSON.stringify({
+      timestamp: '2026-04-25T00:00:02.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'This file has no session metadata.' }],
+      },
+    })}\n`,
+  );
+  const registryPath = path.join(root, 'repos.json');
+  await fs.writeFile(
+    registryPath,
+    JSON.stringify({
+      repos: [
+        {
+          name: 'watch-repo',
+          repoPath: repo,
+          scopeKey: 'github.com/example/isolated-watch-repo',
+        },
+      ],
+    }),
+  );
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+    },
+    cwd: process.cwd(),
+  });
+
+  const result = await watchAgentRoutedSessions(app, {
+    adapters: 'codex',
+    codexSessionsDir,
+    repoRegistry: registryPath,
+    watchStateDir,
+    distill: 'never',
+    iterations: 1,
+    intervalMs: 1,
+    watchVerbose: true,
+  });
+
+  assert.equal(result.totals.filesScanned, 2);
+  assert.equal(result.totals.appendedEvents, 2);
+  const fileResults = result.results[0].adapterResults[0].fileResults;
+  assert.equal(fileResults.some((fileResult) => fileResult.skippedReason === 'unit_error'), true);
+  const events = app.listRawEvents({
+    scope: 'repo',
+    scopeKey: 'github.com/example/isolated-watch-repo',
+    sessionId: 'codex:isolated-good-codex',
+  });
+  assert.equal(events.length, 2);
+});
+
+test('multi-agent routed watch auto-detects installed adapters and uses incremental state', async () => {
+  const dataDir = await makeTempDir();
+  const root = await makeTempDir();
+  const repo = await makeTempDir();
+  const watchStateDir = await makeTempDir();
+  const codexSessionsDir = path.join(root, 'codex');
+  const missingClaudeCodeProjectsDir = path.join(root, 'missing-claude');
+  const missingGrokSessionsDir = path.join(root, 'missing-grok');
+  const missingCursorProjectsDir = path.join(root, 'missing-cursor');
+  const missingOpenCodeDb = path.join(root, 'missing-opencode', 'opencode.db');
+  const rolloutDir = path.join(codexSessionsDir, '2026', '06', '04');
+  const rolloutFile = path.join(rolloutDir, 'rollout-unified-watch.jsonl');
+  await fs.mkdir(rolloutDir, { recursive: true });
+  await writeSyntheticCodexRollout(rolloutFile, 'unified-watch-codex', repo);
+
+  const registryPath = path.join(root, 'repos.json');
+  await fs.writeFile(
+    registryPath,
+    JSON.stringify({
+      repos: [
+        {
+          name: 'watch-repo',
+          repoPath: repo,
+          scopeKey: 'github.com/example/watch-repo',
+        },
+      ],
+    }),
+  );
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+    },
+    cwd: process.cwd(),
+  });
+
+  const first = await watchAgentRoutedSessions(app, {
+    codexSessionsDir,
+    claudeCodeProjectsDir: missingClaudeCodeProjectsDir,
+    grokSessionsDir: missingGrokSessionsDir,
+    cursorProjectsDir: missingCursorProjectsDir,
+    opencodeDb: missingOpenCodeDb,
+    repoRegistry: registryPath,
+    watchStateDir,
+    distill: 'never',
+    iterations: 1,
+    intervalMs: 1,
+    watchVerbose: true,
+  });
+
+  assert.deepEqual(first.adapters, ['codex']);
+  assert.deepEqual(
+    first.inactiveAdapters.map((adapter) => [adapter.adapter, adapter.reason]).sort(),
+    [
+      ['claude_code', 'missing_root'],
+      ['cursor_cli', 'missing_root'],
+      ['grok', 'missing_root'],
+      ['opencode', 'missing_root'],
+    ],
+  );
+  assert.equal(first.totals.filesScanned, 1);
+  assert.equal(first.totals.appendedEvents, 2);
+  assert.equal(first.results[0].adapterResults[0].stateUpdated, true);
+
+  const second = await watchAgentRoutedSessions(app, {
+    codexSessionsDir,
+    claudeCodeProjectsDir: missingClaudeCodeProjectsDir,
+    grokSessionsDir: missingGrokSessionsDir,
+    cursorProjectsDir: missingCursorProjectsDir,
+    opencodeDb: missingOpenCodeDb,
+    repoRegistry: registryPath,
+    watchStateDir,
+    distill: 'never',
+    iterations: 1,
+    intervalMs: 1,
+    watchVerbose: true,
+  });
+
+  assert.deepEqual(second.adapters, ['codex']);
+  assert.equal(second.totals.filesScanned, 1);
+  assert.equal(second.totals.filesChanged, 0);
+  assert.equal(second.totals.appendedEvents, 0);
+  assert.equal(second.results[0].adapterResults[0].stateLoaded, true);
+
+  await fs.appendFile(rolloutFile, '{"malformed":\n');
+  await appendSyntheticCodexAssistantMessage(rolloutFile, 'Recovered after a malformed complete JSONL line.');
+  const third = await watchAgentRoutedSessions(app, {
+    codexSessionsDir,
+    claudeCodeProjectsDir: missingClaudeCodeProjectsDir,
+    grokSessionsDir: missingGrokSessionsDir,
+    cursorProjectsDir: missingCursorProjectsDir,
+    opencodeDb: missingOpenCodeDb,
+    repoRegistry: registryPath,
+    watchStateDir,
+    distill: 'never',
+    iterations: 1,
+    intervalMs: 1,
+    watchVerbose: true,
+  });
+
+  assert.equal(third.totals.filesChanged, 1);
+  assert.equal(third.totals.appendedEvents, 1);
+  assert.equal(
+    third.results[0].adapterResults[0].fileResults[0].warnings.some(
+      (warning) => warning.type === 'malformed_json_line',
+    ),
+    true,
+  );
+
+  const events = app.listRawEvents({
+    scope: 'repo',
+    scopeKey: 'github.com/example/watch-repo',
+    sessionId: 'codex:unified-watch-codex',
+  });
+  assert.equal(events.length, 3);
+});
+
+test('multi-agent routed watch reports explicitly requested missing adapters without scanning files', async () => {
+  const dataDir = await makeTempDir();
+  const root = await makeTempDir();
+  const repo = await makeTempDir();
+  const missingCursorProjectsDir = path.join(root, 'missing-cursor');
+  const registryPath = path.join(root, 'repos.json');
+  await fs.writeFile(
+    registryPath,
+    JSON.stringify({
+      repos: [
+        {
+          name: 'watch-repo',
+          repoPath: repo,
+          scopeKey: 'github.com/example/watch-repo',
+          adapters: ['cursor_cli'],
+        },
+      ],
+    }),
+  );
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+    },
+    cwd: process.cwd(),
+  });
+
+  const result = await watchAgentRoutedSessions(app, {
+    adapters: 'cursor_cli',
+    cursorProjectsDir: missingCursorProjectsDir,
+    repoRegistry: registryPath,
+    distill: 'never',
+    iterations: 1,
+    intervalMs: 1,
+    watchVerbose: true,
+  });
+
+  assert.deepEqual(result.adapters, ['cursor_cli']);
+  assert.equal(result.inactiveAdapters.length, 0);
+  assert.equal(result.totals.filesScanned, 0);
+  assert.equal(result.results[0].adapterResults[0].skippedAdapter, true);
+  assert.equal(result.results[0].adapterResults[0].skippedReason, 'missing_root');
 });
 
 test('repoPath ingest skips Claude Code transcripts from other working directories', async () => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -54,8 +54,20 @@ test('interruptible ingest sleep wakes when stopped', async () => {
 
 async function makeGitRepo(remoteUrl = 'git@github.com:example/contextforge.git') {
   const cwd = await makeTempDir();
-  await fs.mkdir(path.join(cwd, '.git'), { recursive: true });
-  await fs.writeFile(path.join(cwd, '.git', 'config'), `[remote "origin"]\n\turl = ${remoteUrl}\n`);
+  await fs.mkdir(path.join(cwd, '.git', 'objects'), { recursive: true });
+  await fs.mkdir(path.join(cwd, '.git', 'refs', 'heads'), { recursive: true });
+  await fs.writeFile(path.join(cwd, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+  await fs.writeFile(
+    path.join(cwd, '.git', 'config'),
+    `[core]
+\trepositoryformatversion = 0
+\tfilemode = true
+\tbare = false
+\tlogallrefupdates = true
+[remote "origin"]
+\turl = ${remoteUrl}
+`,
+  );
   return cwd;
 }
 
@@ -2944,6 +2956,57 @@ test('multi-agent routed ingest shares repo scope while preserving source proven
   });
   assert.equal(resume.handoff.memoryCandidates.items[0].sourceAgent, 'opencode');
   assert.equal(resume.handoff.memoryCandidates.items[0].sourceProvenance.sourceAdapter, 'opencode_sqlite');
+});
+
+test('multi-agent routed ingest matches temporary checkouts by git remote scopeKey', async () => {
+  const dataDir = await makeTempDir();
+  const root = await makeTempDir();
+  const canonicalRepo = await makeTempDir();
+  const reviewCheckout = await makeGitRepo('git@github.com:example/shared-repo.git');
+  const opencodeDb = path.join(root, 'opencode', 'opencode.db');
+  await writeSyntheticOpenCodeDb(opencodeDb, 'opencode-review-checkout', reviewCheckout);
+
+  const registryPath = path.join(root, 'repos.json');
+  await fs.writeFile(
+    registryPath,
+    JSON.stringify({
+      repos: [
+        {
+          name: 'shared-repo',
+          repoPath: canonicalRepo,
+          scopeKey: 'github.com/example/shared-repo',
+        },
+      ],
+    }),
+  );
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+    },
+    cwd: process.cwd(),
+  });
+
+  const result = await ingestAgentRoutedSessions(app, {
+    adapters: 'opencode',
+    opencodeDb,
+    repoRegistry: registryPath,
+    distill: 'never',
+  });
+
+  assert.equal(result.adapters[0], 'opencode');
+  assert.equal(result.routedFiles, 1);
+  assert.equal(result.skippedFiles, 0);
+  assert.equal(result.appendedEvents, 2);
+  assert.equal(result.adapterResults[0].fileResults[0].matchedRepo.scopeKey, 'github.com/example/shared-repo');
+  assert.equal(result.adapterResults[0].fileResults[0].cwd, undefined);
+  assert.equal(
+    app.listRawEvents({
+      scope: 'repo',
+      scopeKey: 'github.com/example/shared-repo',
+      sessionId: 'opencode:opencode-review-checkout',
+    }).length,
+    2,
+  );
 });
 
 test('Cursor CLI routed ingest matches project names without lossy path decoding', async () => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -15,7 +15,7 @@ import { canonicalizeScope, parseScopeAliases } from '../src/config/index.js';
 import { createContextForge } from '../src/core.js';
 import { STRUCTURED_CHECKPOINT_SCHEMA_VERSION, validateDistillOutput } from '../src/distill/validate.js';
 import { createOpenAiEmbeddingProvider } from '../src/embeddings/index.js';
-import { createInterruptibleSleep, shouldSkipRecentFailedAutoDistill } from '../src/ingest/common.js';
+import { createInterruptibleSleep, normalizeRepoIdentity, shouldSkipRecentFailedAutoDistill } from '../src/ingest/common.js';
 import { watchClaudeCodeSessions } from '../src/ingest/claude_code.js';
 import { ingestCodexRolloutFile, watchCodexSessions } from '../src/ingest/codex.js';
 import { ingestAgentRoutedSessions, ingestAgentSessions, listAgentAdapters, watchAgentRoutedSessions } from '../src/ingest/agents.js';
@@ -566,6 +566,18 @@ test('repo scope key defaults to normalized GitHub origin remote', async () => {
   });
   assert.equal(memory.scopeType, 'repo');
   assert.equal(memory.scopeKey, 'github.com/example/contextforge');
+});
+
+test('repo identity normalization preserves nested namespace paths', () => {
+  assert.equal(normalizeRepoIdentity('git@github.com:Example/ContextForge.git'), 'github.com/example/contextforge');
+  assert.equal(
+    normalizeRepoIdentity('https://gitlab.com/group/subgroup/repo-a.git'),
+    'gitlab.com/group/subgroup/repo-a',
+  );
+  assert.equal(
+    normalizeRepoIdentity('git@gitlab.com:group/subgroup/repo-b.git'),
+    'gitlab.com/group/subgroup/repo-b',
+  );
 });
 
 test('repo scope key falls back to a deterministic path key outside git', async () => {
@@ -1853,9 +1865,11 @@ test('unified agent router service installer creates one auto-detecting router u
       '--repo-registry',
       registryPath,
       '--remote-url',
-      'https://memory.example.com',
+      'https://memory.example.com/api?token=abc$def',
       '--token-env-file',
       path.join(home, 'token.env'),
+      '--codex-sessions-dir',
+      path.join(home, 'codex $sessions'),
       '--distill',
       'false',
     ],
@@ -1878,7 +1892,9 @@ test('unified agent router service installer creates one auto-detecting router u
   assert.match(unit, /ingestAgentRoutedSessions/);
   assert.doesNotMatch(unit, /--adapters/);
   assert.match(unit, /WorkingDirectory="/);
+  assert.match(unit, /Environment="CONTEXTFORGE_REMOTE_URL=https:\/\/memory\.example\.com\/api\?token=abc\$\$def"/);
   assert.match(unit, /--codexSessionsDir/);
+  assert.match(unit, new RegExp(`--codexSessionsDir "${path.join(home, 'codex $$sessions').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
   assert.match(unit, /--claudeCodeProjectsDir/);
   assert.match(unit, /--opencodeDb/);
   assert.match(unit, /--grokSessionsDir/);
@@ -2884,6 +2900,10 @@ test('multi-agent routed ingest shares repo scope while preserving source proven
   assert.equal(result.routedFiles, 5);
   assert.equal(result.appendedEvents, 10);
   assert.equal(result.checkpointsCreated, 5);
+  const opencodeResult = result.adapterResults.find((adapterResult) => adapterResult.adapter === 'opencode');
+  assert.equal(opencodeResult.stateLoaded, false);
+  assert.equal(opencodeResult.stateUpdated, false);
+  assert.equal(opencodeResult.corruptStateFile, null);
   assert.deepEqual(
     result.adapterResults.map((adapterResult) => [adapterResult.adapter, adapterResult.routedFiles]).sort(),
     [
@@ -3004,6 +3024,115 @@ test('multi-agent routed ingest matches temporary checkouts by git remote scopeK
       scope: 'repo',
       scopeKey: 'github.com/example/shared-repo',
       sessionId: 'opencode:opencode-review-checkout',
+    }).length,
+    2,
+  );
+});
+
+test('multi-agent routed ingest keeps nested namespace git remotes distinct', async () => {
+  const dataDir = await makeTempDir();
+  const root = await makeTempDir();
+  const repoA = await makeTempDir();
+  const repoB = await makeTempDir();
+  const reviewCheckout = await makeGitRepo('git@gitlab.com:group/subgroup/repo-b.git');
+  const opencodeDb = path.join(root, 'opencode', 'opencode.db');
+  await writeSyntheticOpenCodeDb(opencodeDb, 'opencode-nested-namespace', reviewCheckout);
+
+  const registryPath = path.join(root, 'repos.json');
+  await fs.writeFile(
+    registryPath,
+    JSON.stringify({
+      repos: [
+        {
+          name: 'repo-a',
+          repoPath: repoA,
+          scopeKey: 'gitlab.com/group/subgroup/repo-a',
+        },
+        {
+          name: 'repo-b',
+          repoPath: repoB,
+          scopeKey: 'gitlab.com/group/subgroup/repo-b',
+        },
+      ],
+    }),
+  );
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+    },
+    cwd: process.cwd(),
+  });
+
+  const result = await ingestAgentRoutedSessions(app, {
+    adapters: 'opencode',
+    opencodeDb,
+    repoRegistry: registryPath,
+    distill: 'never',
+  });
+
+  assert.equal(result.routedFiles, 1);
+  assert.equal(result.adapterResults[0].fileResults[0].matchedRepo.scopeKey, 'gitlab.com/group/subgroup/repo-b');
+  assert.equal(
+    app.listRawEvents({
+      scope: 'repo',
+      scopeKey: 'gitlab.com/group/subgroup/repo-a',
+      sessionId: 'opencode:opencode-nested-namespace',
+    }).length,
+    0,
+  );
+  assert.equal(
+    app.listRawEvents({
+      scope: 'repo',
+      scopeKey: 'gitlab.com/group/subgroup/repo-b',
+      sessionId: 'opencode:opencode-nested-namespace',
+    }).length,
+    2,
+  );
+});
+
+test('Cursor CLI routed ingest matches temporary checkouts by git remote scopeKey', async () => {
+  const dataDir = await makeTempDir();
+  const root = await makeTempDir();
+  const canonicalRepo = await makeTempDir();
+  const reviewCheckout = await makeGitRepo('https://github.com/example/cursor-repo.git');
+  const cursorProjectsDir = path.join(root, 'cursor');
+  await writeSyntheticCursorTranscript(cursorProjectsDir, 'cursor-review-checkout', 'unmatched-review-project');
+
+  const registryPath = path.join(root, 'repos.json');
+  await fs.writeFile(
+    registryPath,
+    JSON.stringify({
+      repos: [
+        {
+          name: 'cursor-repo',
+          repoPath: canonicalRepo,
+          scopeKey: 'github.com/example/cursor-repo',
+        },
+      ],
+    }),
+  );
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+    },
+    cwd: process.cwd(),
+  });
+
+  const result = await ingestAgentRoutedSessions(app, {
+    adapters: 'cursor_cli',
+    cursorProjectsDir,
+    repoRegistry: registryPath,
+    cwd: reviewCheckout,
+    distill: 'never',
+  });
+
+  assert.equal(result.routedFiles, 1);
+  assert.equal(result.adapterResults[0].fileResults[0].matchedRepo.scopeKey, 'github.com/example/cursor-repo');
+  assert.equal(
+    app.listRawEvents({
+      scope: 'repo',
+      scopeKey: 'github.com/example/cursor-repo',
+      sessionId: 'cursor_cli:cursor-review-checkout',
     }).length,
     2,
   );


### PR DESCRIPTION
## Summary

- make `ingestAgentRoutedSessions --watch` the unified multi-agent router watcher
- auto-detect installed adapter stores at watcher startup when `--adapters` is omitted, so missing agent runtimes are not walked or opened repeatedly
- add shared incremental JSONL byte-cursor routing for Codex, Claude Code, Grok, and Cursor CLI adapters
- route temporary or review checkouts by falling back from `cwd` path matching to the checkout Git `origin` remote and registry `scopeKey`
- keep explicit `--adapters` requests visible by reporting `missing_root` without scanning files when a requested adapter store is absent
- add a unified `scripts/install-agent-router-service.sh` systemd user-service installer
- update English/Korean README guidance to recommend one unified router for mixed-agent environments

## Review Follow-up

- isolate per-unit and per-adapter errors so one broken transcript or adapter does not stop the unified watcher
- preserve prior session/cwd context across truncated-file reset reads
- make Codex/Claude malformed-line recovery opt-in through the incremental watcher path, including legacy per-agent incremental watchers
- apply auto-detect to one-shot multi-agent routed ingest as well as watch mode
- quote systemd `ExecStart`, `WorkingDirectory`, `EnvironmentFile`, and remote URL values in the unified installer, including literal `$` handling
- keep repo registry `adapters` optional and support PR-review checkouts whose filesystem path differs from the canonical registered repo path
- preserve full remote path identity for nested namespaces, so subgroup remotes do not collapse to the same scope
- apply Git remote fallback to Cursor CLI after its path/project-name matching fails
- expose explicit false/null state fields for DB-backed OpenCode router results

## Notes

The repo registry `adapters` field remains optional. It is a repo routing policy knob, not a per-machine installation checklist. Machines can run the same unified watcher and let startup auto-detection choose the installed adapter stores for that environment.

The repo registry still provides canonical `repoPath` to `scopeKey` mappings. When a session `cwd` is outside those registered paths, such as a personal-review-machines temporary checkout, the router tries `git -C <cwd> remote get-url origin` and matches the normalized full remote identity against the registry `scopeKey`. If both path and Git remote matching fail, the session remains unmatched and is not silently written to `shared` or `local` memory.

OpenCode remains DB-backed and idempotent; the unified watcher only attempts it when the configured SQLite DB exists. JSONL-backed adapters use the shared incremental cursor and recover from complete malformed JSONL lines by warning and advancing, while still preserving trailing partial-line behavior.

## Tests

- `bash -n scripts/install-agent-router-service.sh`
- `node --check src/ingest/common.js`
- `node --check src/ingest/agents.js`
- `node --check src/ingest/codex.js`
- `node --check src/ingest/claude_code.js`
- `node --check test/core.test.js`
- `git diff --check`
- `node --test test/core.test.js --test-name-pattern "Codex incremental watch keeps trailing partial|Claude Code incremental watch skips unchanged|multi-agent routed watch auto-detects installed adapters"` (159/159 pass; Node test runner executed the full file)
- `npm test` (159/159 pass)

Closes #75
