### PR TITLE
Aggregate routed watch state flags

### DIFF
--- a/src/ingest/agents.js
+++ b/src/ingest/agents.js
@@ -1013,6 +1013,10 @@ export async function ingestAgentRoutedSessionsIncremental(app, options = {}) {
     checkpointsCreated: adapterResults.reduce((total, result) => total + result.checkpointsCreated, 0),
     routedFiles: adapterResults.reduce((total, result) => total + result.routedFiles, 0),
     skippedFiles: adapterResults.reduce((total, result) => total + result.skippedFiles, 0),
+    stateLoaded: adapterResults.some((result) => result.stateLoaded),
+    stateUpdated: adapterResults.some((result) => result.stateUpdated),
+    adapterStateLoadedCount: adapterResults.filter((result) => result.stateLoaded).length,
+    adapterStateUpdatedCount: adapterResults.filter((result) => result.stateUpdated).length,
   };
 }
 

--- a/src/ingest/common.js
+++ b/src/ingest/common.js
@@ -504,6 +504,8 @@ export function createWatchSummary(result, options = {}) {
     stateFile: result.stateFile,
     stateLoaded: Boolean(result.stateLoaded),
     stateUpdated: Boolean(result.stateUpdated),
+    adapterStateLoadedCount: result.adapterStateLoadedCount || 0,
+    adapterStateUpdatedCount: result.adapterStateUpdatedCount || 0,
   };
   if (result.corruptStateFile) {
     summary.corruptStateFile = result.corruptStateFile;

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -3716,6 +3716,10 @@ test('multi-agent routed watch auto-detects installed adapters and uses incremen
   );
   assert.equal(first.totals.filesScanned, 1);
   assert.equal(first.totals.appendedEvents, 2);
+  assert.equal(first.results[0].stateLoaded, false);
+  assert.equal(first.results[0].stateUpdated, true);
+  assert.equal(first.results[0].adapterStateLoadedCount, 0);
+  assert.equal(first.results[0].adapterStateUpdatedCount, 1);
   assert.equal(first.results[0].adapterResults[0].stateUpdated, true);
 
   const second = await watchAgentRoutedSessions(app, {
@@ -3736,6 +3740,10 @@ test('multi-agent routed watch auto-detects installed adapters and uses incremen
   assert.equal(second.totals.filesScanned, 1);
   assert.equal(second.totals.filesChanged, 0);
   assert.equal(second.totals.appendedEvents, 0);
+  assert.equal(second.results[0].stateLoaded, true);
+  assert.equal(second.results[0].stateUpdated, false);
+  assert.equal(second.results[0].adapterStateLoadedCount, 1);
+  assert.equal(second.results[0].adapterStateUpdatedCount, 0);
   assert.equal(second.results[0].adapterResults[0].stateLoaded, true);
 
   await fs.appendFile(rolloutFile, '{"malformed":\n');


### PR DESCRIPTION
## Summary
- aggregate adapter-level stateLoaded/stateUpdated into unified routed watch summaries
- expose adapterStateLoadedCount and adapterStateUpdatedCount counters in watch summaries
- extend the unified routed watch test to cover top-level aggregate flags and counters

## Verification
- npm test
- git diff --check

Closes #132