### PR TITLE
Define session-first memory consult policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1572,18 +1572,26 @@ server's env files, service manager, or local database. When available, use
 `db_info` or `bootstrap_context` `connection.summary` or `connection.accessMode`
 as the live access-path check.
 For loose continuation prompts like "yesterday", "continue", "previous work",
-issue/PR follow-up, or cross-agent handoff, agents should call
-`bootstrap_context` or `bootstrapContext` early. The bootstrap response includes
-`handoff.latestCheckpoints` independently of search ranking, then reviews
-repo-scoped `memory`, `checkpoint`, and `memory_candidate` hits as context
-candidates, optionally includes up to three shared-scope hits, exposes
-`handoff.latestConsolidation` for thread/repo period context when available,
-and reports `memoryLifecycle` so agents can notice stale or missing
-candidate/promotion flow. It then reminds the agent to verify current branch,
-issue/PR, CI, migration, and runtime state against live sources before acting.
-Agents should read latest checkpoints and consolidation before durable memory
-for fast-moving work status; durable memory remains the stable
-policy/contract/runbook layer.
+issue/PR follow-up, context compaction, or cross-agent handoff, agents should
+call `bootstrap_context` or `bootstrapContext` early with an explicit
+`consultReason` such as `resume`, `compaction_recovery`, or `agent_switch`.
+The bootstrap response includes `handoff.latestCheckpoints` independently of
+search ranking, then reviews repo-scoped `memory`, `checkpoint`, and
+`memory_candidate` hits as context candidates, optionally includes up to three
+shared-scope hits, exposes `handoff.latestConsolidation` for thread/repo period
+context when available, and reports `memoryLifecycle` so agents can notice
+stale or missing candidate/promotion flow. It then reminds the agent to verify
+current branch, issue/PR, CI, migration, and runtime state against live sources
+before acting. Agents should read latest checkpoints and consolidation before
+durable memory for fast-moving work status only when the consult reason is
+startup/resume/compaction recovery/agent switch; durable memory remains the
+stable policy/contract/runbook layer.
+
+Inside the same uninterrupted active session, current conversation context is
+the source for current intent. Do not call `bootstrap_context` merely to
+re-confirm what was just discussed. Use targeted `search` for file/API/error or
+domain lookups, and use `db_info`, SQL, git, GitHub, health checks, or service
+manager state for mutable runtime facts.
 
 When resuming a known session, pass `sessionId` to `bootstrap_context` or
 `bootstrapContext`. ContextForge will include the session's latest

--- a/README.md
+++ b/README.md
@@ -1582,10 +1582,12 @@ shared-scope hits, exposes `handoff.latestConsolidation` for thread/repo period
 context when available, and reports `memoryLifecycle` so agents can notice
 stale or missing candidate/promotion flow. It then reminds the agent to verify
 current branch, issue/PR, CI, migration, and runtime state against live sources
