### PR TITLE
Use strict-safe schema for openai_compatible json_schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   memory-candidate v2 review fields (`schemaVersion`, `durabilityReason`,
   `riskReason`, `evidenceRefs`, and `suggestedAction`) when using the bundled
   strict schema.
+- Updated `openai_compatible` `json_schema` mode to send a strict-safe
+  checkpoint schema subset while preserving the default `json_object` behavior.
 - Localized human-readable memory-candidate review text and audit reasons to
   Korean by default while keeping keys, enum values, paths, commands, and other
   technical identifiers machine-readable.

--- a/README.md
+++ b/README.md
@@ -1749,6 +1749,14 @@ JSON output via `response_format: {"type":"json_object"}`. The provider still
 validates the returned checkpoint JSON locally and records failed runs without
 deleting raw evidence.
 
+`CONTEXTFORGE_OPENAI_COMPATIBLE_RESPONSE_FORMAT` defaults to `json_object`.
+When set to `json_schema`, ContextForge sends a strict-safe subset of the
+checkpoint schema with `strict: true`: object schemas use
+`additionalProperties: false`, all properties are listed in `required`, optional
+values are represented with nullable union types, and type-specific validation
+keywords unsupported by strict structured-output implementations are omitted.
+Local validation still runs after the provider response is parsed.
+
 ## Public Repo Hygiene
 
 - Runtime state lives under `.contextforge/` by default and is ignored by git.

--- a/src/distill/providers/openai_compatible.js
+++ b/src/distill/providers/openai_compatible.js
@@ -6,6 +6,26 @@ export const OPENAI_COMPATIBLE_PROMPT_VERSION = 'openai_compatible.prompt.v3';
 const DEFAULT_TIMEOUT_MS = 120000;
 const DEFAULT_BASE_URL = 'https://api.deepseek.com';
 const DEFAULT_MODEL = 'deepseek-v4-flash';
+const STRICT_SCHEMA_UNSUPPORTED_KEYS = new Set(['$id', 'minLength', 'minimum', 'maximum', 'description']);
+
+function strictSafeSchema(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => strictSafeSchema(item));
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  const sanitized = {};
+  for (const [key, nested] of Object.entries(value)) {
+    if (STRICT_SCHEMA_UNSUPPORTED_KEYS.has(key)) {
+      continue;
+    }
+    sanitized[key] = strictSafeSchema(nested);
+  }
+  return sanitized;
+}
+
+export const OPENAI_COMPATIBLE_CHECKPOINT_OUTPUT_SCHEMA = strictSafeSchema(CHECKPOINT_OUTPUT_SCHEMA);
 
 function normalizeBaseUrl(baseUrl) {
   const url = new URL(baseUrl || DEFAULT_BASE_URL);
@@ -61,7 +81,7 @@ function responseFormat(format) {
       json_schema: {
         name: 'contextforge_checkpoint',
         strict: true,
-        schema: CHECKPOINT_OUTPUT_SCHEMA,
+        schema: OPENAI_COMPATIBLE_CHECKPOINT_OUTPUT_SCHEMA,
       },
     };
   }

--- a/src/distill/providers/openai_compatible.js
+++ b/src/distill/providers/openai_compatible.js
@@ -6,7 +6,7 @@ export const OPENAI_COMPATIBLE_PROMPT_VERSION = 'openai_compatible.prompt.v3';
 const DEFAULT_TIMEOUT_MS = 120000;
 const DEFAULT_BASE_URL = 'https://api.deepseek.com';
 const DEFAULT_MODEL = 'deepseek-v4-flash';
