### PR TITLE
Improve durable memory promotion quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1379,11 +1379,14 @@ works for compatibility.
 
 Candidate promotion performs lightweight review checks before writing durable
 memory. It blocks obvious duplicate keys, identical content under another key,
-high-sensitivity candidates, low confidence/stability signals, and candidates
-whose recommendation is `ignore` or `reject`. After manual review, pass
-`--allowWarnings true` to promote anyway. Already promoted or rejected
-candidates are protected from accidental re-review; pass
-`--allowStatusOverride true` only for explicit repair work.
+near-duplicate durable memories, refinement/supersede/conflict cases that should
+update an existing memory, high-sensitivity candidates, low
+confidence/stability signals, and candidates whose recommendation is `ignore` or
+`reject`. `importance` is clamped to the durable ranking range `0..10` before it
+can affect retrieval ordering. After manual review, pass `--allowWarnings true`
+to promote anyway. Already promoted or rejected candidates are protected from
+accidental re-review; pass `--allowStatusOverride true` only for explicit repair
+work.
 
 Promotion is intentional: checkpoints can suggest memory candidates, but durable
 memory is written only when a caller promotes a reviewed fact or decision.
@@ -1425,6 +1428,22 @@ node src/cli.js deactivateMemory \
   --key retrieval-policy \
   --reason "Superseded by a newer policy."
 ```
+
+When a candidate overlaps existing durable memory, prefer an update proposal
+over a new memory. `suggestMemoryPromotions --createUpdateCandidates true` can
+persist `memory_update_candidates` for refinement/supersede/conflict cases. To
+find existing duplicate durable memories without promoting anything, run:
+
+```bash
+node src/cli.js auditMemoryDuplicates \
+  --scope repo \
+  --scopeKey github.com/example/contextforge \
+  --minOverlap 0.82
+```
+
+Add `--createUpdateCandidates true` to persist reviewed
+`merge_duplicate_memories` proposals; applying them is still a separate approval
+step.
 
 Inactive memories are retained for provenance but excluded from search results.
 
@@ -1468,6 +1487,7 @@ The MCP server exposes a narrow tool surface over the same core API:
 - `list_memory_events`
 - `list_memory_candidates`
 - `list_memory_update_candidates`
+- `audit_memory_duplicates`
 - `append_raw`
 - `prune_raw_events`
 - `distill_checkpoint`

--- a/README.md
+++ b/README.md
@@ -1438,12 +1438,15 @@ find existing duplicate durable memories without promoting anything, run:
 node src/cli.js auditMemoryDuplicates \
   --scope repo \
   --scopeKey github.com/example/contextforge \
-  --minOverlap 0.82
+  --minOverlap 0.82 \
+  --scanLimit 250 \
+  --limit 20
 ```
 
 Add `--createUpdateCandidates true` to persist reviewed
 `merge_duplicate_memories` proposals; applying them is still a separate approval
-step.
+step. Duplicate auditing compares memory pairs inside the scanned window, so use
+`--scanLimit` deliberately for large scopes.
 
 Inactive memories are retained for provenance but excluded from search results.
 

--- a/docs/skills/contextforge-memory/SKILL.md
+++ b/docs/skills/contextforge-memory/SKILL.md
@@ -239,7 +239,9 @@ At closeout triggers only, make sure durable memory candidates are audited:
 
 Use `audit_memory_duplicates` to inspect existing active durable memories for
 merge candidates. It is read-only unless `createUpdateCandidates=true`, and even
-then it only creates `merge_duplicate_memories` review proposals.
+then it only creates `merge_duplicate_memories` review proposals. For large
+scopes, set `scanLimit` intentionally because duplicate audit compares memory
+pairs inside the scanned window.
 
 Use `auto_promote_memory_candidates` only when automatic write-side promotion is
 explicitly wanted. It must include `sessionId` or `checkpointId`; real promotion

--- a/docs/skills/contextforge-memory/SKILL.md
+++ b/docs/skills/contextforge-memory/SKILL.md
@@ -229,10 +229,17 @@ At closeout triggers only, make sure durable memory candidates are audited:
    durable memory.
 5. Promote only reviewed, stable, scoped, non-secret facts.
 6. Prefer `promote_memory_candidate` by `candidateId`.
-7. Use `remember` or `promote_memory` for a corrected durable write when the candidate key/content is wrong.
-8. Use `reject_memory_candidate` for wrong candidates.
+7. If `suggest_memory_promotions` reports a duplicate, refinement, supersedes,
+   or conflict assessment, prefer reviewing its `memory_update_candidates`
+   proposal over writing a new durable memory.
+8. Use `remember` or `promote_memory` for a corrected durable write when the candidate key/content is wrong.
+9. Use `reject_memory_candidate` for wrong candidates.
 
 `suggest_memory_promotions` defaults to `promotionRecommendation: "promote"`. If candidates exist but proposals are empty, inspect with `list_memory_candidates`; for `promotionRecommendation: "review"` candidates, either call `suggest_memory_promotions` with `promotionRecommendation: "review"` or manually review the listed candidates.
+
+Use `audit_memory_duplicates` to inspect existing active durable memories for
+merge candidates. It is read-only unless `createUpdateCandidates=true`, and even
+then it only creates `merge_duplicate_memories` review proposals.
 
 Use `auto_promote_memory_candidates` only when automatic write-side promotion is
 explicitly wanted. It must include `sessionId` or `checkpointId`; real promotion

