### PR TITLE
Sync contextforge-memory skill and bump 0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ ContextForge is a sidecar memory runtime. It complements existing agent memory
 systems by providing canonical project/repo memory, evidence retention, and
 LLM-backed distillation.
 
-Current 0.5.0 builds add structured checkpoint handoff payloads, deterministic
+Current 0.5.1 builds add periodic checkpoint consolidation for richer
+bootstrap context, `handoff.latestConsolidation`, `memoryLifecycle` visibility,
+and refreshed packaged `contextforge-memory` skill guidance. They also include
+the 0.5.0 structured checkpoint handoff payloads, deterministic
 `handoff.latestHandoff` bootstrap state, preserved memory-candidate review
 fields, a server-hosted operator UI, DB-backed runtime settings,
 OpenAI-compatible distillation for DeepSeek-style Chat Completions APIs,
@@ -27,6 +30,19 @@ separate auto-promotion audit runners including the experimental
 `codex_sdk_python` audit provider, remote-first MCP workflows, correction
 reconciliation, hybrid retrieval, and an embedding job queue so vector indexing
 can recover independently from memory or checkpoint writes.
+
+## What's New In 0.5.1
+
+- Checkpoints can be consolidated by thread or repo time window so bootstrap can
+  include period context without loading raw evidence by default.
+- `bootstrapContext` exposes `handoff.latestConsolidation.thread`,
+  `handoff.latestConsolidation.repo`, and `memoryLifecycle` alongside ordinary
+  latest handoff checkpoints.
+- CLI, remote client, and MCP surfaces now include `listDueConsolidations` /
+  `processConsolidations` and `list_due_consolidations` /
+  `process_consolidations`.
+- The packaged `contextforge-memory` skill documents checkpoint consolidation,
+  memory lifecycle checks, candidate audit flow, and scope migration guidance.
 
 ## What's New In 0.5.0
 

--- a/docs/skills/contextforge-memory/SKILL.md
+++ b/docs/skills/contextforge-memory/SKILL.md
@@ -37,6 +37,32 @@ Always set scope intentionally:
 - `shared`: cross-repo/user-wide conventions. Include only when it may matter.
 - `local`: machine-specific context; opt in only when appropriate.
 
+For renamed or transferred repositories, treat the new repository identity as
+the canonical `scopeKey`. ContextForge may be configured with
+`CONTEXTFORGE_SCOPE_ALIASES` so future reads and writes using an old repo key
+canonicalize to the new key. Before assuming data is missing, check `db_info`
+for loaded `scopeAliases`.
+
+When scope aliases are enabled, old-scope rows that have not been migrated may
+be hidden from normal scoped reads because read/write calls canonicalize to the
+new key. Use `migrate_scope` for explicit migration rather than trying to read
+both old and new scopes as a union.
+
+`migrate_scope` rules:
+
+- Run it as a dry-run first. `dryRun` defaults to `true`.
+- Pass `fromScope`/`fromScopeKey` as the raw stored old scope. The `from` scope
+  is not alias-canonicalized, so it can find rows written before the alias was
+  configured.
+- Pass `toScope`/`toScopeKey` as the intended canonical target. The `to` scope
+  is alias-canonicalized.
+- Inspect `conflicts`, `blocked`, and `blockedReason` before running with
+  `dryRun: false`.
+- `hasRows: false` or `empty: true` means there is nothing to migrate.
+- `totalRows` counts logical rows to move. `derivedRows.memory_fts` and
+  `rebuilt.memory_fts` describe the derived FTS index, not additional durable
+  memory rows.
+
 Before relying on results, check connection metadata and storage authority from `bootstrap_context` or `db_info`:
 
 - `connection.summary`: quickest human-readable access/process summary.
@@ -229,3 +255,8 @@ Embeddings are the supported quality path for retrieval. If `db_info` or `bootst
 3. Use `rebuild_embeddings` only for intentional backfill or dimension changes.
 
 Use `prune_raw_events` only according to retention policy; durable memory and checkpoints are preserved separately.
+
+After a scope migration, remember that `memory_fts` is rebuilt from `memories`
+and embedding vectors remain keyed by immutable source ids. If retrieval looks
+stale after a migration, inspect `db_info` and embedding job state before
+rebuilding embeddings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contextforge",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contextforge",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contextforge",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Self-hosted memory and distillation runtime for coding agents.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## 요약
- 패키지된 `contextforge-memory` 스킬 소스에 기존 scope alias / `migrate_scope` 안내를 복구했습니다.
- PR #134에서 추가된 checkpoint consolidation, `latestConsolidation`, `memoryLifecycle`, candidate audit 안내와 함께 설치 스킬 내용이 일관되도록 맞췄습니다.
- 패키지 버전을 `0.5.1`로 올리고 README에 0.5.1 변경 요약을 추가했습니다.
- 이 호스트의 설치된 Codex 스킬(`/home/ubuntu/.codex/skills/contextforge-memory/SKILL.md`)도 동일 내용으로 즉시 업데이트했습니다.

## 검증
- `git diff --check`
- `node -p "require(\047./package.json\047).version"` → `0.5.1`
- `node -p "require(\047./package-lock.json\047).version + \047 \047 + require(\047./package-lock.json\047).packages[\047\047].version"` → `0.5.1 0.5.1`
- 설치 스킬과 repo 소스 `cmp` 일치 확인

Refs #134