### PR TITLE
Fix agent router systemd path settings

### DIFF
--- a/scripts/install-agent-router-service.sh
+++ b/scripts/install-agent-router-service.sh
@@ -122,11 +122,11 @@ After=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=$(systemd_quote "$repo_root")
+WorkingDirectory=$repo_root
 Environment=CONTEXTFORGE_STORAGE_MODE=remote
 Environment=$(systemd_quote "CONTEXTFORGE_REMOTE_URL=$remote_url")
 Environment=CONTEXTFORGE_WATCH_STATE_DIR=%h/.local/state/contextforge/watch
-EnvironmentFile=-$(systemd_quote "$token_env_file")
+EnvironmentFile=-$token_env_file
 ExecStart=$(systemd_quote "$node_bin") $(systemd_quote "$cli_path") ingestAgentRoutedSessions${adapter_args} --codexSessionsDir $(systemd_quote "$codex_sessions_dir") --claudeCodeProjectsDir $(systemd_quote "$claude_code_projects_dir") --opencodeDb $(systemd_quote "$opencode_db") --grokSessionsDir $(systemd_quote "$grok_sessions_dir") --cursorProjectsDir $(systemd_quote "$cursor_projects_dir") --repoRegistry $(systemd_quote "$repo_registry") --sinceMinutes $(systemd_quote "$since_minutes") --distill $(systemd_quote "$distill") --watch --intervalMs $(systemd_quote "$interval_ms")
 Restart=always
 RestartSec=10

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1891,7 +1891,8 @@ test('unified agent router service installer creates one auto-detecting router u
   assert.match(result.stdout, /Requested adapters: auto-detect installed adapters/);
   assert.match(unit, /ingestAgentRoutedSessions/);
   assert.doesNotMatch(unit, /--adapters/);
-  assert.match(unit, /WorkingDirectory="/);
+  assert.match(unit, new RegExp(`WorkingDirectory=${process.cwd().replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+  assert.match(unit, new RegExp(`EnvironmentFile=-${path.join(home, 'token.env').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
   assert.match(unit, /Environment="CONTEXTFORGE_REMOTE_URL=https:\/\/memory\.example\.com\/api\?token=abc\$\$def"/);
   assert.match(unit, /--codexSessionsDir/);
   assert.match(unit, new RegExp(`--codexSessionsDir "${path.join(home, 'codex $$sessions').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));


### PR DESCRIPTION
## Summary
- fix unified agent router installer path settings for systemd
- leave ExecStart and Environment value quoting intact, but avoid quoting path-only settings that systemd treats literally
- update the installer regression test so WorkingDirectory and EnvironmentFile are emitted as absolute paths

## Why
Live installation of the unified router exposed that systemd rejects quoted WorkingDirectory values and ignores quoted EnvironmentFile paths. The service now installs and restarts cleanly on the VPS.

## Verification
- npm test: 159/159 pass
- git diff --check
- installed and restarted contextforge-agent-router-all-agents.service successfully on the VPS
- /healthz returns ok