-const STRICT_SCHEMA_UNSUPPORTED_KEYS = new Set(['$id', 'minLength', 'minimum', 'maximum', 'description']);
+const STRICT_SCHEMA_UNSUPPORTED_KEYS = new Set(['$id', 'minLength', 'minimum', 'maximum']);
 
 function strictSafeSchema(value) {
   if (Array.isArray(value)) {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -13,6 +13,7 @@ import Database from 'better-sqlite3';
 import { createCodexSdkPythonAutoPromoteAuditor } from '../src/audit/codex_sdk_python.js';
 import { canonicalizeScope, parseScopeAliases } from '../src/config/index.js';
 import { createContextForge } from '../src/core.js';
+import { OPENAI_COMPATIBLE_CHECKPOINT_OUTPUT_SCHEMA } from '../src/distill/providers/openai_compatible.js';
 import { STRUCTURED_CHECKPOINT_SCHEMA_VERSION, validateDistillOutput } from '../src/distill/validate.js';
 import { createOpenAiEmbeddingProvider } from '../src/embeddings/index.js';
 import { createInterruptibleSleep, normalizeRepoIdentity, shouldSkipRecentFailedAutoDistill } from '../src/ingest/common.js';
@@ -39,6 +40,59 @@ function testAdminPasswordHash(password) {
   const iterations = 100000;
   const hash = crypto.pbkdf2Sync(password, salt, iterations, 32, 'sha256');
   return `${iterations}:${salt.toString('hex')}:${hash.toString('hex')}`;
+}
+
+function collectSchemaKeywordPaths(value, keywords, pathParts = []) {
+  const matches = [];
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      matches.push(...collectSchemaKeywordPaths(item, keywords, [...pathParts, String(index)]));
+    }
+    return matches;
+  }
+  if (!value || typeof value !== 'object') {
+    return matches;
+  }
+  for (const [key, nested] of Object.entries(value)) {
+    const nextPath = [...pathParts, key];
+    if (keywords.has(key)) {
+      matches.push(nextPath.join('.'));
+    }
+    matches.push(...collectSchemaKeywordPaths(nested, keywords, nextPath));
+  }
+  return matches;
+}
+
+function collectStrictObjectSchemaViolations(value, pathParts = []) {
+  const violations = [];
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      violations.push(...collectStrictObjectSchemaViolations(item, [...pathParts, String(index)]));
+    }
+    return violations;
+  }
+  if (!value || typeof value !== 'object') {
+    return violations;
+  }
+  const type = value.type;
+  const includesObject = type === 'object' || (Array.isArray(type) && type.includes('object'));
+  if (includesObject) {
+    const pathText = pathParts.join('.') || '<root>';
+    if (value.additionalProperties !== false) {
+      violations.push(`${pathText}:missing_additionalProperties_false`);
+    }
+    const properties = value.properties && typeof value.properties === 'object' ? Object.keys(value.properties) : [];
+    const required = Array.isArray(value.required) ? value.required : [];
+    for (const property of properties) {
+      if (!required.includes(property)) {
+        violations.push(`${pathText}:missing_required:${property}`);
+      }
+    }
+  }
+  for (const [key, nested] of Object.entries(value)) {
+    violations.push(...collectStrictObjectSchemaViolations(nested, [...pathParts, key]));
+  }
+  return violations;
 }
 
 test('interruptible ingest sleep wakes when stopped', async () => {
@@ -7119,6 +7173,103 @@ test('openai_compatible provider distills through a fake DeepSeek-style chat com
   assert.equal(checkpoint.metadata.providerMetadata.openAiCompatible.baseUrlHost, 'api.deepseek.com');
   assert.equal(checkpoint.metadata.providerMetadata.openAiCompatible.model, 'manual-model');
   assert.equal(checkpoint.metadata.providerMetadata.openAiCompatible.usage.total_tokens, 20);
+});
+
+test('openai_compatible json_schema mode sends a strict-safe checkpoint schema', async () => {
+  const dataDir = await makeTempDir();
+  let requestBody;
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+    },
+    cwd: process.cwd(),
+    fetchImpl: async (url, request) => {
+      assert.equal(String(url), 'https://api.deepseek.com/chat/completions');
+      requestBody = JSON.parse(request.body);
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: JSON.stringify({
+                    summaryShort: 'Strict schema checkpoint.',
+                    summaryText: 'The json_schema response returned valid checkpoint JSON.',
+                    workingSummary: 'Strict schema mode is under test.',
+                    sessionWorkingContext: {
+                      mode: 'task_execution',
+                      currentTask: 'Test strict schema',
+                      currentUserIntent: 'Verify OpenAI-compatible json_schema payload',
+                      targetSubject: null,
+                      sourceSubject: null,
+                      lastUserCorrection: null,
+                      openQuestion: null,
+                      nonGoals: [],
+                      avoidMisreadings: [],
+                      confidence: 0.8,
+                    },
+                    decisions: [],
+                    todos: [],
+                    openQuestions: [],
+                    memoryCandidates: [],
+                    structured: null,
+                    sourceEventCount: 1,
+                    provider: 'openai_compatible',
+                    metadata: {
+                      providerNotes: 'strict schema synthetic output',
+                      retrievalHooks: ['json_schema'],
+                    },
+                  }),
+                },
+              },
+            ],
+          }),
+      };
+    },
+  });
+  app.updateRuntimeSettings({
+    values: {
+      distillProvider: 'openai_compatible',
+      openAiCompatible: {
+        preset: 'deepseek',
+        baseUrl: 'https://api.deepseek.com',
+        model: 'deepseek-v4-flash',
+        responseFormat: 'json_schema',
+      },
+    },
+    secrets: {
+      openAiCompatibleApiKey: 'deepseek-secret',
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'strict-openai-compatible-repo',
+    sessionId: 'strict-openai-compatible-session',
+    role: 'user',
+    content: 'Strict json_schema mode should use a compatible schema subset.',
+  });
+
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'strict-openai-compatible-repo',
+    sessionId: 'strict-openai-compatible-session',
+  });
+
+  assert.equal(requestBody.response_format.type, 'json_schema');
+  assert.equal(requestBody.response_format.json_schema.strict, true);
+  assert.deepEqual(requestBody.response_format.json_schema.schema, OPENAI_COMPATIBLE_CHECKPOINT_OUTPUT_SCHEMA);
+  assert.deepEqual(
+    collectSchemaKeywordPaths(
+      requestBody.response_format.json_schema.schema,
+      new Set(['$id', 'minLength', 'minimum', 'maximum', 'description']),
+    ),
+    [],
+  );
+  assert.deepEqual(collectStrictObjectSchemaViolations(requestBody.response_format.json_schema.schema), []);
+  assert.equal(checkpoint.provider, 'openai_compatible');
+  assert.equal(checkpoint.metadata.providerMetadata.openAiCompatible.responseFormat, 'json_schema');
 });
 
 test('openai_compatible provider repairs invalid JSON output and records retry metadata', async () => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -88,6 +88,11 @@ function collectStrictObjectSchemaViolations(value, pathParts = []) {
         violations.push(`${pathText}:missing_required:${property}`);
       }
     }
