### PR TITLE
Track LLM usage events for distill and audit calls

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -100,6 +100,8 @@ function toCoreOptions(options) {
     sourceCandidateIndex: options.sourceCandidateIndex == null ? undefined : Number(options.sourceCandidateIndex),
     candidateId: options.candidateId,
     checkpointId: options.checkpointId,
+    distillRunId: options.distillRunId,
+    operation: options.operation,
     status: options.status,
     candidateType: options.candidateType,
     promotionRecommendation: options.promotionRecommendation,
@@ -195,6 +197,7 @@ function toCoreOptions(options) {
     confidence: options.confidence == null ? undefined : Number(options.confidence),
     batchSize: options.batchSize == null ? undefined : Number(options.batchSize),
     force: options.force === true || options.force === 'true',
+    includeEvents: options.includeEvents === true || options.includeEvents === 'true',
     retryFailed: options.retryFailed === true || options.retryFailed === 'true',
     staleAfterMs: options.staleAfterMs == null ? undefined : Number(options.staleAfterMs),
   };
@@ -261,6 +264,8 @@ async function main() {
     pruneRawEvents: (app, coreOptions) => app.pruneRawEvents(coreOptions),
     distillCheckpoint: (app, coreOptions) => app.distillCheckpoint(coreOptions),
     listDistillRuns: (app, coreOptions) => app.listDistillRuns(coreOptions),
+    listLlmUsageEvents: (app, coreOptions) => app.listLlmUsageEvents(coreOptions),
+    llmUsageRollup: (app, coreOptions) => app.llmUsageRollup(coreOptions),
     distillUsage: (app, coreOptions) => app.distillUsage(coreOptions),
     ingestCodexRollout: (app, coreOptions) => ingestCodexRolloutFile(app, coreOptions),
     ingestCodexSessions: (app, coreOptions) =>

--- a/src/core.js
+++ b/src/core.js
@@ -219,55 +219,185 @@ function usageNestedNumberFrom(metadata, path) {
   return finiteNumber(current);
 }
 
-function extractUsageMetadata(run) {
-  const providerMetadata = run.outputMetadata?.providerMetadata || {};
-  const candidates = [
-    run.outputMetadata?.usage,
-    providerMetadata.usage,
-    providerMetadata.codexExec?.usage,
-    providerMetadata.codexExec,
-  ];
-
-  for (const candidate of candidates) {
-    const inputTokens = usageNumberFrom(candidate, ['inputTokens', 'input_tokens', 'promptTokens', 'prompt_tokens']);
-    const outputTokens = usageNumberFrom(candidate, [
-      'outputTokens',
-      'output_tokens',
-      'completionTokens',
-      'completion_tokens',
-    ]);
-    const totalTokens = usageNumberFrom(candidate, ['totalTokens', 'total_tokens']);
-    if (inputTokens != null || outputTokens != null || totalTokens != null) {
-      const promptCacheHitTokens =
-        usageNumberFrom(candidate, [
-          'promptCacheHitTokens',
-          'prompt_cache_hit_tokens',
-          'cacheHitInputTokens',
-          'input_cache_hit_tokens',
-        ]) ?? usageNestedNumberFrom(candidate, ['prompt_tokens_details', 'cached_tokens']);
-      const explicitPromptCacheMissTokens = usageNumberFrom(candidate, [
-        'promptCacheMissTokens',
-        'prompt_cache_miss_tokens',
-        'cacheMissInputTokens',
-        'input_cache_miss_tokens',
-      ]);
-      const promptCacheMissTokens =
-        explicitPromptCacheMissTokens ??
-        (inputTokens != null && promptCacheHitTokens != null ? Math.max(0, inputTokens - promptCacheHitTokens) : null);
-      return {
-        inputTokens,
-        outputTokens,
-        totalTokens: totalTokens ?? (inputTokens != null && outputTokens != null ? inputTokens + outputTokens : null),
-        promptCacheHitTokens,
-        promptCacheMissTokens,
-      };
-    }
+function normalizeUsageMetadata(candidate, { includeRaw = false } = {}) {
+  const inputTokens = usageNumberFrom(candidate, ['inputTokens', 'input_tokens', 'promptTokens', 'prompt_tokens']);
+  const outputTokens = usageNumberFrom(candidate, [
+    'outputTokens',
+    'output_tokens',
+    'completionTokens',
+    'completion_tokens',
+  ]);
+  const reasoningTokens =
+    usageNumberFrom(candidate, ['reasoningTokens', 'reasoning_tokens']) ??
+    usageNestedNumberFrom(candidate, ['completion_tokens_details', 'reasoning_tokens']) ??
+    usageNestedNumberFrom(candidate, ['output_tokens_details', 'reasoning_tokens']);
+  const totalTokens = usageNumberFrom(candidate, ['totalTokens', 'total_tokens']);
+  if (inputTokens == null && outputTokens == null && totalTokens == null && reasoningTokens == null) {
+    return null;
   }
 
+  const cachedInputTokens =
+    usageNumberFrom(candidate, [
+      'cachedInputTokens',
+      'cached_input_tokens',
+      'promptCacheHitTokens',
+      'prompt_cache_hit_tokens',
+      'cacheHitInputTokens',
+      'input_cache_hit_tokens',
+    ]) ??
+    usageNestedNumberFrom(candidate, ['prompt_tokens_details', 'cached_tokens']) ??
+    usageNestedNumberFrom(candidate, ['input_tokens_details', 'cached_tokens']);
+  const explicitUncachedInputTokens = usageNumberFrom(candidate, [
+    'uncachedInputTokens',
+    'uncached_input_tokens',
+    'promptCacheMissTokens',
+    'prompt_cache_miss_tokens',
+    'cacheMissInputTokens',
+    'input_cache_miss_tokens',
+  ]);
+  const uncachedInputTokens =
+    explicitUncachedInputTokens ??
+    (inputTokens != null && cachedInputTokens != null ? Math.max(0, inputTokens - cachedInputTokens) : null);
+
+  return {
+    inputTokens,
+    cachedInputTokens,
+    uncachedInputTokens,
+    outputTokens,
+    reasoningTokens,
+    totalTokens: totalTokens ?? (inputTokens != null && outputTokens != null ? inputTokens + outputTokens : null),
+    promptCacheHitTokens: cachedInputTokens,
+    promptCacheMissTokens: uncachedInputTokens,
+    ...(includeRaw ? { usage: candidate } : {}),
+  };
+}
+
+function extractUsageFromCandidates(candidates, options = {}) {
+  for (const candidate of candidates) {
+    const usage = normalizeUsageMetadata(candidate, options);
+    if (usage) return usage;
+  }
   return null;
 }
 
-function summarizeDistillUsage({ scope, sessionId, runs, charsPerToken = 4 }) {
+function providerUsageCandidates(metadata = {}) {
+  const providerMetadata = metadata?.providerMetadata || metadata || {};
+  return [
+    metadata?.usage,
+    providerMetadata.usage,
+    providerMetadata.openAiCompatible?.usage,
+    providerMetadata.openAiCompatible,
+    providerMetadata.codexExec?.usage,
+    providerMetadata.codexExec,
+    providerMetadata.codexSdkPython?.usage,
+    providerMetadata.codexSdkPython,
+  ];
+}
+
+function extractUsageMetadata(run) {
+  return extractUsageFromCandidates([run.outputMetadata?.usage, ...providerUsageCandidates(run.outputMetadata)], {
+    includeRaw: false,
+  });
+}
+
+function extractProviderUsage(metadata) {
+  return extractUsageFromCandidates(providerUsageCandidates(metadata), { includeRaw: true });
+}
+
+function usageEventTimes({ startedAt = null, completedAt = null, elapsedMs = null } = {}) {
+  const completed = completedAt || new Date().toISOString();
+  const elapsed = finiteNumber(elapsedMs);
+  if (startedAt) {
+    return { startedAt, completedAt: completed, elapsedMs: elapsed };
+  }
+  if (elapsed != null) {
+    return {
+      startedAt: new Date(Date.parse(completed) - elapsed).toISOString(),
+      completedAt: completed,
+      elapsedMs: elapsed,
+    };
+  }
+  return { startedAt: completed, completedAt: completed, elapsedMs: null };
+}
+
+function providerModelFromMetadata(metadata = {}, fallback = null) {
+  return (
+    metadata.model ||
+    metadata.openAiCompatible?.model ||
+    metadata.codexExec?.model ||
+    metadata.codexSdkPython?.model ||
+    fallback ||
+    null
+  );
+}
+
+function recordLlmUsageEvent(store, options) {
+  const usage = extractProviderUsage(options.metadata || {});
+  if (!usage) return null;
+  const { usage: usageJson, promptCacheHitTokens, promptCacheMissTokens, ...columns } = usage;
+  const times = usageEventTimes({
+    startedAt: options.startedAt || null,
+    completedAt: options.completedAt || null,
+    elapsedMs: options.elapsedMs ?? options.metadata?.elapsedMs ?? null,
+  });
+  return store.insertLlmUsageEvent({
+    ...options.scope,
+    operation: options.operation,
+    provider: options.provider,
+    model: options.model || providerModelFromMetadata(options.metadata || {}),
+    status: options.status || 'succeeded',
+    sessionId: options.sessionId || null,
+    distillRunId: options.distillRunId || null,
+    checkpointId: options.checkpointId || null,
+    candidateId: options.candidateId || null,
+    ...columns,
+    usage: usageJson || {},
+    estimated: false,
+    ...times,
+  });
+}
+
+function summarizeLlmUsageEvents(events) {
+  const totals = {
+    events: events.length,
+    inputTokens: events.reduce((total, event) => total + (event.inputTokens || 0), 0),
+    cachedInputTokens: events.reduce((total, event) => total + (event.cachedInputTokens || 0), 0),
+    uncachedInputTokens: events.reduce((total, event) => total + (event.uncachedInputTokens || 0), 0),
+    outputTokens: events.reduce((total, event) => total + (event.outputTokens || 0), 0),
+    reasoningTokens: events.reduce((total, event) => total + (event.reasoningTokens || 0), 0),
+    totalTokens: events.reduce((total, event) => total + (event.totalTokens || 0), 0),
+  };
+  const byOperation = {};
+  const byProviderModel = {};
+  for (const event of events) {
+    const operationKey = event.operation;
+    const providerKey = [event.provider, event.model].filter(Boolean).join('/') || event.provider;
+    for (const [key, target] of [
+      [operationKey, byOperation],
+      [providerKey, byProviderModel],
+    ]) {
+      target[key] ||= {
+        events: 0,
+        inputTokens: 0,
+        cachedInputTokens: 0,
+        uncachedInputTokens: 0,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        totalTokens: 0,
+      };
+      target[key].events += 1;
+      target[key].inputTokens += event.inputTokens || 0;
+      target[key].cachedInputTokens += event.cachedInputTokens || 0;
+      target[key].uncachedInputTokens += event.uncachedInputTokens || 0;
+      target[key].outputTokens += event.outputTokens || 0;
+      target[key].reasoningTokens += event.reasoningTokens || 0;
+      target[key].totalTokens += event.totalTokens || 0;
+    }
+  }
+  return { ...totals, byOperation, byProviderModel };
+}
+
+function summarizeDistillUsage({ scope, sessionId, runs, usageEvents = [], charsPerToken = 4 }) {
   const details = runs.map((run) => {
     const window = run.inputMetadata?.sourceEventWindow || {};
     const selectedCharCount = finiteNumber(window.selectedCharCount) ?? 0;
@@ -324,14 +454,17 @@ function summarizeDistillUsage({ scope, sessionId, runs, charsPerToken = 4 }) {
     sessionId,
     charsPerEstimatedToken: charsPerToken,
     note:
-      actualUsage.runs > 0
-        ? 'Actual provider usage was found for some runs; runs without actual usage only have estimates.'
-        : 'No actual provider token usage was recorded; estimatedInputTokens uses selectedCharCount divided by charsPerEstimatedToken. Older runs without sourceEventWindow metadata may estimate as 0.',
+      usageEvents.length > 0
+        ? 'Persisted LLM usage events were found; older runs without events may still only have estimates or embedded provider metadata.'
+        : actualUsage.runs > 0
+          ? 'Actual provider usage was found for some runs; runs without actual usage only have estimates.'
+          : 'No actual provider token usage was recorded; estimatedInputTokens uses selectedCharCount divided by charsPerEstimatedToken. Older runs without sourceEventWindow metadata may estimate as 0.',
     totals: {
       ...totals,
       completedRuns,
       averageElapsedMs: completedRuns ? Math.round(totals.elapsedMs / completedRuns) : 0,
       actualUsage,
+      persistedUsage: summarizeLlmUsageEvents(usageEvents),
     },
     runs: details,
   };
@@ -1529,6 +1662,24 @@ async function auditAutoPromotionCandidate({ auditor, store, scope, item }) {
     candidate: item.candidate,
     warnings: item.warnings,
     checkpoint,
+  });
+}
+
+function recordCandidateAuditUsageEvent(store, { scope, item, audit, sessionId = null, checkpointId = null }) {
+  const metadata = audit?.metadata || {};
+  const provider = metadata.provider || 'none';
+  if (provider === 'none') return null;
+  return recordLlmUsageEvent(store, {
+    scope,
+    operation: 'candidate_audit',
+    provider,
+    model: providerModelFromMetadata(metadata),
+    status: audit?.riskCodes?.includes('audit_failed') ? 'failed' : 'succeeded',
+    sessionId: sessionId || item.candidate.sessionId || null,
+    distillRunId: item.candidate.source?.distillRunId || null,
+    checkpointId: checkpointId || item.candidate.checkpointId || null,
+    candidateId: item.candidate.id,
+    metadata,
   });
 }
 
@@ -3451,6 +3602,13 @@ export function createContextForge(options = {}) {
         for (const item of selected) {
           try {
             const audit = await auditAutoPromotionCandidate({ auditor, store, scope, item });
+            recordCandidateAuditUsageEvent(store, {
+              scope,
+              item,
+              audit,
+              sessionId: options.sessionId || null,
+              checkpointId,
+            });
             const auditedCandidate = store.markMemoryCandidateAudited({
               ...scope,
               candidateId: item.candidate.id,
@@ -3694,6 +3852,13 @@ export function createContextForge(options = {}) {
             for (const item of selected) {
               try {
                 const audit = await auditAutoPromotionCandidate({ auditor, store, scope, item });
+                recordCandidateAuditUsageEvent(store, {
+                  scope,
+                  item,
+                  audit,
+                  sessionId: options.sessionId || null,
+                  checkpointId,
+                });
                 audited.push({ ...item, audit });
               } catch (error) {
                 audited.push({
@@ -4577,6 +4742,21 @@ export function createContextForge(options = {}) {
           });
           throw error;
         }
+        const completedAt = new Date().toISOString();
+        recordLlmUsageEvent(store, {
+          scope,
+          operation: 'checkpoint_consolidation',
+          provider: checkpoint.provider,
+          model: providerModelFromMetadata(output.metadata, providerMetadata.model),
+          status: 'succeeded',
+          sessionId: plan.sessionId,
+          distillRunId: distillRun.id,
+          checkpointId: checkpoint.id,
+          metadata: output.metadata,
+          startedAt: distillRun.createdAt,
+          completedAt,
+          elapsedMs: Date.parse(completedAt) - Date.parse(distillRun.createdAt),
+        });
         store.completeDistillRun({
           id: distillRun.id,
           outputMetadata: {
@@ -4975,6 +5155,13 @@ export function createContextForge(options = {}) {
                   metadata: { errorName: error.name },
                 };
               }
+              recordCandidateAuditUsageEvent(store, {
+                scope,
+                item,
+                audit,
+                sessionId: options.sessionId,
+                checkpointId: checkpoint.id,
+              });
               const auditedCandidate = store.markMemoryCandidateAudited({
                 ...scope,
                 candidateId: item.candidate.id,
@@ -5042,6 +5229,21 @@ export function createContextForge(options = {}) {
           };
         }
 
+        const completedAt = new Date().toISOString();
+        recordLlmUsageEvent(store, {
+          scope,
+          operation: 'checkpoint_distill',
+          provider: checkpoint.provider,
+          model: providerModelFromMetadata(output.metadata, providerMetadata.model),
+          status: 'succeeded',
+          sessionId: options.sessionId,
+          distillRunId: distillRun.id,
+          checkpointId: checkpoint.id,
+          metadata: output.metadata,
+          startedAt: distillRun.createdAt,
+          completedAt,
+          elapsedMs: Date.parse(completedAt) - Date.parse(distillRun.createdAt),
+        });
         store.completeDistillRun({
           id: distillRun.id,
           outputMetadata: {
@@ -5143,10 +5345,15 @@ export function createContextForge(options = {}) {
           ...scope,
           sessionId: options.sessionId,
         });
+        const usageEvents = store.listLlmUsageEvents({
+          ...scope,
+          sessionId: options.sessionId,
+        });
         return summarizeDistillUsage({
           scope,
           sessionId: options.sessionId,
           runs,
+          usageEvents,
           charsPerToken,
         });
       });

--- a/src/core.js
+++ b/src/core.js
@@ -331,6 +331,14 @@ function providerModelFromMetadata(metadata = {}, fallback = null) {
   );
 }
 
+function errorUsageMetadata(error) {
+  const metadata = error?.metadata && typeof error.metadata === 'object' ? { ...error.metadata } : {};
+  if (error?.usage && metadata.usage == null) {
+    metadata.usage = error.usage;
+  }
+  return metadata;
+}
+
 function recordLlmUsageEvent(store, options) {
   const usage = extractProviderUsage(options.metadata || {});
   if (!usage) return null;
@@ -369,12 +377,15 @@ function summarizeLlmUsageEvents(events) {
   };
   const byOperation = {};
   const byProviderModel = {};
+  const byProviderModelOperation = {};
   for (const event of events) {
     const operationKey = event.operation;
     const providerKey = [event.provider, event.model].filter(Boolean).join('/') || event.provider;
+    const providerOperationKey = `${providerKey}:${operationKey}`;
     for (const [key, target] of [
       [operationKey, byOperation],
       [providerKey, byProviderModel],
+      [providerOperationKey, byProviderModelOperation],
     ]) {
       target[key] ||= {
         events: 0,
@@ -394,7 +405,7 @@ function summarizeLlmUsageEvents(events) {
       target[key].totalTokens += event.totalTokens || 0;
     }
   }
-  return { ...totals, byOperation, byProviderModel };
+  return { ...totals, byOperation, byProviderModel, byProviderModelOperation };
 }
 
 function summarizeDistillUsage({ scope, sessionId, runs, usageEvents = [], charsPerToken = 4 }) {
@@ -433,7 +444,7 @@ function summarizeDistillUsage({ scope, sessionId, runs, usageEvents = [], chars
   };
   const completedRuns = totals.succeeded + totals.failed;
   const actualUsageRuns = details.filter((run) => run.usage);
-  const actualUsage = {
+  const embeddedActualUsage = {
     runs: actualUsageRuns.length,
     inputTokens: actualUsageRuns.reduce((total, run) => total + (run.usage.inputTokens || 0), 0),
     outputTokens: actualUsageRuns.reduce((total, run) => total + (run.usage.outputTokens || 0), 0),
@@ -444,9 +455,14 @@ function summarizeDistillUsage({ scope, sessionId, runs, usageEvents = [], chars
     promptCacheHitTokens: actualUsageRuns.reduce((total, run) => total + (run.usage.promptCacheHitTokens || 0), 0),
     promptCacheMissTokens: actualUsageRuns.reduce((total, run) => total + (run.usage.promptCacheMissTokens || 0), 0),
   };
-  actualUsage.promptCacheHitRatio = actualUsage.inputTokens
-    ? actualUsage.promptCacheHitTokens / actualUsage.inputTokens
+  embeddedActualUsage.promptCacheHitRatio = embeddedActualUsage.inputTokens
+    ? embeddedActualUsage.promptCacheHitTokens / embeddedActualUsage.inputTokens
     : null;
+  const persistedUsage = summarizeLlmUsageEvents(usageEvents);
+  const canonicalUsage =
+    usageEvents.length > 0
+      ? { source: 'persisted_usage_events', ...persistedUsage }
+      : { source: 'embedded_provider_metadata', ...embeddedActualUsage };
 
   return {
     scopeType: scope.scopeType,
@@ -455,16 +471,18 @@ function summarizeDistillUsage({ scope, sessionId, runs, usageEvents = [], chars
     charsPerEstimatedToken: charsPerToken,
     note:
       usageEvents.length > 0
-        ? 'Persisted LLM usage events were found; older runs without events may still only have estimates or embedded provider metadata.'
-        : actualUsage.runs > 0
+        ? 'Persisted LLM usage events are the canonical usage totals for this response. embeddedActualUsage is legacy run metadata and must not be added to persistedUsage.'
+        : embeddedActualUsage.runs > 0
           ? 'Actual provider usage was found for some runs; runs without actual usage only have estimates.'
           : 'No actual provider token usage was recorded; estimatedInputTokens uses selectedCharCount divided by charsPerEstimatedToken. Older runs without sourceEventWindow metadata may estimate as 0.',
     totals: {
       ...totals,
       completedRuns,
       averageElapsedMs: completedRuns ? Math.round(totals.elapsedMs / completedRuns) : 0,
-      actualUsage,
-      persistedUsage: summarizeLlmUsageEvents(usageEvents),
+      actualUsage: embeddedActualUsage,
+      embeddedActualUsage,
+      persistedUsage,
+      canonicalUsage,
     },
     runs: details,
   };
@@ -1665,7 +1683,10 @@ async function auditAutoPromotionCandidate({ auditor, store, scope, item }) {
   });
 }
 
-function recordCandidateAuditUsageEvent(store, { scope, item, audit, sessionId = null, checkpointId = null }) {
+function recordCandidateAuditUsageEvent(
+  store,
+  { scope, item, audit, sessionId = null, checkpointId = null, status = 'succeeded' },
+) {
   const metadata = audit?.metadata || {};
   const provider = metadata.provider || 'none';
   if (provider === 'none') return null;
@@ -1674,7 +1695,7 @@ function recordCandidateAuditUsageEvent(store, { scope, item, audit, sessionId =
     operation: 'candidate_audit',
     provider,
     model: providerModelFromMetadata(metadata),
-    status: audit?.riskCodes?.includes('audit_failed') ? 'failed' : 'succeeded',
+    status,
     sessionId: sessionId || item.candidate.sessionId || null,
     distillRunId: item.candidate.source?.distillRunId || null,
     checkpointId: checkpointId || item.candidate.checkpointId || null,
@@ -3630,8 +3651,16 @@ export function createContextForge(options = {}) {
               decision: 'needs_review',
               reason: `Memory candidate audit failed: ${error.message}`,
               riskCodes: ['audit_failed'],
-              metadata: { errorName: error.name },
+              metadata: { ...(auditor?.metadata || {}), ...errorUsageMetadata(error), errorName: error.name },
             };
+            recordCandidateAuditUsageEvent(store, {
+              scope,
+              item,
+              audit,
+              sessionId: options.sessionId || null,
+              checkpointId,
+              status: 'failed',
+            });
             const auditedCandidate = store.markMemoryCandidateAudited({
               ...scope,
               candidateId: item.candidate.id,
@@ -3861,15 +3890,24 @@ export function createContextForge(options = {}) {
                 });
                 audited.push({ ...item, audit });
               } catch (error) {
+                const audit = {
+                  approved: false,
+                  decision: 'needs_review',
+                  reason: `Auto-promotion audit failed: ${error.message}`,
+                  riskCodes: ['audit_failed'],
+                  metadata: { ...(auditor?.metadata || {}), ...errorUsageMetadata(error), errorName: error.name },
+                };
+                recordCandidateAuditUsageEvent(store, {
+                  scope,
+                  item,
+                  audit,
+                  sessionId: options.sessionId || null,
+                  checkpointId,
+                  status: 'failed',
+                });
                 audited.push({
                   ...item,
-                  audit: {
-                    approved: false,
-                    decision: 'needs_review',
-                    reason: `Auto-promotion audit failed: ${error.message}`,
-                    riskCodes: ['audit_failed'],
-                    metadata: { errorName: error.name },
-                  },
+                  audit,
                 });
               }
             }
@@ -4627,6 +4665,18 @@ export function createContextForge(options = {}) {
             requestedOutputSchema: consolidationRequestedOutputSchema(),
           });
         } catch (error) {
+          recordLlmUsageEvent(store, {
+            scope,
+            operation: 'checkpoint_consolidation',
+            provider: provider.name,
+            model: providerModelFromMetadata(errorUsageMetadata(error), providerMetadata.model),
+            status: 'failed',
+            sessionId: plan.sessionId,
+            distillRunId: distillRun.id,
+            metadata: errorUsageMetadata(error),
+            startedAt: distillRun.createdAt,
+            completedAt: new Date().toISOString(),
+          });
           store.failDistillRun({
             id: distillRun.id,
             error,
@@ -4642,6 +4692,18 @@ export function createContextForge(options = {}) {
         try {
           output = validateDistillOutput(rawOutput);
         } catch (error) {
+          recordLlmUsageEvent(store, {
+            scope,
+            operation: 'checkpoint_consolidation',
+            provider: provider.name,
+            model: providerModelFromMetadata(rawOutput?.metadata || {}, providerMetadata.model),
+            status: 'failed',
+            sessionId: plan.sessionId,
+            distillRunId: distillRun.id,
+            metadata: rawOutput?.metadata || {},
+            startedAt: distillRun.createdAt,
+            completedAt: new Date().toISOString(),
+          });
           store.failDistillRun({
             id: distillRun.id,
             error,
@@ -4703,6 +4765,19 @@ export function createContextForge(options = {}) {
               })
             : null;
           if (existing) {
+            recordLlmUsageEvent(store, {
+              scope,
+              operation: 'checkpoint_consolidation',
+              provider: output.provider || provider.name,
+              model: providerModelFromMetadata(output.metadata, providerMetadata.model),
+              status: 'succeeded',
+              sessionId: plan.sessionId,
+              distillRunId: distillRun.id,
+              checkpointId: existing.id,
+              metadata: output.metadata,
+              startedAt: distillRun.createdAt,
+              completedAt: new Date().toISOString(),
+            });
             store.failDistillRun({
               id: distillRun.id,
               error,
@@ -4732,6 +4807,18 @@ export function createContextForge(options = {}) {
               memoryLifecycle: lifecycle,
             };
           }
+          recordLlmUsageEvent(store, {
+            scope,
+            operation: 'checkpoint_consolidation',
+            provider: output.provider || provider.name,
+            model: providerModelFromMetadata(output.metadata, providerMetadata.model),
+            status: 'succeeded',
+            sessionId: plan.sessionId,
+            distillRunId: distillRun.id,
+            metadata: output.metadata,
+            startedAt: distillRun.createdAt,
+            completedAt: new Date().toISOString(),
+          });
           store.failDistillRun({
             id: distillRun.id,
             error,
@@ -4746,7 +4833,7 @@ export function createContextForge(options = {}) {
         recordLlmUsageEvent(store, {
           scope,
           operation: 'checkpoint_consolidation',
-          provider: checkpoint.provider,
+          provider: output.provider || provider.name,
           model: providerModelFromMetadata(output.metadata, providerMetadata.model),
           status: 'succeeded',
           sessionId: plan.sessionId,
@@ -4931,6 +5018,18 @@ export function createContextForge(options = {}) {
             requestedOutputSchema,
           });
         } catch (error) {
+          recordLlmUsageEvent(store, {
+            scope,
+            operation: 'checkpoint_distill',
+            provider: provider.name,
+            model: providerModelFromMetadata(errorUsageMetadata(error), providerMetadata.model),
+            status: 'failed',
+            sessionId: options.sessionId,
+            distillRunId: distillRun.id,
+            metadata: errorUsageMetadata(error),
+            startedAt: distillRun.createdAt,
+            completedAt: new Date().toISOString(),
+          });
           store.failDistillRun({
             id: distillRun.id,
             error,
@@ -4946,6 +5045,18 @@ export function createContextForge(options = {}) {
         try {
           output = validateDistillOutput(rawOutput);
         } catch (error) {
+          recordLlmUsageEvent(store, {
+            scope,
+            operation: 'checkpoint_distill',
+            provider: provider.name,
+            model: providerModelFromMetadata(rawOutput?.metadata || {}, providerMetadata.model),
+            status: 'failed',
+            sessionId: options.sessionId,
+            distillRunId: distillRun.id,
+            metadata: rawOutput?.metadata || {},
+            startedAt: distillRun.createdAt,
+            completedAt: new Date().toISOString(),
+          });
           store.failDistillRun({
             id: distillRun.id,
             error,
@@ -5050,6 +5161,18 @@ export function createContextForge(options = {}) {
         }
 
         if (checkpointError) {
+          recordLlmUsageEvent(store, {
+            scope,
+            operation: 'checkpoint_distill',
+            provider: output.provider || provider.name,
+            model: providerModelFromMetadata(output.metadata, providerMetadata.model),
+            status: 'succeeded',
+            sessionId: options.sessionId,
+            distillRunId: distillRun.id,
+            metadata: output.metadata,
+            startedAt: distillRun.createdAt,
+            completedAt: new Date().toISOString(),
+          });
           store.failDistillRun({
             id: distillRun.id,
             error: checkpointError,
@@ -5152,7 +5275,7 @@ export function createContextForge(options = {}) {
                   decision: 'needs_review',
                   reason: `Automatic candidate audit failed: ${error.message}`,
                   riskCodes: ['audit_failed'],
-                  metadata: { errorName: error.name },
+                  metadata: { ...(auditor?.metadata || {}), ...errorUsageMetadata(error), errorName: error.name },
                 };
               }
               recordCandidateAuditUsageEvent(store, {
@@ -5161,6 +5284,7 @@ export function createContextForge(options = {}) {
                 audit,
                 sessionId: options.sessionId,
                 checkpointId: checkpoint.id,
+                status: audit.riskCodes?.includes('audit_failed') ? 'failed' : 'succeeded',
               });
               const auditedCandidate = store.markMemoryCandidateAudited({
                 ...scope,
@@ -5233,7 +5357,7 @@ export function createContextForge(options = {}) {
         recordLlmUsageEvent(store, {
           scope,
           operation: 'checkpoint_distill',
-          provider: checkpoint.provider,
+          provider: output.provider || provider.name,
           model: providerModelFromMetadata(output.metadata, providerMetadata.model),
           status: 'succeeded',
           sessionId: options.sessionId,
@@ -5331,6 +5455,57 @@ export function createContextForge(options = {}) {
           limit: options.limit == null ? 25 : Number(options.limit),
         }),
       );
+    },
+
+    listLlmUsageEvents(options) {
+      const scope = normalizeScopeOptions(options, config);
+      return useStore((store) =>
+        store.listLlmUsageEvents({
+          ...scope,
+          sessionId: options.sessionId || null,
+          distillRunId: options.distillRunId || null,
+          checkpointId: options.checkpointId || null,
+          candidateId: options.candidateId || null,
+          operation: options.operation || null,
+          provider: options.provider || null,
+          limit: options.limit == null ? 100 : Number(options.limit),
+          order: options.order || 'desc',
+        }),
+      );
+    },
+
+    llmUsageRollup(options) {
+      const scope = normalizeScopeOptions(options, config);
+      const limit = options.limit == null ? 1000 : Number(options.limit);
+      return useStore((store) => {
+        const events = store.listLlmUsageEvents({
+          ...scope,
+          sessionId: options.sessionId || null,
+          distillRunId: options.distillRunId || null,
+          checkpointId: options.checkpointId || null,
+          candidateId: options.candidateId || null,
+          operation: options.operation || null,
+          provider: options.provider || null,
+          limit,
+          order: options.order || 'desc',
+        });
+        return {
+          scopeType: scope.scopeType,
+          scopeKey: scope.scopeKey,
+          filters: {
+            sessionId: options.sessionId || null,
+            distillRunId: options.distillRunId || null,
+            checkpointId: options.checkpointId || null,
+            candidateId: options.candidateId || null,
+            operation: options.operation || null,
+            provider: options.provider || null,
+            limit,
+            order: options.order || 'desc',
+          },
+          totals: summarizeLlmUsageEvents(events),
+          events: truthyOption(options.includeEvents) ? events : undefined,
+        };
+      });
     },
 
     distillUsage(options) {

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -626,6 +626,59 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
   );
 
   server.registerTool(
+    'list_llm_usage_events',
+    {
+      title: 'List LLM Usage Events',
+      description:
+        'List persisted normalized LLM usage events for a scope, optionally filtered by session, distill run, checkpoint, candidate, operation, or provider.',
+      inputSchema: {
+        ...scopedSchema,
+        sessionId: z.string().optional(),
+        distillRunId: z.string().optional(),
+        checkpointId: z.string().optional(),
+        candidateId: z.string().optional(),
+        operation: z.string().optional(),
+        provider: z.string().optional(),
+        limit: z.number().int().positive().optional(),
+        order: z.enum(['asc', 'desc']).optional(),
+      },
+      annotations: {
+        title: 'List LLM Usage Events',
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.listLlmUsageEvents(args)),
+  );
+
+  server.registerTool(
+    'llm_usage_rollup',
+    {
+      title: 'LLM Usage Rollup',
+      description:
+        'Report persisted LLM usage totals by operation, provider/model, and provider/model/operation for a scope.',
+      inputSchema: {
+        ...scopedSchema,
+        sessionId: z.string().optional(),
+        distillRunId: z.string().optional(),
+        checkpointId: z.string().optional(),
+        candidateId: z.string().optional(),
+        operation: z.string().optional(),
+        provider: z.string().optional(),
+        limit: z.number().int().positive().optional(),
+        order: z.enum(['asc', 'desc']).optional(),
+        includeEvents: z.boolean().optional(),
+      },
+      annotations: {
+        title: 'LLM Usage Rollup',
+        readOnlyHint: true,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.llmUsageRollup(args)),
+  );
+
+  server.registerTool(
     'list_memory_events',
     {
       title: 'List Memory Events',

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -49,6 +49,8 @@ const REMOTE_METHODS = [
   'distillCheckpoint',
   'listDistillRuns',
   'listRecentDistillRuns',
+  'listLlmUsageEvents',
+  'llmUsageRollup',
   'distillUsage',
 ];
 

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -597,7 +597,7 @@ export class ContextForgeStore {
         operation TEXT NOT NULL,
         provider TEXT NOT NULL,
         model TEXT,
-        status TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('started', 'succeeded', 'failed')),
         session_id TEXT,
         distill_run_id TEXT,
         checkpoint_id TEXT,
@@ -3226,6 +3226,9 @@ export class ContextForgeStore {
     completedAt = null,
     elapsedMs = null,
   }) {
+    if (!['started', 'succeeded', 'failed'].includes(status)) {
+      throw new Error('LLM usage event status must be started, succeeded, or failed.');
+    }
     const row = this.db
       .prepare(`
         INSERT INTO llm_usage_events (

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -4,7 +4,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import Database from 'better-sqlite3';
 import * as sqliteVec from 'sqlite-vec';
 
-export const SCHEMA_VERSION = 16;
+export const SCHEMA_VERSION = 17;
 
 function nowIso() {
   return new Date().toISOString();
@@ -105,6 +105,34 @@ function hydrateDistillRun(row) {
     errorStack: row.error_stack,
     createdAt: row.created_at,
     completedAt: row.completed_at,
+  };
+}
+
+function hydrateLlmUsageEvent(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    scopeType: row.scope_type,
+    scopeKey: row.scope_key,
+    operation: row.operation,
+    provider: row.provider,
+    model: row.model,
+    status: row.status,
+    sessionId: row.session_id,
+    distillRunId: row.distill_run_id,
+    checkpointId: row.checkpoint_id,
+    candidateId: row.candidate_id,
+    inputTokens: row.input_tokens,
+    cachedInputTokens: row.cached_input_tokens,
+    uncachedInputTokens: row.uncached_input_tokens,
+    outputTokens: row.output_tokens,
+    reasoningTokens: row.reasoning_tokens,
+    totalTokens: row.total_tokens,
+    usage: parseJson(row.usage_json, {}),
+    estimated: Boolean(row.estimated),
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+    elapsedMs: row.elapsed_ms,
   };
 }
 
@@ -562,6 +590,34 @@ export class ContextForgeStore {
         completed_at TEXT
       );
 
+      CREATE TABLE IF NOT EXISTS llm_usage_events (
+        id TEXT PRIMARY KEY,
+        scope_type TEXT NOT NULL CHECK (scope_type IN ('shared', 'repo', 'local')),
+        scope_key TEXT NOT NULL,
+        operation TEXT NOT NULL,
+        provider TEXT NOT NULL,
+        model TEXT,
+        status TEXT NOT NULL,
+        session_id TEXT,
+        distill_run_id TEXT,
+        checkpoint_id TEXT,
+        candidate_id TEXT,
+        input_tokens INTEGER,
+        cached_input_tokens INTEGER,
+        uncached_input_tokens INTEGER,
+        output_tokens INTEGER,
+        reasoning_tokens INTEGER,
+        total_tokens INTEGER,
+        usage_json TEXT NOT NULL DEFAULT '{}',
+        estimated INTEGER NOT NULL DEFAULT 0 CHECK (estimated IN (0, 1)),
+        started_at TEXT NOT NULL,
+        completed_at TEXT,
+        elapsed_ms INTEGER,
+        FOREIGN KEY (distill_run_id) REFERENCES distill_runs(id) ON DELETE SET NULL,
+        FOREIGN KEY (checkpoint_id) REFERENCES checkpoints(id) ON DELETE SET NULL,
+        FOREIGN KEY (candidate_id) REFERENCES memory_candidate_index(id) ON DELETE SET NULL
+      );
+
       CREATE TABLE IF NOT EXISTS runtime_settings (
         key TEXT PRIMARY KEY,
         value_json TEXT NOT NULL,
@@ -746,6 +802,14 @@ export class ContextForgeStore {
         ON checkpoints(scope_type, scope_key, session_id, created_at);
       CREATE INDEX IF NOT EXISTS idx_distill_runs_session
         ON distill_runs(scope_type, scope_key, session_id, created_at);
+      CREATE INDEX IF NOT EXISTS idx_llm_usage_events_scope
+        ON llm_usage_events(scope_type, scope_key, started_at);
+      CREATE INDEX IF NOT EXISTS idx_llm_usage_events_session
+        ON llm_usage_events(scope_type, scope_key, session_id, started_at);
+      CREATE INDEX IF NOT EXISTS idx_llm_usage_events_distill_run
+        ON llm_usage_events(distill_run_id);
+      CREATE INDEX IF NOT EXISTS idx_llm_usage_events_candidate
+        ON llm_usage_events(candidate_id);
       CREATE INDEX IF NOT EXISTS idx_runtime_settings_secret
         ON runtime_settings(secret, updated_at);
       CREATE INDEX IF NOT EXISTS idx_working_summaries_scope
@@ -837,6 +901,7 @@ export class ContextForgeStore {
         rawEvents: count('raw_events'),
         checkpoints: count('checkpoints'),
         distillRuns: count('distill_runs'),
+        llmUsageEvents: count('llm_usage_events'),
         runtimeSettings: count('runtime_settings'),
         workingSummaries: count('working_summaries'),
         sessionWorkingContexts: count('session_working_context'),
@@ -3136,6 +3201,121 @@ export class ContextForgeStore {
         id,
       );
     return hydrateDistillRun(row);
+  }
+
+  insertLlmUsageEvent({
+    scopeType,
+    scopeKey,
+    operation,
+    provider,
+    model = null,
+    status = 'succeeded',
+    sessionId = null,
+    distillRunId = null,
+    checkpointId = null,
+    candidateId = null,
+    inputTokens = null,
+    cachedInputTokens = null,
+    uncachedInputTokens = null,
+    outputTokens = null,
+    reasoningTokens = null,
+    totalTokens = null,
+    usage = {},
+    estimated = false,
+    startedAt = nowIso(),
+    completedAt = null,
+    elapsedMs = null,
+  }) {
+    const row = this.db
+      .prepare(`
+        INSERT INTO llm_usage_events (
+          id, scope_type, scope_key, operation, provider, model, status,
+          session_id, distill_run_id, checkpoint_id, candidate_id,
+          input_tokens, cached_input_tokens, uncached_input_tokens,
+          output_tokens, reasoning_tokens, total_tokens, usage_json,
+          estimated, started_at, completed_at, elapsed_ms
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        RETURNING *
+      `)
+      .get(
+        randomUUID(),
+        scopeType,
+        scopeKey,
+        operation,
+        provider,
+        model,
+        status,
+        sessionId,
+        distillRunId,
+        checkpointId,
+        candidateId,
+        inputTokens == null ? null : Number(inputTokens),
+        cachedInputTokens == null ? null : Number(cachedInputTokens),
+        uncachedInputTokens == null ? null : Number(uncachedInputTokens),
+        outputTokens == null ? null : Number(outputTokens),
+        reasoningTokens == null ? null : Number(reasoningTokens),
+        totalTokens == null ? null : Number(totalTokens),
+        json(usage, {}),
+        estimated ? 1 : 0,
+        startedAt,
+        completedAt,
+        elapsedMs == null ? null : Number(elapsedMs),
+      );
+    return hydrateLlmUsageEvent(row);
+  }
+
+  listLlmUsageEvents({
+    scopeType,
+    scopeKey,
+    sessionId = null,
+    distillRunId = null,
+    checkpointId = null,
+    candidateId = null,
+    operation = null,
+    provider = null,
+    limit = null,
+    order = 'asc',
+  }) {
+    const filters = ['scope_type = ?', 'scope_key = ?'];
+    const values = [scopeType, scopeKey];
+    if (sessionId) {
+      filters.push('session_id = ?');
+      values.push(sessionId);
+    }
+    if (distillRunId) {
+      filters.push('distill_run_id = ?');
+      values.push(distillRunId);
+    }
+    if (checkpointId) {
+      filters.push('checkpoint_id = ?');
+      values.push(checkpointId);
+    }
+    if (candidateId) {
+      filters.push('candidate_id = ?');
+      values.push(candidateId);
+    }
+    if (operation) {
+      filters.push('operation = ?');
+      values.push(operation);
+    }
+    if (provider) {
+      filters.push('provider = ?');
+      values.push(provider);
+    }
+    const parsedLimit = limit == null ? null : Number(limit);
+    const limitClause = Number.isInteger(parsedLimit) && parsedLimit > 0 ? 'LIMIT ?' : '';
+    if (limitClause) values.push(parsedLimit);
+    const orderDirection = order === 'desc' ? 'DESC' : 'ASC';
+    return this.db
+      .prepare(`
+        SELECT * FROM llm_usage_events
+        WHERE ${filters.join(' AND ')}
+        ORDER BY started_at ${orderDirection}, id ${orderDirection}
+        ${limitClause}
+      `)
+      .all(...values)
+      .map(hydrateLlmUsageEvent);
   }
 
   listDistillRuns({ scopeType, scopeKey, sessionId = null, status = null, provider = null, limit = null, order = 'asc' }) {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -5711,8 +5711,30 @@ test('distillUsage summarizes estimated and actual provider usage', async () => 
     promptCacheMissTokens: 32,
     promptCacheHitRatio: 10 / 42,
   });
+  assert.equal(usage.totals.persistedUsage.events, 1);
+  assert.equal(usage.totals.persistedUsage.inputTokens, 42);
+  assert.equal(usage.totals.persistedUsage.cachedInputTokens, 10);
+  assert.equal(usage.totals.persistedUsage.uncachedInputTokens, 32);
+  assert.equal(usage.totals.persistedUsage.outputTokens, 8);
+  assert.equal(usage.totals.persistedUsage.totalTokens, 50);
+  assert.equal(usage.totals.persistedUsage.byOperation.checkpoint_distill.events, 1);
+  assert.equal(usage.totals.persistedUsage.byProviderModel.usage_provider.events, 1);
   assert.equal(usage.runs[0].usage.totalTokens, 50);
   assert.equal(usage.runs[0].usage.promptCacheHitTokens, 10);
+
+  const store = new ContextForgeStore({ dataDir });
+  const events = store.listLlmUsageEvents({
+    scopeType: 'repo',
+    scopeKey: 'repo-usage',
+    sessionId: 'usage-session',
+  });
+  assert.equal(events.length, 1);
+  assert.equal(events[0].operation, 'checkpoint_distill');
+  assert.equal(events[0].inputTokens, 42);
+  assert.equal(events[0].cachedInputTokens, 10);
+  assert.equal(events[0].uncachedInputTokens, 32);
+  assert.equal(events[0].usage.prompt_cache_hit_tokens, 10);
+  store.close();
 });
 
 test('distillUsage averages elapsed time across completed runs only', async () => {
@@ -7349,6 +7371,17 @@ test('auditMemoryCandidates returns audited read-only recommendations', async ()
           provider: 'codex_exec',
           model: 'gpt-5.5',
           reasoningEffort: 'low',
+          usage: {
+            prompt_tokens: 100,
+            completion_tokens: 25,
+            total_tokens: 125,
+            prompt_tokens_details: {
+              cached_tokens: 40,
+            },
+            completion_tokens_details: {
+              reasoning_tokens: 7,
+            },
+          },
         },
       };
     },
@@ -7425,6 +7458,26 @@ test('auditMemoryCandidates returns audited read-only recommendations', async ()
   });
   assert.equal(pendingCandidates.length, 1);
   assert.equal(pendingCandidates[0].candidate.key, 'audited-readonly-runbook');
+
+  const store = new ContextForgeStore({ dataDir });
+  const events = store.listLlmUsageEvents({
+    scopeType: 'repo',
+    scopeKey: 'audit-suggestions-repo',
+    sessionId: 'audit-suggestions-session',
+  });
+  assert.equal(events.length, 1);
+  assert.equal(events[0].operation, 'candidate_audit');
+  assert.equal(events[0].provider, 'codex_exec');
+  assert.equal(events[0].model, 'gpt-5.5');
+  assert.equal(events[0].checkpointId, checkpoint.id);
+  assert.equal(events[0].candidateId, pendingCandidates[0].id);
+  assert.equal(events[0].inputTokens, 100);
+  assert.equal(events[0].cachedInputTokens, 40);
+  assert.equal(events[0].uncachedInputTokens, 60);
+  assert.equal(events[0].outputTokens, 25);
+  assert.equal(events[0].reasoningTokens, 7);
+  assert.equal(events[0].totalTokens, 125);
+  store.close();
 });
 
 test('auditMemoryCandidates audits review candidates and skips noisy events before runner', async () => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -355,6 +355,7 @@ test('dbInfo initializes a fresh SQLite store', async () => {
 
   assert.equal(info.schemaVersion, SCHEMA_VERSION);
   assert.equal(info.tables.memories, 0);
+  assert.equal(info.tables.llmUsageEvents, 0);
   assert.equal(info.tables.embeddingJobs, 0);
   assert.equal(info.embeddings.requiredForQuality, true);
   assert.equal(info.embeddings.staleAfterMs, 10 * 60 * 1000);
@@ -5719,6 +5720,9 @@ test('distillUsage summarizes estimated and actual provider usage', async () => 
   assert.equal(usage.totals.persistedUsage.totalTokens, 50);
   assert.equal(usage.totals.persistedUsage.byOperation.checkpoint_distill.events, 1);
   assert.equal(usage.totals.persistedUsage.byProviderModel.usage_provider.events, 1);
+  assert.equal(usage.totals.persistedUsage.byProviderModelOperation['usage_provider:checkpoint_distill'].events, 1);
+  assert.equal(usage.totals.canonicalUsage.source, 'persisted_usage_events');
+  assert.equal(usage.totals.canonicalUsage.totalTokens, 50);
   assert.equal(usage.runs[0].usage.totalTokens, 50);
   assert.equal(usage.runs[0].usage.promptCacheHitTokens, 10);
 
@@ -5735,6 +5739,16 @@ test('distillUsage summarizes estimated and actual provider usage', async () => 
   assert.equal(events[0].uncachedInputTokens, 32);
   assert.equal(events[0].usage.prompt_cache_hit_tokens, 10);
   store.close();
+
+  const rollup = app.llmUsageRollup({
+    scope: 'repo',
+    scopeKey: 'repo-usage',
+    sessionId: 'usage-session',
+  });
+  assert.equal(rollup.totals.events, 1);
+  assert.equal(rollup.totals.byOperation.checkpoint_distill.totalTokens, 50);
+  assert.equal(rollup.totals.byProviderModel.usage_provider.inputTokens, 42);
+  assert.equal(rollup.totals.byProviderModelOperation['usage_provider:checkpoint_distill'].outputTokens, 8);
 });
 
 test('distillUsage averages elapsed time across completed runs only', async () => {
@@ -7480,6 +7494,89 @@ test('auditMemoryCandidates returns audited read-only recommendations', async ()
   store.close();
 });
 
+test('auditMemoryCandidates records failed audit usage when error metadata includes usage', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'audit_failure_usage_provider',
+    },
+    cwd: process.cwd(),
+    autoPromoteAuditor: async () => {
+      const error = new Error('Synthetic audit transport failure.');
+      error.metadata = {
+        provider: 'codex_sdk_python',
+        model: 'gpt-5.5',
+        usage: {
+          input_tokens: 30,
+          output_tokens: 4,
+          total_tokens: 34,
+          input_tokens_details: {
+            cached_tokens: 12,
+          },
+        },
+      };
+      throw error;
+    },
+    distillProviders: {
+      audit_failure_usage_provider: async () => ({
+        summaryShort: 'Audit failure usage checkpoint.',
+        summaryText: 'Closeout produced a candidate whose audit fails after usage is known.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'audit-failure-usage-runbook',
+            content: 'Failed audit calls should preserve token usage when providers expose it.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.96,
+            stability: 0.96,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'audit-failure-usage-repo',
+    sessionId: 'audit-failure-usage-session',
+    role: 'assistant',
+    content: 'Failed audit usage should be preserved.',
+  });
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'audit-failure-usage-repo',
+    sessionId: 'audit-failure-usage-session',
+  });
+
+  const result = await app.auditMemoryCandidates({
+    scope: 'repo',
+    scopeKey: 'audit-failure-usage-repo',
+    checkpointId: checkpoint.id,
+    trigger: 'manual_closeout',
+  });
+  assert.equal(result.proposals.length, 1);
+  assert.equal(result.proposals[0].recommendedAction, 'review');
+
+  const events = app.listLlmUsageEvents({
+    scope: 'repo',
+    scopeKey: 'audit-failure-usage-repo',
+    sessionId: 'audit-failure-usage-session',
+  });
+  assert.equal(events.length, 1);
+  assert.equal(events[0].operation, 'candidate_audit');
+  assert.equal(events[0].status, 'failed');
+  assert.equal(events[0].provider, 'codex_sdk_python');
+  assert.equal(events[0].inputTokens, 30);
+  assert.equal(events[0].cachedInputTokens, 12);
+  assert.equal(events[0].uncachedInputTokens, 18);
+  assert.equal(events[0].totalTokens, 34);
+});
+
 test('auditMemoryCandidates audits review candidates and skips noisy events before runner', async () => {
   const dataDir = await makeTempDir();
   const auditInvocations = [];
@@ -7728,6 +7825,11 @@ test('distillCheckpoint automatically audits session candidate batches', async (
           provider: 'codex_sdk_python',
           model: 'gpt-5.5',
           reasoningEffort: 'low',
+          usage: {
+            input_tokens: 20,
+            output_tokens: 5,
+            total_tokens: 25,
+          },
         },
       };
     },
@@ -7791,6 +7893,23 @@ test('distillCheckpoint automatically audits session candidate batches', async (
   assert.equal(candidates.length, 2);
   assert.ok(candidates.every((candidate) => candidate.reviewMetadata.audit?.metadata?.model === 'gpt-5.5'));
   assert.ok(candidates.every((candidate) => candidate.reviewMetadata.auditMetadata?.sourceMode === 'threshold_batch'));
+  const usageEvents = app.listLlmUsageEvents({
+    scope: 'repo',
+    scopeKey: 'batch-audit-repo',
+    sessionId: 'batch-audit-session',
+    operation: 'candidate_audit',
+    order: 'asc',
+  });
+  assert.equal(usageEvents.length, 2);
+  assert.ok(usageEvents.every((event) => event.distillRunId === checkpoint.distillRunId));
+  assert.deepEqual(
+    usageEvents.map((event) => event.candidateId).sort(),
+    candidates.map((candidate) => candidate.id).sort(),
+  );
+  assert.deepEqual(
+    usageEvents.map((event) => event.totalTokens),
+    [25, 25],
+  );
 
   const storedAudit = await app.auditMemoryCandidates({
     scope: 'repo',
@@ -9513,6 +9632,8 @@ test('REMOTE_METHODS exposes resume, suggestion, auto-promotion, and reconciliat
   assert.ok(REMOTE_METHODS.includes('checkDistillProvider'));
   assert.ok(REMOTE_METHODS.includes('listScopeKeys'));
   assert.ok(REMOTE_METHODS.includes('listRecentDistillRuns'));
+  assert.ok(REMOTE_METHODS.includes('listLlmUsageEvents'));
+  assert.ok(REMOTE_METHODS.includes('llmUsageRollup'));
   assert.ok(REMOTE_METHODS.includes('listDueDistillSessions'));
   assert.ok(REMOTE_METHODS.includes('processDueDistills'));
   assert.ok(REMOTE_METHODS.includes('listMemories'));
@@ -9656,6 +9777,39 @@ test('CLI supports the v0 workflow with synthetic data', async () => {
   );
   assert.match(usage.stdout, /"estimatedInputTokens":/);
   assert.match(usage.stdout, /"runs": 1/);
+
+  const usageRollup = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'llmUsageRollup',
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'cli-repo',
+      '--sessionId',
+      'cli-session',
+    ],
+    { env },
+  );
+  assert.match(usageRollup.stdout, /"byOperation":/);
+  assert.match(usageRollup.stdout, /"events":/);
+
+  const usageEvents = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'listLlmUsageEvents',
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'cli-repo',
+      '--sessionId',
+      'cli-session',
+    ],
+    { env },
+  );
+  assert.match(usageEvents.stdout, /\[/);
 });
 
 test('MCP stdio server exposes core tools for synthetic integration', async () => {
@@ -9697,10 +9851,12 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'list_due_consolidations',
       'list_due_distill_sessions',
       'list_embedding_jobs',
+      'list_llm_usage_events',
       'list_memory_candidates',
       'list_memory_events',
       'list_memory_update_candidates',
       'list_preference_occurrences',
+      'llm_usage_rollup',
       'migrate_scope',
       'process_consolidations',
       'process_due_distills',
@@ -9752,6 +9908,12 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     assert.ok(listCheckpointsTool.inputSchema.properties.level);
     const distillUsageTool = toolList.tools.find((tool) => tool.name === 'distill_usage');
     assert.ok(distillUsageTool.inputSchema.properties.charsPerToken);
+    const llmUsageRollupTool = toolList.tools.find((tool) => tool.name === 'llm_usage_rollup');
+    assert.ok(llmUsageRollupTool.inputSchema.properties.operation);
+    assert.ok(llmUsageRollupTool.inputSchema.properties.includeEvents);
+    const listLlmUsageEventsTool = toolList.tools.find((tool) => tool.name === 'list_llm_usage_events');
+    assert.ok(listLlmUsageEventsTool.inputSchema.properties.distillRunId);
+    assert.ok(listLlmUsageEventsTool.inputSchema.properties.provider);
     const processEmbeddingJobsTool = toolList.tools.find((tool) => tool.name === 'process_embedding_jobs');
     assert.ok(processEmbeddingJobsTool.inputSchema.properties.retryFailed);
     const listEmbeddingJobsTool = toolList.tools.find((tool) => tool.name === 'list_embedding_jobs');


### PR DESCRIPTION
## 요약
- llm_usage_events 테이블을 추가하고 schema version을 17로 올렸습니다.
- checkpoint distill, checkpoint consolidation, candidate audit 호출에서 provider usage metadata가 있을 때 정규화된 usage event를 저장합니다.
- distillUsage가 persisted usage totals를 operation/provider-model 기준으로 함께 보고하도록 확장했습니다.
- checkpoint usage와 candidate audit usage 저장 테스트를 추가했습니다.

## 검증
- npm test pass: 162 tests
- git diff --check pass

## 후속
- 실제 codex_exec/codex_sdk_python runner 출력에서 usage metadata를 어느 형태로 받을 수 있는지 확인하고 provider별 extraction을 더 연결해야 합니다.
- 별도 CLI/MCP usage rollup 전용 명령은 아직 만들지 않았고, 현재는 distillUsage 응답에 persisted totals를 포함합니다.

Refs #136