-before acting. Agents should read latest checkpoints and consolidation before
-durable memory for fast-moving work status only when the consult reason is
-startup/resume/compaction recovery/agent switch; durable memory remains the
-stable policy/contract/runbook layer.
+before acting. Only for startup, resume, compaction recovery, or agent switch,
+agents should read latest checkpoints and consolidation before durable memory
+for fast-moving work status; durable memory remains the stable
+policy/contract/runbook layer. Legacy calls that omit `consultReason` are
+treated as `unknown`: latest handoff is still returned for compatibility, but
+the response warns callers to pass an explicit reason.
 
 Inside the same uninterrupted active session, current conversation context is
 the source for current intent. Do not call `bootstrap_context` merely to

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -25,9 +25,18 @@ Replace `github.com/example/repo` when a canonical scope key is required.
 ```text
 Use ContextForge MCP for scoped project memory when it is available.
 
-At task start, call `bootstrap_context` with this task, `scope: "repo"`, and
-this repo path or the canonical scope key `github.com/example/repo`. Include
-shared memory only when cross-repo or user-wide policy may matter.
+At task start, after context compaction, or when resuming prior work, call
+`bootstrap_context` with this task, `scope: "repo"`, this repo path or the
+canonical scope key `github.com/example/repo`, and an explicit
+`consultReason` such as `startup`, `resume`, `compaction_recovery`, or
+`agent_switch`. Include shared memory only when cross-repo or user-wide policy
+may matter.
+
+Do not call `bootstrap_context` just to re-confirm current intent inside the
+same uninterrupted active session. For active-session file/API/error/domain
+lookups, use targeted `search`. For runtime, DB, git, GitHub, CI, health, or
+deployment state, use live checks such as `db_info`, SQL, git, GitHub,
+`/healthz`, or the service manager.
 
 Before relying on retrieval, distinguish storage authority. Remote
 ContextForge storage is canonical shared memory for the configured scope;
@@ -61,9 +70,12 @@ Connection mode: external remote client. Storage authority: remote canonical
 ContextForge. Agents may be sandboxed and may not be able to inspect the
 ContextForge server env files, service manager, or local database.
 
-At task start, call `bootstrap_context` with `scope: "repo"` and the canonical
-scope key `github.com/example/repo`. Include shared scope only for user-wide
-policy, deployment, credential-location, or cross-repo conventions.
+At task start, after context compaction, or when resuming prior work, call
+`bootstrap_context` with `scope: "repo"`, the canonical scope key
+`github.com/example/repo`, and an explicit `consultReason` such as `startup`,
+`resume`, `compaction_recovery`, or `agent_switch`. Include shared scope only
+for user-wide policy, deployment, credential-location, or cross-repo
+conventions.
 
 Read `handoff.latestCheckpoints` before durable memory for recent work status,
 recent decisions, open todos, branch/PR/CI flow, and next actions. Treat
@@ -82,6 +94,11 @@ ranking. Use `sync_resume_context` only when the exact session id is known and
 session working state or raw tail is needed. Use checkpoints for prior intent,
 recent decisions, and unfinished work, then verify current git/GitHub/CI/runtime
 state from live sources.
+
+Inside the same uninterrupted active session, current conversation context is
+the source for current intent. Do not use latest handoff as routine
+self-confirmation. Use targeted `search` for stable memory lookup by
+file/API/error/domain names, and use live source checks for mutable state.
 
 Use the installed `contextforge-memory` skill for session IDs, distillation,
 checkpoint consolidation, candidate review, closeout promotion, correction, and

--- a/docs/skills/contextforge-memory/SKILL.md
+++ b/docs/skills/contextforge-memory/SKILL.md
@@ -77,11 +77,30 @@ Before relying on results, check connection metadata and storage authority from 
 - `remote-client` access means server-backed canonical memory for the configured scope.
 - `direct-local` with `local` or `project-local` storage is local context unless the repo `AGENTS.md` says otherwise.
 
+## Session-First Consult Policy
+
+Latest handoff is for continuity recovery. Do not use it as routine
+self-confirmation when the current uninterrupted session still contains the
+user's intent and recent decisions.
+
+Use paths by reason:
+
+- `startup`, `resume`, `compaction_recovery`, `agent_switch`: call
+  `bootstrap_context` with that `consultReason` and read latest handoff.
+- active uninterrupted session: proceed from current conversation context.
+- file/API/error/domain lookup during active work: use targeted `search`.
+- runtime/DB/git/GitHub/CI/health/deployment questions: use live checks such as
+  `db_info`, SQL, git, GitHub, `/healthz`, or service manager.
+
+If current session context conflicts with a handoff, prefer current context or
+live verification. Treat handoff as compressed stale-prone context.
+
 ## Startup Bootstrap
 
 At the start of non-trivial project work:
 
-1. Call `bootstrap_context` with a task-derived query, `scope: "repo"`, and `repoPath`, `cwd`, or explicit `scopeKey`.
+1. Call `bootstrap_context` with a task-derived query, `scope: "repo"`,
+   `repoPath`, `cwd`, or explicit `scopeKey`, and `consultReason: "startup"`.
 2. Read `handoff.latestHandoff` first when present. It is the deterministic
    newest handoff checkpoint and is loaded independently from search ranking.
 3. Inspect `handoff.latestHandoff.structured`, especially
@@ -120,7 +139,9 @@ When resuming a known session, pass that `sessionId` to `bootstrap_context`, `sy
 
 For "continue", "yesterday", prior issue/PR follow-up, or cross-agent handoff:
 