+    for (const property of required) {
+      if (!properties.includes(property)) {
+        violations.push(`${pathText}:unknown_required:${property}`);
+      }
+    }
   }
   for (const [key, nested] of Object.entries(value)) {
     violations.push(...collectStrictObjectSchemaViolations(nested, [...pathParts, key]));
@@ -7263,9 +7268,14 @@ test('openai_compatible json_schema mode sends a strict-safe checkpoint schema',
   assert.deepEqual(
     collectSchemaKeywordPaths(
       requestBody.response_format.json_schema.schema,
-      new Set(['$id', 'minLength', 'minimum', 'maximum', 'description']),
+      new Set(['$id', 'minLength', 'minimum', 'maximum']),
     ),
     [],
+  );
+  assert.deepEqual(
+    requestBody.response_format.json_schema.schema.properties.structured.properties.changes.items.properties
+      .description.type,
+    ['string', 'null'],
   );
   assert.deepEqual(collectStrictObjectSchemaViolations(requestBody.response_format.json_schema.schema), []);
   assert.equal(checkpoint.provider, 'openai_compatible');


### PR DESCRIPTION
## Summary
- derive a strict-safe checkpoint schema for openai_compatible json_schema mode
- omit strict-incompatible validation keywords while preserving the default json_object behavior
- add request payload tests for strict json_schema and document the mode difference

## Verification
- npm test
- git diff --check

Closes #123