--- a/src/cli.js
+++ b/src/cli.js
@@ -110,6 +110,7 @@ function toCoreOptions(options) {
     dryRun: options.dryRun == null ? undefined : options.dryRun === true || options.dryRun === 'true',
     minConfidence: options.minConfidence == null ? undefined : Number(options.minConfidence),
     minStability: options.minStability == null ? undefined : Number(options.minStability),
+    minOverlap: options.minOverlap == null ? undefined : Number(options.minOverlap),
     allowedCategories: options.allowedCategories
       ? String(options.allowedCategories)
           .split(',')
@@ -120,6 +121,7 @@ function toCoreOptions(options) {
     order: options.order,
     allowWarnings: options.allowWarnings === true || options.allowWarnings === 'true',
     allowStatusOverride: options.allowStatusOverride === true || options.allowStatusOverride === 'true',
+    createUpdateCandidates: options.createUpdateCandidates === true || options.createUpdateCandidates === 'true',
     reason: options.reason,
     live: options.live === true || options.live === 'true',
     minEvents: options.minEvents == null ? undefined : Number(options.minEvents),
@@ -244,6 +246,7 @@ async function main() {
     listMemoryCandidates: (app, coreOptions) => app.listMemoryCandidates(coreOptions),
     listPreferenceOccurrences: (app, coreOptions) => app.listPreferenceOccurrences(coreOptions),
     listMemoryUpdateCandidates: (app, coreOptions) => app.listMemoryUpdateCandidates(coreOptions),
+    auditMemoryDuplicates: (app, coreOptions) => app.auditMemoryDuplicates(coreOptions),
     applyMemoryUpdateCandidate: (app, coreOptions) => app.applyMemoryUpdateCandidate(coreOptions),
     rejectMemoryUpdateCandidate: (app, coreOptions) => app.rejectMemoryUpdateCandidate(coreOptions),
     skipMemoryUpdateCandidate: (app, coreOptions) => app.skipMemoryUpdateCandidate(coreOptions),

--- a/src/core.js
+++ b/src/core.js
@@ -964,12 +964,235 @@ function normalizeContentForRisk(value) {
     .trim();
 }
 
+function clampImportance(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.max(0, Math.min(10, Math.round(parsed)));
+}
+
+function qualityTokens(value) {
+  return String(value || '')
+    .toLowerCase()
+    .split(/[^a-z0-9_./:-]+/)
+    .filter((token) => token.length > 2);
+}
+
+function tokenOverlapScore(left, right) {
+  const leftTokens = new Set(qualityTokens(left));
+  const rightTokens = new Set(qualityTokens(right));
+  if (!leftTokens.size || !rightTokens.size) return 0;
+  let intersection = 0;
+  for (const token of leftTokens) {
+    if (rightTokens.has(token)) intersection += 1;
+  }
+  const union = new Set([...leftTokens, ...rightTokens]).size;
+  return union ? intersection / union : 0;
+}
+
+function candidateQualityText({ key, content, candidate = {} }) {
+  return [
+    key,
+    candidate.key,
+    content,
+    candidate.content,
+    candidate.reason,
+    candidate.durabilityReason,
+    candidate.riskReason,
+    candidate.candidateType,
+    candidate.category,
+    ...(Array.isArray(candidate.tags) ? candidate.tags : []),
+    ...(Array.isArray(candidate.evidenceRefs) ? candidate.evidenceRefs : []),
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function normalizeSuggestedPromotionAction(candidate = {}) {
+  return String(candidate.suggestedAction || candidate.duplicateAction || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[-\s]+/g, '_');
+}
+
+function promotionClassificationFromProvider(candidate = {}) {
+  const action = normalizeSuggestedPromotionAction(candidate);
+  if (['duplicate', 'refinement', 'supersedes', 'conflict', 'too_specific'].includes(action)) {
+    return action;
+  }
+  if (['merge', 'merge_duplicate', 'merge_duplicate_memories'].includes(action)) return 'duplicate';
+  if (['refine', 'update', 'correct_memory'].includes(action)) return 'refinement';
+  if (['supersede', 'replace'].includes(action)) return 'supersedes';
+  if (['reject', 'skip', 'too_specific'].includes(action)) return 'too_specific';
+  return null;
+}
+
+function memorySimilaritySummary(memory, { key, content, candidate = {} }, retrieval = null) {
+  const candidateText = candidateQualityText({ key, content, candidate });
+  const memoryText = [memory.key, memory.category, memory.content, ...(memory.tags || [])].join('\n');
+  const overlap = tokenOverlapScore(candidateText, memoryText);
+  return {
+    memoryId: memory.id,
+    key: memory.key,
+    category: memory.category,
+    content: truncateText(memory.content, 280),
+    importance: memory.importance,
+    overlap,
+    exactContent: normalizeContentForRisk(memory.content) === normalizeContentForRisk(content),
+    sameKey: memory.key === key,
+    retrieval: retrieval || null,
+  };
+}
+
+function similarDurableMemories(store, scope, { key, content, candidate = {}, queryEmbedding = null, limit = 8 }) {
+  const query = candidateQualityText({ key, content, candidate });
+  const lexicalMatches = store.listMemories(scope).map((memory) =>
+    memorySimilaritySummary(memory, { key, content, candidate }),
+  );
+  const searchMatches = searchMemories(store, {
+    ...scope,
+    query,
+    limit: Math.max(limit, 8),
+    queryEmbedding,
+  })
+    .filter((result) => result.type === 'memory' && result.memory)
+    .map((result) =>
+      memorySimilaritySummary(result.memory, { key, content, candidate }, result.retrieval),
+    );
+  const byId = new Map();
+  for (const item of [...lexicalMatches, ...searchMatches]) {
+    const existing = byId.get(item.memoryId);
+    if (!existing || item.overlap > existing.overlap || item.retrieval?.vectorDistance != null) {
+      byId.set(item.memoryId, item);
+    }
+  }
+  return [...byId.values()]
+    .filter((item) => item.sameKey || item.exactContent || item.overlap >= 0.2 || item.retrieval?.vectorDistance != null)
+    .sort(
+      (a, b) =>
+        Number(b.exactContent) - Number(a.exactContent) ||
+        Number(b.sameKey) - Number(a.sameKey) ||
+        b.overlap - a.overlap ||
+        (a.retrieval?.vectorDistance ?? Number.POSITIVE_INFINITY) -
+          (b.retrieval?.vectorDistance ?? Number.POSITIVE_INFINITY),
+    )
+    .slice(0, limit);
+}
+
+function classifyPromotionAssessment(candidate, similarMemories) {
+  const providerClassification = promotionClassificationFromProvider(candidate);
+  const candidateText = candidateQualityText({
+    key: candidate.key,
+    content: candidate.content,
+    candidate,
+  });
+  if (providerClassification) return providerClassification;
+  if (AUTO_ONE_OFF_EVENT_PATTERN.test(candidateText) || AUTO_TRANSIENT_CATEGORIES.has(normalizeToken(candidate.category))) {
+    return 'too_specific';
+  }
+  const top = similarMemories[0];
+  if (!top) return 'new';
+  if (top.exactContent || (top.sameKey && top.overlap >= 0.85)) return 'duplicate';
+  if (/conflict|contradict|incompatible|different content/i.test(candidateText)) return 'conflict';
+  if (/supersede|replace|newer|more complete|deprecate/i.test(candidateText)) return 'supersedes';
+  if (top.sameKey || top.overlap >= 0.45 || (top.retrieval?.vectorDistance != null && top.retrieval.vectorDistance <= 0.2)) {
+    return 'refinement';
+  }
+  return 'new';
+}
+
+function promotionAssessment(store, scope, { key, content, candidate = {}, queryEmbedding = null, embedding = null }) {
+  const normalizedCandidate = {
+    ...candidate,
+    key: key || candidate.key,
+    content: content || candidate.content,
+  };
+  const similarMemories = similarDurableMemories(store, scope, {
+    key: normalizedCandidate.key,
+    content: normalizedCandidate.content,
+    candidate: normalizedCandidate,
+    queryEmbedding,
+  });
+  const classification = classifyPromotionAssessment(normalizedCandidate, similarMemories);
+  const recommendedAction =
+    classification === 'new'
+      ? 'promote_as_new_memory'
+      : classification === 'duplicate'
+        ? 'reject_or_merge_duplicate'
+        : classification === 'too_specific'
+          ? 'keep_as_checkpoint_context'
+          : 'create_memory_update_candidate';
+  return {
+    classification,
+    recommendedAction,
+    similarMemories,
+    embedding: embedding || {
+      used: Boolean(queryEmbedding),
+      degraded: !queryEmbedding,
+      reason: queryEmbedding ? null : 'embedding_not_used_for_this_assessment',
+    },
+  };
+}
+
+function warningForPromotionAssessment(assessment) {
+  if (!assessment || assessment.classification === 'new') return null;
+  const top = assessment.similarMemories[0] || null;
+  const base = {
+    classification: assessment.classification,
+    recommendedAction: assessment.recommendedAction,
+    similarMemories: assessment.similarMemories,
+  };
+  if (assessment.classification === 'duplicate') {
+    return {
+      code: 'duplicate_durable_memory',
+      message: top
+        ? `Candidate is already covered by active durable memory "${top.key}".`
+        : 'Candidate appears to duplicate existing durable memory.',
+      memoryKey: top?.key || null,
+      memoryId: top?.memoryId || null,
+      ...base,
+    };
+  }
+  if (assessment.classification === 'too_specific') {
+    return {
+      code: 'candidate_too_specific',
+      message: 'Candidate appears useful as checkpoint handoff context, but too specific for durable memory.',
+      ...base,
+    };
+  }
+  return {
+    code: `candidate_${assessment.classification}_requires_update`,
+    message: top
+      ? `Candidate overlaps active durable memory "${top.key}" and should create a ${assessment.classification} update proposal instead of a new memory.`
+      : `Candidate should create a ${assessment.classification} update proposal instead of a new memory.`,
+    memoryKey: top?.key || null,
+    memoryId: top?.memoryId || null,
+    ...base,
+  };
+}
+
+function mergeWarnings(warnings, extraWarnings) {
+  const merged = [];
+  const seen = new Set();
+  for (const warning of [...warnings, ...extraWarnings].filter(Boolean)) {
+    const key = `${warning.code}:${warning.memoryId || ''}:${warning.memoryKey || ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(warning);
+  }
+  return merged;
+}
+
 function truthyOption(value) {
   return value === true || value === 'true' || value === '1' || value === 1;
 }
 
 function candidatePromotionWarnings(store, scope, { key, content, candidate }) {
   const warnings = [];
+  const assessment = promotionAssessment(store, scope, { key, content, candidate });
+  const assessmentWarning = warningForPromotionAssessment(assessment);
+  if (assessmentWarning) {
+    warnings.push(assessmentWarning);
+  }
   const existingByKey = store.getMemory({ ...scope, key });
   if (existingByKey?.status === 'active') {
     warnings.push({
@@ -1054,6 +1277,11 @@ const AUTO_SKIP_WARNING_CODES = new Set([
   'duplicate_key',
   'existing_key_conflict',
   'duplicate_content',
+  'duplicate_durable_memory',
+  'candidate_refinement_requires_update',
+  'candidate_supersedes_requires_update',
+  'candidate_conflict_requires_update',
+  'candidate_too_specific',
   'high_sensitivity',
   'recommendation_not_promote',
   'low_confidence',
@@ -1396,6 +1624,71 @@ function promotionCandidateWarnings(store, scope, indexedCandidate) {
   });
 }
 
+function promotionAssessmentForIndexedCandidate(store, scope, indexedCandidate, queryEmbedding = null) {
+  const candidate = indexedCandidate.candidate || {};
+  return promotionAssessment(store, scope, {
+    key: candidate.key,
+    content: candidate.content,
+    candidate,
+    queryEmbedding,
+    embedding: {
+      used: Boolean(queryEmbedding),
+      degraded: !queryEmbedding,
+      reason: queryEmbedding ? null : 'embedding_not_available_or_not_requested',
+    },
+  });
+}
+
+function updateCandidateDraftForPromotionAssessment(scope, indexedCandidate, assessment) {
+  if (!assessment || ['new', 'duplicate', 'too_specific'].includes(assessment.classification)) {
+    return null;
+  }
+  const candidate = indexedCandidate.candidate || {};
+  const target = assessment.similarMemories[0] || null;
+  if (!target) return null;
+  return {
+    id: null,
+    status: 'proposed',
+    scopeType: scope.scopeType,
+    scopeKey: scope.scopeKey,
+    action: assessment.classification === 'duplicate' ? 'merge_duplicate_memories' : 'correct_memory',
+    targetMemoryId: target.memoryId,
+    targetMemoryKey: target.key,
+    proposedKey: target.key,
+    proposedContent: candidate.content,
+    proposedCategory: candidate.category || target.category || 'note',
+    proposedTags: candidate.tags || [],
+    proposedImportance: clampImportance(candidate.importance ?? target.importance ?? 0),
+    reason: `Promotion quality assessment classified candidate as ${assessment.classification}; update existing durable memory instead of writing a new one.`,
+    confidence:
+      assessment.classification === 'conflict'
+        ? 0.55
+        : assessment.classification === 'supersedes'
+          ? 0.75
+          : 0.7,
+    sourceSessionId: indexedCandidate.sessionId || null,
+    sourceCheckpointId: indexedCandidate.checkpointId || null,
+    sourceCandidateId: indexedCandidate.id || null,
+    correction: candidate.content,
+    basis: [
+      {
+        type: 'memory',
+        key: target.key,
+        memoryId: target.memoryId,
+        category: target.category,
+        content: target.content,
+        overlap: target.overlap,
+        classification: assessment.classification,
+      },
+      indexedCandidateBasisResult(indexedCandidate),
+    ],
+  };
+}
+
+function persistUpdateCandidateDraft(store, draft) {
+  return draft ? store.createMemoryUpdateCandidate(draft) : null;
+}
+
 function candidateWarningReason(warnings) {
   if (!warnings.length) return null;
   return warnings.map((warning) => warning.code).join(', ');
@@ -1420,6 +1713,7 @@ function scorePromotionCandidate(indexedCandidate, warnings, skipWarningCodes = 
 function promotionProposal(indexedCandidate, warnings, rank) {
   const candidate = indexedCandidate.candidate || {};
   const sourceProvenance = indexedCandidate.source?.sourceProvenance || null;
+  const assessmentWarning = warnings.find((warning) => warning.classification);
   const proposal = {
     rank,
     candidateId: indexedCandidate.id,
@@ -1448,6 +1742,13 @@ function promotionProposal(indexedCandidate, warnings, rank) {
     warnings,
     recommendedAction: 'ask_user',
   };
+  if (assessmentWarning) {
+    proposal.promotionAssessment = {
+      classification: assessmentWarning.classification,
+      recommendedAction: assessmentWarning.recommendedAction,
+      similarMemories: assessmentWarning.similarMemories || [],
+    };
+  }
   if (candidate.suggestedAction) {
     proposal.providerSuggestedAction = candidate.suggestedAction;
   }
@@ -3279,6 +3580,111 @@ export function createContextForge(options = {}) {
       );
     },
 
+    auditMemoryDuplicates(options = {}) {
+      const scope = normalizeScopeOptions(options, config);
+      const minOverlap = Number(options.minOverlap ?? 0.82);
+      if (!Number.isFinite(minOverlap) || minOverlap < 0 || minOverlap > 1) {
+        throw new Error('minOverlap must be between 0 and 1.');
+      }
+      const limit = positiveNumber(options.limit == null ? 20 : Number(options.limit), 'limit');
+      const createUpdateCandidates = truthyOption(options.createUpdateCandidates);
+      return useStore((store) => {
+        const memories = store.listMemories(scope);
+        const pairs = [];
+        for (let i = 0; i < memories.length; i += 1) {
+          for (let j = i + 1; j < memories.length; j += 1) {
+            const left = memories[i];
+            const right = memories[j];
+            const leftText = [left.key, left.category, left.content, ...(left.tags || [])].join('\n');
+            const rightText = [right.key, right.category, right.content, ...(right.tags || [])].join('\n');
+            const exactContent = normalizeContentForRisk(left.content) === normalizeContentForRisk(right.content);
+            const overlap = tokenOverlapScore(leftText, rightText);
+            const sameKeyStem = slugForKey(left.key) === slugForKey(right.key);
+            if (!exactContent && !sameKeyStem && overlap < minOverlap) {
+              continue;
+            }
+            const survivor =
+              left.importance > right.importance ||
+              (left.importance === right.importance && left.updatedAt >= right.updatedAt)
+                ? left
+                : right;
+            const duplicate = survivor.id === left.id ? right : left;
+            const updateDraft = {
+              id: null,
+              status: createUpdateCandidates ? 'pending' : 'proposed',
+              scopeType: scope.scopeType,
+              scopeKey: scope.scopeKey,
+              action: 'merge_duplicate_memories',
+              targetMemoryId: duplicate.id,
+              targetMemoryKey: duplicate.key,
+              proposedKey: survivor.key,
+              proposedContent: survivor.content,
+              proposedCategory: survivor.category,
+              proposedTags: survivor.tags,
+              proposedImportance: clampImportance(survivor.importance),
+              reason: exactContent
+                ? `Duplicate durable memory content; merge ${duplicate.key} into ${survivor.key}.`
+                : `Highly overlapping durable memory (${overlap.toFixed(2)} token overlap); review merge into ${survivor.key}.`,
+              confidence: exactContent ? 0.95 : Math.max(0.5, overlap),
+              basis: [
+                {
+                  type: 'memory',
+                  key: survivor.key,
+                  memoryId: survivor.id,
+                  content: truncateText(survivor.content, 500),
+                  role: 'survivor',
+                },
+                {
+                  type: 'memory',
+                  key: duplicate.key,
+                  memoryId: duplicate.id,
+                  content: truncateText(duplicate.content, 500),
+                  role: 'duplicate',
+                },
+              ],
+            };
+            const updateCandidate = createUpdateCandidates
+              ? store.createMemoryUpdateCandidate(updateDraft)
+              : updateDraft;
+            pairs.push({
+              survivor: {
+                memoryId: survivor.id,
+                key: survivor.key,
+                importance: survivor.importance,
+                updatedAt: survivor.updatedAt,
+              },
+              duplicate: {
+                memoryId: duplicate.id,
+                key: duplicate.key,
+                importance: duplicate.importance,
+                updatedAt: duplicate.updatedAt,
+              },
+              exactContent,
+              overlap,
+              reason: updateDraft.reason,
+              updateCandidate: memoryUpdateCandidateProposal(updateCandidate),
+            });
+          }
+        }
+        return {
+          kind: 'memory_duplicate_audit',
+          scope,
+          minOverlap,
+          createUpdateCandidates,
+          scanned: memories.length,
+          duplicatePairs: pairs
+            .sort((a, b) => Number(b.exactContent) - Number(a.exactContent) || b.overlap - a.overlap)
+            .slice(0, limit),
+          nextActions: [
+            createUpdateCandidates
+              ? 'Review pending merge_duplicate_memories update candidates before applying them.'
+              : 'Rerun with createUpdateCandidates=true to persist merge proposals for reviewed duplicates.',
+            'Do not merge memories without checking provenance and current policy relevance.',
+          ],
+        };
+      });
+    },
+
     applyMemoryUpdateCandidate(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.candidateId, 'candidateId');
@@ -3425,6 +3831,7 @@ export function createContextForge(options = {}) {
           : [];
       const scanLimit = positiveNumber(options.scanLimit == null ? 10 : Number(options.scanLimit), 'scanLimit');
       const promotionRecommendation = options.promotionRecommendation || 'promote';
+      const createUpdateCandidates = truthyOption(options.createUpdateCandidates);
 
       return useStore(async (store) => {
         let checkpointId = options.checkpointId || null;
@@ -3496,9 +3903,13 @@ export function createContextForge(options = {}) {
           limit: scanLimit,
         });
         const assessed = candidates.map((candidate) => {
+          const assessment = promotionAssessmentForIndexedCandidate(store, scope, candidate);
           const warnings = promotionCandidateWarnings(store, scope, candidate);
           const score = scorePromotionCandidate(candidate, warnings);
-          return { candidate, warnings, score };
+          const updateDraft = updateCandidateDraftForPromotionAssessment(scope, candidate, assessment);
+          const updateCandidate =
+            createUpdateCandidates && updateDraft ? persistUpdateCandidateDraft(store, updateDraft) : updateDraft;
+          return { candidate, warnings, score, assessment, updateCandidate };
         });
         const selected = assessed
           .filter((item) => item.score > 0)
@@ -3514,11 +3925,22 @@ export function createContextForge(options = {}) {
             allowScopeFallback,
           },
           proposals: selected.map((item, index) => promotionProposal(item.candidate, item.warnings, index + 1)),
+          updateCandidates: assessed
+            .filter((item) => item.updateCandidate)
+            .map((item) => memoryUpdateCandidateProposal(item.updateCandidate)),
           skipped: assessed
             .filter((item) => item.score <= 0)
             .map((item) => ({
               candidateId: item.candidate.id,
               reason: candidateWarningReason(item.warnings) || 'low_score',
+              ...(item.assessment?.classification && item.assessment.classification !== 'new'
+                ? {
+                    promotionAssessment: item.assessment,
+                    updateCandidate: item.updateCandidate
+                      ? memoryUpdateCandidateProposal(item.updateCandidate)
+                      : null,
+                  }
+                : {}),
             })),
           requestWarnings,
           nextActions: [
@@ -3950,10 +4372,54 @@ export function createContextForge(options = {}) {
           sort: 'recommendation',
           limit: scanLimit,
         });
-        const assessed = candidates.map((candidate) => {
-          const warnings = autoPromotionWarnings(store, scope, candidate, policy);
+        let candidateEmbeddings = [];
+        let assessmentEmbedding = {
+          used: false,
+          degraded: !embeddingProvider,
+          reason: embeddingProvider ? 'no_candidates' : 'embeddings_disabled',
+          provider: embeddingProvider?.name || config.embeddings.provider,
+          model: embeddingProvider?.model || null,
+          dimensions: embeddingProvider?.dimensions || null,
+        };
+        if (embeddingProvider && candidates.length > 0) {
+          try {
+            candidateEmbeddings = await embeddingProvider.embed(
+              candidates.map((candidate) =>
+                candidateQualityText({
+                  key: candidate.candidate?.key,
+                  content: candidate.candidate?.content,
+                  candidate: candidate.candidate,
+                }),
+              ),
+            );
+            assessmentEmbedding = {
+              used: true,
+              degraded: false,
+              reason: null,
+              provider: embeddingProvider.name,
+              model: embeddingProvider.model,
+              dimensions: embeddingProvider.dimensions,
+            };
+          } catch (error) {
+            assessmentEmbedding = {
+              used: false,
+              degraded: true,
+              reason: `embedding_failed: ${error.message}`,
+              provider: embeddingProvider.name,
+              model: embeddingProvider.model,
+              dimensions: embeddingProvider.dimensions,
+            };
+          }
+        }
+        const assessed = candidates.map((candidate, index) => {
+          const queryEmbedding = candidateEmbeddings[index] || null;
+          const assessment = promotionAssessmentForIndexedCandidate(store, scope, candidate, queryEmbedding);
+          assessment.embedding = queryEmbedding ? assessmentEmbedding : { ...assessmentEmbedding, used: false };
+          const warnings = mergeWarnings(autoPromotionWarnings(store, scope, candidate, policy), [
+            warningForPromotionAssessment(assessment),
+          ]);
           const score = scorePromotionCandidate(candidate, warnings, AUTO_PROMOTE_SKIP_WARNING_CODES);
-          return { candidate, warnings, score };
+          return { candidate, warnings, score, assessment };
         });
         const selected = assessed
           .filter((item) => item.score > 0)
@@ -4073,6 +4539,9 @@ export function createContextForge(options = {}) {
               .map((item) => ({
                 candidateId: item.candidate.id,
                 reason: candidateWarningReason(item.warnings) || 'low_score',
+                ...(item.assessment?.classification && item.assessment.classification !== 'new'
+                  ? { promotionAssessment: item.assessment }
+                  : {}),
               })),
             ...auditSkipped,
           ],
@@ -4390,6 +4859,7 @@ export function createContextForge(options = {}) {
         requireOption(key, 'key');
         const content = options.content || candidate.content;
         requireOption(content, 'content');
+        const assessment = promotionAssessment(store, scope, { key, content, candidate });
         const warnings = candidatePromotionWarnings(store, scope, { key, content, candidate });
         if (warnings.length > 0 && !truthyOption(options.allowWarnings)) {
           const error = new Error(
@@ -4409,11 +4879,17 @@ export function createContextForge(options = {}) {
           content,
           category: options.category || candidate.category || 'note',
           tags: options.tags?.length ? options.tags : candidate.tags || [],
-          importance: options.importance == null ? candidate.importance || 0 : options.importance,
+          importance: clampImportance(options.importance == null ? candidate.importance || 0 : options.importance),
           reason: options.reason || null,
           warnings,
           sourceRawEventIds: options.sourceRawEventIds || [],
           allowStatusOverride: truthyOption(options.allowStatusOverride),
+          eventMetadata: {
+            promotionAssessment: assessment,
+          },
+          reviewMetadata: {
+            promotionAssessment: assessment,
+          },
         });
         enqueueEmbeddingSources(store, [store.embeddingSourceForMemory(memory)]);
         return memory;

--- a/src/core.js
+++ b/src/core.js
@@ -1022,7 +1022,6 @@ function promotionClassificationFromProvider(candidate = {}) {
   if (['merge', 'merge_duplicate', 'merge_duplicate_memories'].includes(action)) return 'duplicate';
   if (['refine', 'update', 'correct_memory'].includes(action)) return 'refinement';
   if (['supersede', 'replace'].includes(action)) return 'supersedes';
-  if (['reject', 'skip', 'too_specific'].includes(action)) return 'too_specific';
   return null;
 }
 
@@ -1061,7 +1060,11 @@ function similarDurableMemories(store, scope, { key, content, candidate = {}, qu
   const byId = new Map();
   for (const item of [...lexicalMatches, ...searchMatches]) {
     const existing = byId.get(item.memoryId);
-    if (!existing || item.overlap > existing.overlap || item.retrieval?.vectorDistance != null) {
+    if (
+      !existing ||
+      item.overlap > existing.overlap ||
+      (item.retrieval?.vectorDistance != null && existing.retrieval?.vectorDistance == null)
+    ) {
       byId.set(item.memoryId, item);
     }
   }
@@ -1092,8 +1095,10 @@ function classifyPromotionAssessment(candidate, similarMemories) {
   const top = similarMemories[0];
   if (!top) return 'new';
   if (top.exactContent || (top.sameKey && top.overlap >= 0.85)) return 'duplicate';
-  if (/conflict|contradict|incompatible|different content/i.test(candidateText)) return 'conflict';
-  if (/supersede|replace|newer|more complete|deprecate/i.test(candidateText)) return 'supersedes';
+  const strongOverlap =
+    top.sameKey || top.overlap >= 0.6 || (top.retrieval?.vectorDistance != null && top.retrieval.vectorDistance <= 0.2);
+  if (strongOverlap && /conflict|contradict|incompatible|different content/i.test(candidateText)) return 'conflict';
+  if (strongOverlap && /supersede|replace|newer|more complete|deprecate/i.test(candidateText)) return 'supersedes';
   if (top.sameKey || top.overlap >= 0.45 || (top.retrieval?.vectorDistance != null && top.retrieval.vectorDistance <= 0.2)) {
     return 'refinement';
   }
@@ -1186,10 +1191,10 @@ function truthyOption(value) {
   return value === true || value === 'true' || value === '1' || value === 1;
 }
 
-function candidatePromotionWarnings(store, scope, { key, content, candidate }) {
+function candidatePromotionWarnings(store, scope, { key, content, candidate, assessment = null }) {
   const warnings = [];
-  const assessment = promotionAssessment(store, scope, { key, content, candidate });
-  const assessmentWarning = warningForPromotionAssessment(assessment);
+  const effectiveAssessment = assessment || promotionAssessment(store, scope, { key, content, candidate });
+  const assessmentWarning = warningForPromotionAssessment(effectiveAssessment);
   if (assessmentWarning) {
     warnings.push(assessmentWarning);
   }
@@ -1615,12 +1620,14 @@ function indexedCandidateBasisResult(indexedCandidate) {
   };
 }
 
-function promotionCandidateWarnings(store, scope, indexedCandidate) {
+function promotionCandidateWarnings(store, scope, indexedCandidate, assessment = null) {
   const candidate = indexedCandidate.candidate || {};
+  const effectiveAssessment = assessment || promotionAssessmentForIndexedCandidate(store, scope, indexedCandidate);
   return candidatePromotionWarnings(store, scope, {
     key: candidate.key,
     content: candidate.content,
     candidate,
+    assessment: effectiveAssessment,
   });
 }
 
@@ -1648,6 +1655,7 @@ function updateCandidateDraftForPromotionAssessment(scope, indexedCandidate, ass
   if (!target) return null;
   return {
     id: null,
+    // `proposed` is an in-memory draft status; persisted update candidates are stored as `pending`.
     status: 'proposed',
     scopeType: scope.scopeType,
     scopeKey: scope.scopeKey,
@@ -1825,9 +1833,9 @@ function normalizeAllowedCategories(value, defaultCategories = SAFE_AUTO_PROMOTE
   };
 }
 
-function autoPromotionWarnings(store, scope, indexedCandidate, policy) {
+function autoPromotionWarnings(store, scope, indexedCandidate, policy, assessment = null) {
   const candidate = indexedCandidate.candidate || {};
-  const warnings = [...promotionCandidateWarnings(store, scope, indexedCandidate)];
+  const warnings = [...promotionCandidateWarnings(store, scope, indexedCandidate, assessment)];
   const category = normalizeToken(candidate.category);
   const searchableText = [
     candidate.key,
@@ -3587,9 +3595,10 @@ export function createContextForge(options = {}) {
         throw new Error('minOverlap must be between 0 and 1.');
       }
       const limit = positiveNumber(options.limit == null ? 20 : Number(options.limit), 'limit');
+      const scanLimit = positiveNumber(options.scanLimit == null ? 250 : Number(options.scanLimit), 'scanLimit');
       const createUpdateCandidates = truthyOption(options.createUpdateCandidates);
       return useStore((store) => {
-        const memories = store.listMemories(scope);
+        const memories = store.listMemories(scope).slice(0, scanLimit);
         const pairs = [];
         for (let i = 0; i < memories.length; i += 1) {
           for (let j = i + 1; j < memories.length; j += 1) {
@@ -3600,7 +3609,7 @@ export function createContextForge(options = {}) {
             const exactContent = normalizeContentForRisk(left.content) === normalizeContentForRisk(right.content);
             const overlap = tokenOverlapScore(leftText, rightText);
             const sameKeyStem = slugForKey(left.key) === slugForKey(right.key);
-            if (!exactContent && !sameKeyStem && overlap < minOverlap) {
+            if (!exactContent && overlap < minOverlap && !(sameKeyStem && overlap >= Math.min(minOverlap, 0.6))) {
               continue;
             }
             const survivor =
@@ -3611,6 +3620,7 @@ export function createContextForge(options = {}) {
             const duplicate = survivor.id === left.id ? right : left;
             const updateDraft = {
               id: null,
+              // `proposed` is an in-memory draft status; persisted update candidates are stored as `pending`.
               status: createUpdateCandidates ? 'pending' : 'proposed',
               scopeType: scope.scopeType,
               scopeKey: scope.scopeKey,
@@ -3643,9 +3653,6 @@ export function createContextForge(options = {}) {
                 },
               ],
             };
-            const updateCandidate = createUpdateCandidates
-              ? store.createMemoryUpdateCandidate(updateDraft)
-              : updateDraft;
             pairs.push({
               survivor: {
                 memoryId: survivor.id,
@@ -3662,19 +3669,41 @@ export function createContextForge(options = {}) {
               exactContent,
               overlap,
               reason: updateDraft.reason,
-              updateCandidate: memoryUpdateCandidateProposal(updateCandidate),
+              updateDraft,
             });
+          }
+        }
+        const selectedPairs = [];
+        const seenDuplicates = new Set();
+        for (const pair of pairs
+          .sort((a, b) => Number(b.exactContent) - Number(a.exactContent) || b.overlap - a.overlap)) {
+          if (seenDuplicates.has(pair.duplicate.memoryId)) {
+            continue;
+          }
+          seenDuplicates.add(pair.duplicate.memoryId);
+          selectedPairs.push(pair);
+          if (selectedPairs.length >= limit) {
+            break;
           }
         }
         return {
           kind: 'memory_duplicate_audit',
           scope,
           minOverlap,
+          scanLimit,
           createUpdateCandidates,
           scanned: memories.length,
-          duplicatePairs: pairs
-            .sort((a, b) => Number(b.exactContent) - Number(a.exactContent) || b.overlap - a.overlap)
-            .slice(0, limit),
+          matchedPairs: pairs.length,
+          duplicatePairs: selectedPairs.map((pair) => {
+            const updateCandidate = createUpdateCandidates
+              ? store.createMemoryUpdateCandidate(pair.updateDraft)
+              : pair.updateDraft;
+            const { updateDraft, ...rest } = pair;
+            return {
+              ...rest,
+              updateCandidate: memoryUpdateCandidateProposal(updateCandidate),
+            };
+          }),
           nextActions: [
             createUpdateCandidates
               ? 'Review pending merge_duplicate_memories update candidates before applying them.'
@@ -3902,9 +3931,50 @@ export function createContextForge(options = {}) {
           sort: 'recommendation',
           limit: scanLimit,
         });
-        const assessed = candidates.map((candidate) => {
-          const assessment = promotionAssessmentForIndexedCandidate(store, scope, candidate);
-          const warnings = promotionCandidateWarnings(store, scope, candidate);
+        let candidateEmbeddings = [];
+        let assessmentEmbedding = {
+          used: false,
+          degraded: !embeddingProvider,
+          reason: embeddingProvider ? 'no_candidates' : 'embeddings_disabled',
+          provider: embeddingProvider?.name || config.embeddings.provider,
+          model: embeddingProvider?.model || null,
+          dimensions: embeddingProvider?.dimensions || null,
+        };
+        if (embeddingProvider && candidates.length > 0) {
+          try {
+            candidateEmbeddings = await embeddingProvider.embed(
+              candidates.map((candidate) =>
+                candidateQualityText({
+                  key: candidate.candidate?.key,
+                  content: candidate.candidate?.content,
+                  candidate: candidate.candidate,
+                }),
+              ),
+            );
+            assessmentEmbedding = {
+              used: true,
+              degraded: false,
+              reason: null,
+              provider: embeddingProvider.name,
+              model: embeddingProvider.model,
+              dimensions: embeddingProvider.dimensions,
+            };
+          } catch (error) {
+            assessmentEmbedding = {
+              used: false,
+              degraded: true,
+              reason: `embedding_failed: ${error.message}`,
+              provider: embeddingProvider.name,
+              model: embeddingProvider.model,
+              dimensions: embeddingProvider.dimensions,
+            };
+          }
+        }
+        const assessed = candidates.map((candidate, index) => {
+          const queryEmbedding = candidateEmbeddings[index] || null;
+          const assessment = promotionAssessmentForIndexedCandidate(store, scope, candidate, queryEmbedding);
+          assessment.embedding = queryEmbedding ? assessmentEmbedding : { ...assessmentEmbedding, used: false };
+          const warnings = promotionCandidateWarnings(store, scope, candidate, assessment);
           const score = scorePromotionCandidate(candidate, warnings);
           const updateDraft = updateCandidateDraftForPromotionAssessment(scope, candidate, assessment);
           const updateCandidate =
@@ -4415,7 +4485,7 @@ export function createContextForge(options = {}) {
           const queryEmbedding = candidateEmbeddings[index] || null;
           const assessment = promotionAssessmentForIndexedCandidate(store, scope, candidate, queryEmbedding);
           assessment.embedding = queryEmbedding ? assessmentEmbedding : { ...assessmentEmbedding, used: false };
-          const warnings = mergeWarnings(autoPromotionWarnings(store, scope, candidate, policy), [
+          const warnings = mergeWarnings(autoPromotionWarnings(store, scope, candidate, policy, assessment), [
             warningForPromotionAssessment(assessment),
           ]);
           const score = scorePromotionCandidate(candidate, warnings, AUTO_PROMOTE_SKIP_WARNING_CODES);
@@ -4860,7 +4930,7 @@ export function createContextForge(options = {}) {
         const content = options.content || candidate.content;
         requireOption(content, 'content');
         const assessment = promotionAssessment(store, scope, { key, content, candidate });
-        const warnings = candidatePromotionWarnings(store, scope, { key, content, candidate });
+        const warnings = candidatePromotionWarnings(store, scope, { key, content, candidate, assessment });
         if (warnings.length > 0 && !truthyOption(options.allowWarnings)) {
           const error = new Error(
             `Memory candidate promotion has ${warnings.length} warning(s). Pass allowWarnings to promote anyway.`,

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -778,6 +778,27 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
   );
 
   server.registerTool(
+    'audit_memory_duplicates',
+    {
+      title: 'Audit Memory Duplicates',
+      description:
+        'Detect overlapping active durable memories in a scope and optionally persist merge_duplicate_memories update candidates. Read-only unless createUpdateCandidates=true.',
+      inputSchema: {
+        ...scopedSchema,
+        minOverlap: z.number().min(0).max(1).optional(),
+        limit: z.number().int().positive().optional(),
+        createUpdateCandidates: z.boolean().optional(),
+      },
+      annotations: {
+        title: 'Audit Memory Duplicates',
+        readOnlyHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args) => jsonResult(await app.auditMemoryDuplicates(args)),
+  );
+
+  server.registerTool(
     'apply_memory_update_candidate',
     {
       title: 'Apply Memory Update Candidate',
@@ -865,10 +886,11 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
         promotionRecommendation: z.string().optional(),
         includeWarnings: z.boolean().optional(),
         allowScopeFallback: z.boolean().optional(),
+        createUpdateCandidates: z.boolean().optional(),
       },
       annotations: {
         title: 'Suggest Memory Promotions',
-        readOnlyHint: true,
+        readOnlyHint: false,
         idempotentHint: true,
       },
     },

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -786,6 +786,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
       inputSchema: {
         ...scopedSchema,
         minOverlap: z.number().min(0).max(1).optional(),
+        scanLimit: z.number().int().positive().optional(),
         limit: z.number().int().positive().optional(),
         createUpdateCandidates: z.boolean().optional(),
       },

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -26,6 +26,7 @@ const REMOTE_METHODS = [
   'listMemoryCandidates',
   'listPreferenceOccurrences',
   'listMemoryUpdateCandidates',
+  'auditMemoryDuplicates',
   'applyMemoryUpdateCandidate',
   'rejectMemoryUpdateCandidate',
   'skipMemoryUpdateCandidate',

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -324,6 +324,14 @@ function normalizeTags(tags) {
   return Array.isArray(tags) ? tags.map((tag) => String(tag)) : [];
 }
 
+function clampImportance(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(10, Math.round(parsed)));
+}
+
 function contentHash(value) {
   return createHash('sha256').update(String(value || '')).digest('hex');
 }
@@ -357,11 +365,34 @@ function validateDimensions(dimensions) {
   return parsed;
 }
 
-const SUGGESTED_ACTIONS = new Set(['promote', 'review', 'reject', 'skip']);
+const SUGGESTED_ACTIONS = new Set([
+  'promote',
+  'review',
+  'reject',
+  'skip',
+  'duplicate',
+  'merge',
+  'merge_duplicate',
+  'merge_duplicate_memories',
+  'refinement',
+  'refine',
+  'update',
+  'correct_memory',
+  'supersedes',
+  'supersede',
+  'replace',
+  'conflict',
+  'too_specific',
+]);
 
 function normalizeCandidate(candidate) {
   const value = candidate && typeof candidate === 'object' && !Array.isArray(candidate) ? candidate : {};
-  const suggestedAction = value.suggestedAction ? String(value.suggestedAction) : null;
+  const suggestedAction = value.suggestedAction
+    ? String(value.suggestedAction)
+        .trim()
+        .toLowerCase()
+        .replace(/[-\s]+/g, '_')
+    : null;
   return {
     schemaVersion: value.schemaVersion ? String(value.schemaVersion) : null,
     key: String(value.key || ''),
@@ -369,7 +400,7 @@ function normalizeCandidate(candidate) {
     reason: String(value.reason || ''),
     category: value.category ? String(value.category) : 'note',
     tags: normalizeTags(value.tags),
-    importance: Number.isFinite(Number(value.importance)) ? Number(value.importance) : 0,
+    importance: clampImportance(value.importance),
     candidateType: value.candidateType ? String(value.candidateType) : null,
     confidence: Number.isFinite(Number(value.confidence)) ? Number(value.confidence) : null,
     stability: Number.isFinite(Number(value.stability)) ? Number(value.stability) : null,
@@ -1753,7 +1784,7 @@ export class ContextForgeStore {
         candidate.reason,
         candidate.category,
         json(candidate.tags, []),
-        candidate.importance,
+        clampImportance(candidate.importance),
         candidate.candidateType,
         candidate.confidence,
         candidate.stability,
@@ -1993,7 +2024,7 @@ export class ContextForgeStore {
         category,
         content,
         json(normalizedTags, []),
-        Number(importance),
+        clampImportance(importance),
         status,
         supersedesMemoryId,
         deactivatedAt,
@@ -2790,7 +2821,7 @@ export class ContextForgeStore {
           proposedContent,
           proposedCategory,
           json(proposedTags, []),
-          proposedImportance,
+          proposedImportance == null ? null : clampImportance(proposedImportance),
           reason,
           confidence,
           sourceSessionId,
@@ -2824,7 +2855,7 @@ export class ContextForgeStore {
         proposedContent,
         proposedCategory,
         json(proposedTags, []),
-        proposedImportance,
+        proposedImportance == null ? null : clampImportance(proposedImportance),
         reason,
         confidence,
         sourceSessionId,

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1668,6 +1668,99 @@ test('promotion quality assessment prefers update proposals over duplicate durab
   );
 });
 
+test('promotion quality assessment covers supersedes, too-specific, and new candidates', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'classification_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      classification_provider: async () => ({
+        summaryShort: 'Classification checkpoint.',
+        summaryText: 'The checkpoint proposes several promotion classifications.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'runtime-verification',
+            content: 'Verify git, GitHub, CI, runtime health, and migrations before acting on live state.',
+            reason: 'This is a more complete runtime verification rule that should supersede the older version.',
+            category: 'runbook',
+            confidence: 0.92,
+            stability: 0.9,
+            promotionRecommendation: 'promote',
+          },
+          {
+            key: 'pr-142-status',
+            content: 'PR #142 CI passed on Node 20, 22, and 24.',
+            reason: 'One-off PR status should stay in checkpoint context.',
+            category: 'temporary',
+            confidence: 0.95,
+            stability: 0.95,
+            promotionRecommendation: 'promote',
+          },
+          {
+            key: 'api-contract-rule',
+            content: 'API contract memories should include endpoint, request shape, response shape, and migration notes.',
+            reason: 'Reusable API contract guidance.',
+            category: 'api-contract',
+            confidence: 0.95,
+            stability: 0.95,
+            promotionRecommendation: 'promote',
+          },
+        ],
+        sourceEventCount: 1,
+        metadata: { synthetic: true },
+      }),
+    },
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'classification-repo',
+    key: 'runtime-verification',
+    content: 'Verify git and GitHub before acting on live state.',
+    category: 'runbook',
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'classification-repo',
+    sessionId: 'classification-session',
+    role: 'assistant',
+    content: 'Candidate: classify memory promotions.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'classification-repo',
+    sessionId: 'classification-session',
+  });
+
+  const suggestions = await app.suggestMemoryPromotions({
+    scope: 'repo',
+    scopeKey: 'classification-repo',
+    sessionId: 'classification-session',
+    trigger: 'manual_closeout',
+    createUpdateCandidates: true,
+    scanLimit: 10,
+  });
+
+  assert.ok(suggestions.proposals.some((proposal) => proposal.key === 'api-contract-rule'));
+  assert.ok(
+    suggestions.updateCandidates.some(
+      (candidate) =>
+        candidate.targetMemoryKey === 'runtime-verification' &&
+        candidate.reason.includes('supersedes'),
+    ),
+  );
+  assert.ok(
+    suggestions.skipped.some(
+      (item) => item.promotionAssessment?.classification === 'too_specific',
+    ),
+  );
+});
+
 test('auditMemoryDuplicates reports merge proposals without mutating by default', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
@@ -1714,6 +1807,43 @@ test('auditMemoryDuplicates reports merge proposals without mutating by default'
     app.listMemoryUpdateCandidates({
       scope: 'repo',
       scopeKey: 'duplicate-audit-repo',
+      action: 'merge_duplicate_memories',
+    }).length,
+    1,
+  );
+});
+
+test('auditMemoryDuplicates limits persisted update candidates after sorting and dedupe', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+  for (const [key, importance] of [
+    ['runtime-rule-a', 9],
+    ['runtime-rule-b', 5],
+    ['runtime-rule-c', 1],
+  ]) {
+    app.remember({
+      scope: 'repo',
+      scopeKey: 'duplicate-limit-repo',
+      key,
+      content: 'Agents must verify git and GitHub before making live-state claims.',
+      category: 'runbook',
+      importance,
+    });
+  }
+
+  const result = app.auditMemoryDuplicates({
+    scope: 'repo',
+    scopeKey: 'duplicate-limit-repo',
+    createUpdateCandidates: true,
+    limit: 1,
+  });
+
+  assert.equal(result.matchedPairs, 3);
+  assert.equal(result.duplicatePairs.length, 1);
+  assert.equal(
+    app.listMemoryUpdateCandidates({
+      scope: 'repo',
+      scopeKey: 'duplicate-limit-repo',
       action: 'merge_duplicate_memories',
     }).length,
     1,
@@ -10214,6 +10344,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     assert.ok(updateCandidatesTool.inputSchema.properties.action);
     const duplicateAuditTool = toolList.tools.find((tool) => tool.name === 'audit_memory_duplicates');
     assert.ok(duplicateAuditTool.inputSchema.properties.minOverlap);
+    assert.ok(duplicateAuditTool.inputSchema.properties.scanLimit);
     assert.ok(duplicateAuditTool.inputSchema.properties.createUpdateCandidates);
     const listCandidateTool = toolList.tools.find((tool) => tool.name === 'list_memory_candidates');
     assert.ok(listCandidateTool.description.includes('current closeout source'));

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1510,7 +1510,14 @@ test('candidate promotion warnings require explicit override', async () => {
     assert.equal(error.name, 'MemoryCandidatePromotionWarningError');
     assert.deepEqual(
       error.warnings.map((warning) => warning.code),
-      ['existing_key_conflict', 'high_sensitivity', 'recommendation_not_promote', 'low_confidence', 'low_stability'],
+      [
+        'candidate_conflict_requires_update',
+        'existing_key_conflict',
+        'high_sensitivity',
+        'recommendation_not_promote',
+        'low_confidence',
+        'low_stability',
+      ],
     );
   }
 
@@ -1540,6 +1547,177 @@ test('candidate promotion warnings require explicit override', async () => {
   });
   assert.equal(events.at(-1).eventType, 'promote');
   assert.ok(events.at(-1).metadata.promotionWarnings.length >= 1);
+});
+
+test('promotion quality assessment prefers update proposals over duplicate durable memories', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'dedupe_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      dedupe_provider: async () => ({
+        summaryShort: 'Dedupe checkpoint.',
+        summaryText: 'The checkpoint proposes overlapping memory candidates.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'runtime-verification',
+            content: 'Verify git, GitHub, CI, runtime health, and migrations before making live-state claims.',
+            reason: 'Adds CI and migration specifics to the existing runtime verification rule.',
+            category: 'runbook',
+            tags: ['runtime', 'verification'],
+            importance: 72,
+            confidence: 0.9,
+            stability: 0.9,
+            promotionRecommendation: 'promote',
+          },
+          {
+            key: 'duplicate-runtime-rule',
+            content: 'Verify git and GitHub before making live-state claims.',
+            reason: 'Exact duplicate content should not be promoted again.',
+            category: 'runbook',
+            confidence: 0.9,
+            stability: 0.9,
+            promotionRecommendation: 'promote',
+          },
+        ],
+        sourceEventCount: 1,
+        metadata: { synthetic: true },
+      }),
+    },
+  });
+
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'dedupe-repo',
+    key: 'runtime-verification',
+    content: 'Verify git and GitHub before making live-state claims.',
+    category: 'runbook',
+    importance: 99,
+  });
+  assert.equal(
+    app.getMemory({ scope: 'repo', scopeKey: 'dedupe-repo', key: 'runtime-verification' }).importance,
+    10,
+  );
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'dedupe-repo',
+    sessionId: 'dedupe-session',
+    role: 'assistant',
+    content: 'Candidate: improve runtime verification memory.',
+  });
+  await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'dedupe-repo',
+    sessionId: 'dedupe-session',
+  });
+
+  const suggestions = await app.suggestMemoryPromotions({
+    scope: 'repo',
+    scopeKey: 'dedupe-repo',
+    sessionId: 'dedupe-session',
+    trigger: 'manual_closeout',
+    createUpdateCandidates: true,
+    scanLimit: 10,
+  });
+  assert.equal(suggestions.proposals.length, 0);
+  assert.equal(suggestions.updateCandidates.length, 1);
+  assert.equal(suggestions.updateCandidates[0].action, 'correct_memory');
+  assert.equal(suggestions.updateCandidates[0].targetMemoryKey, 'runtime-verification');
+  assert.equal(suggestions.updateCandidates[0].proposedImportance, 10);
+  assert.ok(
+    suggestions.skipped.some(
+      (item) => item.promotionAssessment?.classification === 'refinement',
+    ),
+  );
+  assert.ok(
+    suggestions.skipped.some(
+      (item) => item.promotionAssessment?.classification === 'duplicate',
+    ),
+  );
+
+  const updateCandidates = app.listMemoryUpdateCandidates({
+    scope: 'repo',
+    scopeKey: 'dedupe-repo',
+    status: 'pending',
+  });
+  assert.equal(updateCandidates.length, 1);
+  assert.equal(updateCandidates[0].targetMemoryKey, 'runtime-verification');
+
+  const duplicateCandidate = app
+    .listMemoryCandidates({
+      scope: 'repo',
+      scopeKey: 'dedupe-repo',
+      status: 'pending',
+    })
+    .find((candidate) => candidate.candidate.key === 'duplicate-runtime-rule');
+  assert.equal(duplicateCandidate.candidate.importance, 0);
+  assert.throws(
+    () =>
+      app.promoteMemoryCandidate({
+        scope: 'repo',
+        scopeKey: 'dedupe-repo',
+        candidateId: duplicateCandidate.id,
+      }),
+    /allowWarnings/,
+  );
+});
+
+test('auditMemoryDuplicates reports merge proposals without mutating by default', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'duplicate-audit-repo',
+    key: 'runtime-rule-a',
+    content: 'Agents must verify git and GitHub before making live-state claims.',
+    category: 'runbook',
+    importance: 5,
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'duplicate-audit-repo',
+    key: 'runtime-rule-b',
+    content: 'Agents must verify git and GitHub before making live-state claims.',
+    category: 'runbook',
+    importance: 2,
+  });
+
+  const dryRun = app.auditMemoryDuplicates({
+    scope: 'repo',
+    scopeKey: 'duplicate-audit-repo',
+  });
+  assert.equal(dryRun.duplicatePairs.length, 1);
+  assert.equal(dryRun.duplicatePairs[0].survivor.key, 'runtime-rule-a');
+  assert.equal(dryRun.duplicatePairs[0].updateCandidate.status, 'proposed');
+  assert.equal(
+    app.listMemoryUpdateCandidates({
+      scope: 'repo',
+      scopeKey: 'duplicate-audit-repo',
+    }).length,
+    0,
+  );
+
+  const persisted = app.auditMemoryDuplicates({
+    scope: 'repo',
+    scopeKey: 'duplicate-audit-repo',
+    createUpdateCandidates: true,
+  });
+  assert.equal(persisted.duplicatePairs[0].updateCandidate.status, 'pending');
+  assert.equal(
+    app.listMemoryUpdateCandidates({
+      scope: 'repo',
+      scopeKey: 'duplicate-audit-repo',
+      action: 'merge_duplicate_memories',
+    }).length,
+    1,
+  );
 });
 
 test('CLI accepts repoPath for repo-scoped memory', async () => {
@@ -7121,8 +7299,8 @@ test('suggestMemoryPromotions avoids scope fallback unless explicitly allowed', 
         memoryCandidates: [
           {
             key: 'closeout-runbook',
-            content: 'Closeout should verify branch parity before frontend follow-up.',
-            reason: 'PR #595 merge and main parity were verified.',
+            content: 'Closeout should verify branch parity before follow-up work starts.',
+            reason: 'Branch parity verification is a reusable closeout runbook.',
             category: 'runbook',
             candidateType: 'runbook',
             confidence: 0.91,
@@ -9730,6 +9908,7 @@ test('REMOTE_METHODS exposes resume, suggestion, auto-promotion, and reconciliat
   assert.ok(REMOTE_METHODS.includes('reconcileMemory'));
   assert.ok(REMOTE_METHODS.includes('listPreferenceOccurrences'));
   assert.ok(REMOTE_METHODS.includes('listMemoryUpdateCandidates'));
+  assert.ok(REMOTE_METHODS.includes('auditMemoryDuplicates'));
   assert.ok(REMOTE_METHODS.includes('applyMemoryUpdateCandidate'));
   assert.ok(REMOTE_METHODS.includes('rejectMemoryUpdateCandidate'));
   assert.ok(REMOTE_METHODS.includes('skipMemoryUpdateCandidate'));
@@ -9922,6 +10101,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
       'append_raw',
       'apply_memory_update_candidate',
       'audit_memory_candidates',
+      'audit_memory_duplicates',
       'auto_promote_memory_candidates',
       'begin_session',
       'bootstrap_context',
@@ -10024,6 +10204,7 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     const suggestTool = toolList.tools.find((tool) => tool.name === 'suggest_memory_promotions');
     assert.ok(suggestTool.inputSchema.properties.allowScopeFallback);
     assert.ok(suggestTool.inputSchema.properties.trigger);
+    assert.ok(suggestTool.inputSchema.properties.createUpdateCandidates);
     assert.ok(suggestTool.description.includes('missing_closeout_source'));
     const preferenceOccurrencesTool = toolList.tools.find((tool) => tool.name === 'list_preference_occurrences');
     assert.ok(preferenceOccurrencesTool.inputSchema.properties.status);
@@ -10031,6 +10212,9 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     const updateCandidatesTool = toolList.tools.find((tool) => tool.name === 'list_memory_update_candidates');
     assert.ok(updateCandidatesTool.inputSchema.properties.status);
     assert.ok(updateCandidatesTool.inputSchema.properties.action);
+    const duplicateAuditTool = toolList.tools.find((tool) => tool.name === 'audit_memory_duplicates');
+    assert.ok(duplicateAuditTool.inputSchema.properties.minOverlap);
+    assert.ok(duplicateAuditTool.inputSchema.properties.createUpdateCandidates);
     const listCandidateTool = toolList.tools.find((tool) => tool.name === 'list_memory_candidates');
     assert.ok(listCandidateTool.description.includes('current closeout source'));
     const applyUpdateTool = toolList.tools.find((tool) => tool.name === 'apply_memory_update_candidate');


### PR DESCRIPTION
## Summary
- Add promotion quality assessment before durable memory writes: duplicate, refinement, supersedes, conflict, too_specific, and new classifications.
- Route overlapping candidates toward memory update proposals from suggestMemoryPromotions instead of adding near-duplicate durable memories.
- Add auditMemoryDuplicates CLI/MCP/remote workflow for existing active durable-memory duplicate pairs.
- Clamp memory and candidate importance to 0..10 before it can affect retrieval ordering.
- Document the promotion-quality workflow and duplicate-audit tool.

## Validation
- npm test: 166 passed
- git diff --check: passed

Refs #137