-1. Call `bootstrap_context` first; its latest checkpoint handoff is not dependent on semantic search ranking.
+1. Call `bootstrap_context` first with `consultReason: "resume"` or
+   `consultReason: "compaction_recovery"`; its latest checkpoint handoff is not
+   dependent on semantic search ranking.
 2. Prefer `handoff.latestHandoff` for the immediate resume state, then read
    other `handoff.latestCheckpoints` if more recent context is needed.
 3. Use `handoff.latestConsolidation` for broader thread/repo period context

--- a/src/cli.js
+++ b/src/cli.js
@@ -80,6 +80,7 @@ function toCoreOptions(options) {
     tags: Array.isArray(tags) ? tags : typeof tags === 'string' ? tags.split(',').filter(Boolean) : [],
     importance: options.importance == null ? 0 : Number(options.importance),
     query: options.query,
+    consultReason: options.consultReason,
     limit: options.limit == null ? 10 : Number(options.limit),
     searchScopes: options.searchScopes,
     sharedScopeKey: options.sharedScopeKey,

--- a/src/core.js
+++ b/src/core.js
@@ -164,6 +164,7 @@ function normalizeConsultReason(value) {
 
 function bootstrapConsultPolicy({ consultReason, latestCheckpointLimit, sessionId }) {
   const warnings = [];
+  // Machine-readable tokens used by API consumers; prose can use friendlier names.
   const recommendedTools = [];
   const handoffRecommended = RECOVERY_CONSULT_REASONS.has(consultReason);
   if (consultReason === 'unknown') {
@@ -209,7 +210,7 @@ function bootstrapConsultPolicy({ consultReason, latestCheckpointLimit, sessionI
     warnings.push({
       code: 'same_session_bootstrap_warning',
       message:
-        'This bootstrap call includes a sessionId during active-session work; repeated same-session bootstrap calls can inject stale compressed context.',
+        'This bootstrap call includes a sessionId during active-session work; same-session bootstrap can inject stale compressed context.',
     });
   }
   return {
@@ -2777,7 +2778,6 @@ export function createContextForge(options = {}) {
           summary: bootstrapSummary(results),
           results,
           nextActions: [
-            ...consultPolicy.warnings.map((warning) => warning.message),
             'Verify current git/GitHub/CI/runtime/migration state before final claims or risky actions.',
             'Review memory_candidate results at task end if durable lessons remain.',
           ],

--- a/src/core.js
+++ b/src/core.js
@@ -137,6 +137,94 @@ function positiveInteger(value, name) {
   return parsed;
 }
 
+const CONSULT_REASONS = new Set([
+  'startup',
+  'resume',
+  'compaction_recovery',
+  'agent_switch',
+  'targeted_search',
+  'live_state_check',
+  'active_session',
+  'unknown',
+]);
+
+const RECOVERY_CONSULT_REASONS = new Set(['startup', 'resume', 'compaction_recovery', 'agent_switch']);
+const ACTIVE_SESSION_CONSULT_REASONS = new Set(['active_session', 'targeted_search', 'live_state_check']);
+
+function normalizeConsultReason(value) {
+  const reason = String(value || 'unknown')
+    .trim()
+    .toLowerCase()
+    .replace(/[-\s]+/g, '_');
+  if (!CONSULT_REASONS.has(reason)) {
+    throw new Error(`consultReason must be one of: ${Array.from(CONSULT_REASONS).join(', ')}.`);
+  }
+  return reason;
+}
+
+function bootstrapConsultPolicy({ consultReason, latestCheckpointLimit, sessionId }) {
+  const warnings = [];
+  const recommendedTools = [];
+  const handoffRecommended = RECOVERY_CONSULT_REASONS.has(consultReason);
+  if (consultReason === 'unknown') {
+    warnings.push({
+      code: 'consult_reason_unknown',
+      message:
+        'Pass consultReason so agents can distinguish startup/resume recovery from active-session targeted lookup.',
+    });
+  }
+  if (ACTIVE_SESSION_CONSULT_REASONS.has(consultReason)) {
+    warnings.push({
+      code: 'active_session_handoff_not_self_check',
+      message:
+        'Current uninterrupted session context should remain authoritative for current intent; do not use latest handoff as routine self-confirmation.',
+    });
+    if (latestCheckpointLimit > 0) {
+      warnings.push({
+        code: 'latest_handoff_returned_for_context_only',
+        message:
+          'latestHandoff is still returned for compatibility, but should be ignored unless this is actually resume, compaction recovery, or agent transfer.',
+      });
+    }
+  }
+  if (consultReason === 'targeted_search') {
+    recommendedTools.push('search');
+    warnings.push({
+      code: 'prefer_search_for_targeted_lookup',
+      message: 'Use targeted search for file/API/error/domain lookups during an active session instead of full handoff bootstrap.',
+    });
+  }
+  if (consultReason === 'live_state_check') {
+    recommendedTools.push('db_info', 'git', 'gh', 'healthz', 'service_manager');
+    warnings.push({
+      code: 'prefer_live_sources_for_mutable_state',
+      message:
+        'Use live sources for mutable DB/git/GitHub/CI/runtime/deployment state; checkpoints are compressed handoff notes.',
+    });
+  }
+  if (consultReason === 'active_session') {
+    recommendedTools.push('current_conversation', 'search');
+  }
+  if (sessionId && ACTIVE_SESSION_CONSULT_REASONS.has(consultReason)) {
+    warnings.push({
+      code: 'same_session_bootstrap_warning',
+      message:
+        'This bootstrap call includes a sessionId during active-session work; repeated same-session bootstrap calls can inject stale compressed context.',
+    });
+  }
+  return {
+    reason: consultReason,
+    handoffRecommended,
+    latestHandoffUse: handoffRecommended
+      ? 'Use latest handoff for continuity recovery, then verify mutable live state.'
+      : 'Do not use latest handoff as routine self-confirmation while active session context is intact.',
+    targetedSearchUse: 'Use search for active-session file/API/error/domain lookups.',
+    liveStateUse: 'Use db_info, git, GitHub, health checks, service manager, SQL, or migrations for mutable state.',
+    warnings,
+    recommendedTools: [...new Set(recommendedTools)],
+  };
+}
+
 function withStore(config, fn) {
   const store = new ContextForgeStore({ dataDir: config.dataDir });
   try {
@@ -2557,6 +2645,12 @@ export function createContextForge(options = {}) {
         'latestCheckpointLimit',
         { min: 0, max: 3 },
       );
+      const consultReason = normalizeConsultReason(options.consultReason);
+      const consultPolicy = bootstrapConsultPolicy({
+        consultReason,
+        latestCheckpointLimit,
+        sessionId,
+      });
       const relatedScopeKeys = normalizeRelatedScopeKeys(options.relatedScopeKeys).filter(
         (scopeKey) => scopeKey !== scope.scopeKey,
       );
@@ -2660,6 +2754,7 @@ export function createContextForge(options = {}) {
           scope,
           storage: storageBootstrapInfo(config, info),
           query: options.query,
+          consult: consultPolicy,
           includeShared,
           sharedLimit: includeShared ? sharedLimit : null,
           handoff: {
@@ -2682,6 +2777,7 @@ export function createContextForge(options = {}) {
           summary: bootstrapSummary(results),
           results,
           nextActions: [
+            ...consultPolicy.warnings.map((warning) => warning.message),
             'Verify current git/GitHub/CI/runtime/migration state before final claims or risky actions.',
             'Review memory_candidate results at task end if durable lessons remain.',
           ],
@@ -2694,6 +2790,7 @@ export function createContextForge(options = {}) {
       const bootstrap = await this.bootstrapContext({
         ...options,
         limit: options.limit == null ? 8 : options.limit,
+        consultReason: options.consultReason || 'resume',
       });
       const durableMemories = [];
       const recentCheckpoints = [];
@@ -2732,6 +2829,7 @@ export function createContextForge(options = {}) {
         scope: bootstrap.scope,
         storage: bootstrap.storage,
         query: bootstrap.query,
+        consult: bootstrap.consult,
         includeShared: bootstrap.includeShared,
         ...(bootstrap.sessionId ? { sessionId: bootstrap.sessionId } : {}),
         handoff: {

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -5,6 +5,16 @@ import { z } from 'zod';
 import { createContextForge } from './core.js';
 
 const scopeSchema = z.enum(['shared', 'repo', 'local']);
+const consultReasonSchema = z.enum([
+  'startup',
+  'resume',
+  'compaction_recovery',
+  'agent_switch',
+  'targeted_search',
+  'live_state_check',
+  'active_session',
+  'unknown',
+]);
 const metadataSchema = z.record(z.string(), z.unknown());
 const optionalTags = z.array(z.string()).optional();
 
@@ -24,10 +34,11 @@ function jsonResult(result) {
 
 const MCP_INSTRUCTIONS = [
   'Use ContextForge for scoped memory retrieval on demand.',
-  'At the start of non-trivial project work, call bootstrap_context with repoPath, cwd, or an explicit scopeKey. It summarizes storage authority, vector readiness, query retrieval results, trust hints, and query-independent latest checkpoint handoff in one response.',
+  'At the start of non-trivial project work or after resume/compaction/agent transfer, call bootstrap_context with repoPath, cwd, or an explicit scopeKey and consultReason=startup/resume/compaction_recovery/agent_switch. It summarizes storage authority, vector readiness, query retrieval results, trust hints, and query-independent latest checkpoint handoff in one response.',
+  'Do not call bootstrap_context merely to re-confirm current active-session intent. During uninterrupted work, prefer current conversation context; use search for targeted file/API/error/domain lookups and db_info/git/GitHub/health checks/service manager for mutable live state.',
   'bootstrap_context does not create a session. In Codex or Claude Code auto-ingest environments, preserve or recover the adapter session id such as codex:<native-session-id> or claude_code:<native-session-id> before session_status, distill_checkpoint, or closeout promotion. Use begin_session only for manual ContextForge evidence streams where the agent will call append_raw itself; do not create a fresh cf_... session at closeout to review candidates from an existing Codex/Claude session.',
   'Use db_info connection metadata for access path: prefer connection.summary, then connection.accessMode/accessPath and connection.serverRole. connection.mode is kept for compatibility. Top-level storageMode describes the responding ContextForge process; connection.server may describe the server-owned store behind a remote call.',
-  'Read bootstrap_context.handoff.latestCheckpoints before durable memory for recent work status, recent decisions, open todos, branch/PR/CI flow, and next actions. Durable memory is for reviewed stable facts, contracts, policies, and runbooks. Verify mutable checkpoint claims with git/GitHub/CI/runtime/migrations before final action.',
+  'Read bootstrap_context.handoff.latestCheckpoints before durable memory only when the consult reason is startup, resume, compaction recovery, or agent switch. Durable memory is for reviewed stable facts, contracts, policies, and runbooks. Verify mutable checkpoint claims with git/GitHub/CI/runtime/migrations before final action.',
   'Search result types have different trust roles: memory is reviewed durable fact or decision; checkpoint is credible recent handoff state for continuity, planning, prior intent, recent decisions, and unfinished work, but mutable live-state claims must be verified with git/GitHub/CI/runtime/migrations before acting; memory_candidate is unreviewed promotion material and not durable truth.',
   'For task start or loose continuation prompts such as "지난 환경 작업과 동기화", "어제 하던 거 이어서", "previous work", or "continue", call bootstrap_context first; it includes latest checkpoint handoff independent of search ranking. Use sync_resume_context only when you know the exact sessionId and need session working state or raw tail.',
   'For closeout distillation, pass auditTrigger to distill_checkpoint. Candidate audit is automatic and batched: session pending candidates are audited after closeout triggers or once the configured batch threshold is reached. Audit results are stored on candidates; automatic promotion only controls whether approved strict-safe results are written to durable memory.',
@@ -118,10 +129,11 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Bootstrap Context',
       description:
-        'Resolve scoped ContextForge memory for a task in one call. Includes query-independent latest checkpoint handoff (default 1, max 3) before search results, searches repo scope semantically across memory, checkpoint, and memory_candidate results, optionally includes up to 3 shared-scope results, and annotates trust and verification hints for agents. Does not create a session; pass a known Codex/Claude/ContextForge sessionId to load session working state. rawTailLimit defaults to 0; set a positive value to include raw tail.',
+        'Resolve scoped ContextForge memory for startup/resume/compaction recovery in one call. Includes query-independent latest checkpoint handoff (default 1, max 3) before search results, but latest handoff is not a routine active-session self-confirmation source. Pass consultReason to distinguish startup/resume/compaction_recovery/agent_switch from active_session, targeted_search, or live_state_check. During active work, prefer search for file/API/error/domain lookups and live sources for mutable state. Does not create a session; pass a known Codex/Claude/ContextForge sessionId to load session working state. rawTailLimit defaults to 0; set a positive value to include raw tail.',
       inputSchema: {
         ...scopedSchema,
         query: z.string(),
+        consultReason: consultReasonSchema.optional(),
         sessionId: z.string().optional(),
         rawTailLimit: z.number().int().nonnegative().optional(),
         latestCheckpointLimit: z.number().int().min(0).max(3).optional(),
@@ -144,10 +156,11 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Sync Resume Context',
       description:
-        'Build a start/resume handoff package for continuing work across machines or agent environments. Use checkpoints as credible recent handoff notes, durable memories as canonical long-term context, and memory candidates only as review material. rawTailLimit defaults to 0; set a positive value to include raw tail. This tool must not propose or perform durable memory promotion.',
+        'Build a resume/compaction/agent-transfer handoff package for continuing work across machines or agent environments. Use checkpoints as credible recent handoff notes, durable memories as canonical long-term context, and memory candidates only as review material. Do not use this as routine active-session self-confirmation. rawTailLimit defaults to 0; set a positive value to include raw tail. This tool must not propose or perform durable memory promotion.',
       inputSchema: {
         ...scopedSchema,
         query: z.string(),
+        consultReason: consultReasonSchema.optional(),
         sessionId: z.string().optional(),
         includeShared: z.boolean().optional(),
         limit: z.number().int().positive().optional(),

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -4672,7 +4672,7 @@ test('bootstrapContext records session-first consult reasons and active-session 
   assert.equal(active.consult.handoffRecommended, false);
   assert.ok(active.consult.warnings.some((warning) => warning.code === 'active_session_handoff_not_self_check'));
   assert.ok(active.consult.warnings.some((warning) => warning.code === 'same_session_bootstrap_warning'));
-  assert.ok(active.nextActions.some((action) => /routine self-confirmation/.test(action)));
+  assert.ok(!active.nextActions.some((action) => /routine self-confirmation/.test(action)));
 
   const targeted = await app.bootstrapContext({
     scope: 'repo',
@@ -4699,6 +4699,22 @@ test('bootstrapContext records session-first consult reasons and active-session 
     consultReason: 'compaction_recovery',
   });
   assert.equal(compaction.consult.handoffRecommended, true);
+
+  const resume = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-consult-policy',
+    query: 'resume recovery',
+    consultReason: 'resume',
+  });
+  assert.equal(resume.consult.handoffRecommended, true);
+
+  const agentSwitch = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-consult-policy',
+    query: 'agent switch recovery',
+    consultReason: 'agent_switch',
+  });
+  assert.equal(agentSwitch.consult.handoffRecommended, true);
 
   await assert.rejects(
     () =>

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -4641,6 +4641,77 @@ test('bootstrapContext includes latest checkpoints independently from search res
   assert.equal(disabled.handoff.latestHandoff, null);
 });
 
+test('bootstrapContext records session-first consult reasons and active-session warnings', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'repo-consult-policy',
+    key: 'targeted-search-rule',
+    content: 'Use targeted search for active-session API lookup.',
+  });
+
+  const startup = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-consult-policy',
+    query: 'startup consult policy',
+    consultReason: 'startup',
+  });
+  assert.equal(startup.consult.reason, 'startup');
+  assert.equal(startup.consult.handoffRecommended, true);
+  assert.deepEqual(startup.consult.warnings, []);
+
+  const active = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-consult-policy',
+    sessionId: 'active-session',
+    query: 'active session consult policy',
+    consultReason: 'active_session',
+  });
+  assert.equal(active.consult.reason, 'active_session');
+  assert.equal(active.consult.handoffRecommended, false);
+  assert.ok(active.consult.warnings.some((warning) => warning.code === 'active_session_handoff_not_self_check'));
+  assert.ok(active.consult.warnings.some((warning) => warning.code === 'same_session_bootstrap_warning'));
+  assert.ok(active.nextActions.some((action) => /routine self-confirmation/.test(action)));
+
+  const targeted = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-consult-policy',
+    query: 'targeted API lookup',
+    consultReason: 'targeted_search',
+  });
+  assert.ok(targeted.consult.recommendedTools.includes('search'));
+  assert.ok(targeted.consult.warnings.some((warning) => warning.code === 'prefer_search_for_targeted_lookup'));
+
+  const liveState = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-consult-policy',
+    query: 'runtime status check',
+    consultReason: 'live_state_check',
+  });
+  assert.ok(liveState.consult.recommendedTools.includes('db_info'));
+  assert.ok(liveState.consult.warnings.some((warning) => warning.code === 'prefer_live_sources_for_mutable_state'));
+
+  const compaction = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'repo-consult-policy',
+    query: 'compaction recovery',
+    consultReason: 'compaction_recovery',
+  });
+  assert.equal(compaction.consult.handoffRecommended, true);
+
+  await assert.rejects(
+    () =>
+      app.bootstrapContext({
+        scope: 'repo',
+        scopeKey: 'repo-consult-policy',
+        query: 'bad consult reason',
+        consultReason: 'just_checking',
+      }),
+    /consultReason/,
+  );
+});
+
 test('processConsolidations creates scope-window checkpoints and bootstrap exposes them', async () => {
   const dataDir = await makeTempDir();
   const store = new ContextForgeStore({ dataDir });
@@ -9920,13 +9991,17 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     assert.ok(listEmbeddingJobsTool.inputSchema.properties.status);
     const bootstrapTool = toolList.tools.find((tool) => tool.name === 'bootstrap_context');
     assert.ok(bootstrapTool.inputSchema.properties.sessionId);
+    assert.ok(bootstrapTool.inputSchema.properties.consultReason);
     assert.ok(bootstrapTool.inputSchema.properties.rawTailLimit);
     assert.ok(bootstrapTool.inputSchema.properties.latestCheckpointLimit);
     assert.ok(bootstrapTool.inputSchema.properties.relatedScopeKeys);
     assert.ok(bootstrapTool.description.includes('Does not create a session'));
     assert.ok(bootstrapTool.description.includes('latest checkpoint handoff'));
+    assert.ok(bootstrapTool.description.includes('not a routine active-session self-confirmation source'));
     const syncResumeTool = toolList.tools.find((tool) => tool.name === 'sync_resume_context');
     assert.ok(syncResumeTool.inputSchema.properties.sessionId);
+    assert.ok(syncResumeTool.inputSchema.properties.consultReason);
+    assert.ok(syncResumeTool.description.includes('Do not use this as routine active-session self-confirmation'));
     const sessionWorkingContextTool = toolList.tools.find((tool) => tool.name === 'upsert_session_working_context');
     assert.ok(sessionWorkingContextTool.inputSchema.properties.currentTask);
     assert.ok(sessionWorkingContextTool.inputSchema.properties.avoidMisreadings);


### PR DESCRIPTION
## 요약
- bootstrapContext에 consultReason을 추가하고 startup/resume/compaction_recovery/agent_switch와 active_session/targeted_search/live_state_check를 구분합니다.
- active-session 계열 consultReason에서는 latest handoff를 routine self-confirmation으로 쓰지 말라는 warning과 대체 경로(search/live checks)를 응답에 포함합니다.
- syncResumeContext는 기본 consultReason을 resume으로 기록합니다.
- MCP instructions/tool description/schema와 CLI option pass-through를 업데이트했습니다.
- agent instruction docs와 packaged contextforge-memory skill 문서에 session-first consult policy를 추가했습니다.

## 검증
- npm test pass: 164 tests
- git diff --check pass

Refs #138
