### PR TITLE
[codex] Add workspace bootstrap federation

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -109,14 +109,40 @@ node src/cli.js workspaceResolve \
 ```
 
 `resolveWorkspace`는 included/excluded member, `includedBecause`, matched routing
-rule, warning을 반환한다. `bootstrap_context`에서 workspace federation을 실제로
-검색에 붙이는 작업은 별도 단계이며, 기본 동작은 계속 단일 repo bootstrap이다.
+rule, warning을 반환한다. `bootstrap_context`와 `bootstrapContext`는
+`workspaceKey`를 받으면 이 scope plan을 사용한다. `workspaceKey`가 없으면 기존
+단일 repo bootstrap 동작은 그대로 유지된다.
+
+Workspace bootstrap은 별도의 `workspace` block을 반환한다. top-level `results`는
+기존 primary scope 결과를 유지하고, `workspace.results`는 기본적으로 supplemental
+member scope만 담는다. 그래서 primary repo memory가 두 번 보이지 않는다. primary
+결과까지 workspace block에 넣고 싶을 때만 `includePrimaryInWorkspaceResults=true`를
+쓴다. Cross-repo retrieval은 `workspaceResultLimit` 기본 `8`,
+`workspacePerScopeLimit` 기본 `4`로 제한된다. 다른 repo의 checkpoint handoff는
+stale state가 섞일 수 있으므로 기본 제외이며, 필요할 때만
+`includeWorkspaceHandoffs=true`를 켠다. top-level `includeShared=true`는 primary
+bootstrap view에만 shared 결과를 추가한다. workspace shared retrieval은 workspace
+routing rule의 `includeShared`가 켤 때만 동작한다.
+
+Bootstrap 예시:
+
+```bash
+node src/cli.js bootstrapContext \
+  --scope repo \
+  --scopeKey github.com/example/backend \
+  --query "OpenAPI permission frontend contract" \
+  --consultReason startup \
+  --workspaceKey synthetic-product \
+  --workspaceMode auto \
+  --workspaceResultLimit 8 \
+  --workspacePerScopeLimit 4
+```
 
 `includeByDefault`는 보통 canonical suite나 contract repo에만 신중하게 쓴다. 이
-값은 scope-plan 포함 여부만 바꾸며, 이후 workspace retrieval은 여전히 per-scope와
-전체 result limit를 지켜야 한다. `workspaceDeactivate`는 profile을 hard delete하지
-않고 inactive로 표시한다. 같은 key로 `workspaceUpsert`를 다시 호출하면 기존 profile
-id를 유지한 채 재활성화한다.
+값은 scope-plan 포함 여부만 바꾸며, workspace retrieval은 여전히 per-scope와 전체
+result limit를 지킨다. `workspaceDeactivate`는 profile을 hard delete하지 않고
+inactive로 표시한다. 같은 key로 `workspaceUpsert`를 다시 호출하면 기존 profile id를
+유지한 채 재활성화한다.
 
 ## Multi-Agent Ingest
 
@@ -398,6 +424,9 @@ node src/cli.js bootstrapContext \
   최신 handoff를 구분해 볼 수 있다.
 - `handoff.latestCheckpoints`: 최근 checkpoint 목록.
 - `results`: durable memory, checkpoint, memory candidate 검색 결과.
+- `workspace`: `workspaceKey`를 넘겼을 때의 scope plan, bounded supplemental
+  member-scope 결과, compact workspace memory map. top-level `results`는 계속
+  primary scope view다.
 - `workingSummary`: sessionId를 알 때 가져오는 현재 세션 resume state.
 - `rawTail`: 필요한 경우에만 요청하는 최근 raw event 꼬리.
 

--- a/README.md
+++ b/README.md
@@ -151,14 +151,40 @@ node src/cli.js workspaceResolve \
 
 `resolveWorkspace` returns a scope plan with included/excluded members,
 `includedBecause`, matched routing rules, and warnings. `bootstrap_context`
-federation is intentionally a follow-up layer: single-repo bootstrap remains
-the default behavior until a caller opts into workspace use.
+and `bootstrapContext` can opt into that plan with `workspaceKey`. Without a
+workspace key, single-repo bootstrap remains unchanged.
+
+Workspace bootstrap returns a separate `workspace` block. Top-level `results`
+keep the existing primary-scope behavior; `workspace.results` defaults to
+supplemental member scopes only so the primary repo is not shown twice. Use
+`includePrimaryInWorkspaceResults=true` only when a merged workspace result view
+is explicitly useful. Cross-repo retrieval is bounded with
+`workspaceResultLimit` (default `8`) and `workspacePerScopeLimit` (default `4`).
+Workspace checkpoint handoffs are excluded by default; set
+`includeWorkspaceHandoffs=true` when the caller wants stale-prone recent
+handoff state from member repos. Top-level `includeShared=true` only adds
+shared results to the primary bootstrap view; workspace shared retrieval is
+enabled by workspace routing rules with `includeShared`.
+
+Example bootstrap:
+
+```bash
+node src/cli.js bootstrapContext \
+  --scope repo \
+  --scopeKey github.com/example/backend \
+  --query "OpenAPI permission frontend contract" \
+  --consultReason startup \
+  --workspaceKey synthetic-product \
+  --workspaceMode auto \
+  --workspaceResultLimit 8 \
+  --workspacePerScopeLimit 4
+```
 
 Use `includeByDefault` sparingly, usually for a canonical suite or contract
-repo. It only affects scope-plan inclusion; future workspace retrieval still
-must respect bounded per-scope and total result limits. `workspaceDeactivate`
-soft-deletes a profile by marking it inactive, and a later `workspaceUpsert`
-with the same key reactivates the existing profile.
+repo. It only affects scope-plan inclusion; workspace retrieval still respects
+bounded per-scope and total result limits. `workspaceDeactivate` soft-deletes a
+profile by marking it inactive, and a later `workspaceUpsert` with the same key
+reactivates the existing profile.
 
 ## Distillation
 
@@ -1193,6 +1219,11 @@ It also exposes `handoff.latestConsolidation.thread` and
 so agents can see a richer period summary without loading raw evidence by
 default. For multi-repo work, pass comma-separated repo `--relatedScopeKeys` so a
 subrepo can also receive the suite/root repo's latest handoff.
+For configured workspace profiles, pass `--workspaceKey` to add a separate
+`workspace` block with a scope plan, bounded supplemental member-scope results,
+and compact per-scope memory overview. Top-level `results` remain the primary
+scope view unless the caller explicitly enables primary duplication in the
+workspace block.
 Bootstrap also returns a separate `memoryMap` channel for progressive durable
 memory navigation. The map groups related active memories into compact clusters,
 chooses a canonical `consolidatedMemory` for each cluster, and includes an

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -33,10 +33,15 @@ canonical scope key `github.com/example/repo`, and an explicit
 may matter.
 
 If the repository belongs to a configured multi-repo workspace, use
-`resolve_workspace` first to inspect the scope plan. Workspace profiles do not
-change storage mode; they only define which existing scopes are consulted
-together. Keep ordinary single-repo bootstrap as the default unless the task
-needs cross-repo context.
+`resolve_workspace` first to inspect the scope plan, or pass `workspaceKey` to
+`bootstrap_context` when cross-repo context is needed during startup/resume.
+Workspace profiles do not change storage mode; they only define which existing
+scopes are consulted together. Keep ordinary single-repo bootstrap as the
+default unless the task needs cross-repo context. When workspace bootstrap is
+enabled, read top-level `results` as the primary-scope view and
+`workspace.results` as bounded supplemental member-scope context. Top-level
+`includeShared=true` does not by itself enable workspace shared retrieval;
+workspace shared results require a workspace routing rule with `includeShared`.
 
 Do not call `bootstrap_context` just to re-confirm current intent inside the
 same uninterrupted active session. For active-session file/API/error/domain
@@ -92,7 +97,11 @@ For multi-repo products, a workspace profile may define a federation plan for
 related repo scopes. In remote mode, workspace profile reads/writes/resolve
 calls must go to the remote canonical server and must not fall back to local
 state. Use `resolve_workspace` to see included/excluded scopes and routing
-reasons before relying on cross-repo context.
+reasons before relying on cross-repo context, or pass `workspaceKey` to
+`bootstrap_context` to retrieve bounded supplemental member-scope results.
+Workspace bootstrap result provenance should preserve `workspaceKey`,
+`memberName`, `role`, and `includedBecause`; checkpoint results from member
+repos require live-state verification before action.
 
 Read `handoff.latestCheckpoints` before durable memory for recent work status,
 recent decisions, open todos, branch/PR/CI flow, and next actions. Treat

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,10 +158,27 @@ member, included and excluded scopes, `includedBecause`, matched rules or
 matched terms, and warnings such as `primary_scope_not_workspace_member` or
 `canonical_scope_not_member`.
 
+`bootstrap_context` can opt into workspace federation with `workspaceKey`.
+Workspace bootstrap keeps ordinary top-level `results` focused on the primary
+scope and returns supplemental cross-repo retrieval in a separate `workspace`
+block. `workspace.results` defaults to supplemental member scopes only; callers
+can opt into duplicating the primary scope with
+`includePrimaryInWorkspaceResults=true`.
+
+Workspace retrieval is bounded and explainable. The default total limit is
+`workspaceResultLimit=8`; the default per-member limit is
+`workspacePerScopeLimit=4`. Result provenance includes `workspaceKey`,
+`memberName`, `role`, and `includedBecause`. Checkpoint and memory-candidate
+results remain lower-trust material and carry verification or review hints.
+Workspace ranking keeps result type as the first tier, so durable memory is not
+overtaken by checkpoint handoff state when handoffs are explicitly included.
+Top-level `includeShared` belongs to the primary bootstrap view; workspace
+shared retrieval is enabled by workspace routing rules with `includeShared`.
+
 `include_by_default` is a scope-plan convenience, not permission to retrieve an
 unbounded amount of memory. Use it sparingly, usually for the canonical suite or
-contract repo, and keep future workspace retrieval bounded by per-scope and
-total limits. Deactivating a workspace profile is a soft delete that marks the
+contract repo, and keep workspace retrieval bounded by per-scope and total
+limits. Deactivating a workspace profile is a soft delete that marks the
 profile inactive; upserting the same `workspaceKey` later reactivates the
 existing profile.
 

--- a/docs/runtime-modes.md
+++ b/docs/runtime-modes.md
@@ -178,6 +178,13 @@ those scopes are authoritative. Remote mode plus workspace profiles is the
 recommended topology for users who work across several machines and several
 repositories.
 
+When `bootstrap_context` is called with a `workspaceKey`, workspace resolution
+and supplemental retrieval must use the same storage authority as the caller.
+In remote client mode, the workspace profile, member scopes, routing rules, and
+retrieval all go through the remote canonical server. The response keeps
+primary-scope results at top level and returns bounded cross-repo results in a
+separate `workspace` block.
+
 Useful checks:
 
 ```bash

--- a/docs/skills/contextforge-memory/SKILL.md
+++ b/docs/skills/contextforge-memory/SKILL.md
@@ -45,7 +45,11 @@ For multi-repo products, call `resolve_workspace` when a workspace profile is
 configured and the task may involve cross-repo contracts, frontend consumers,
 E2E, release gates, or shared API/domain decisions. Read the scope plan before
 using cross-repo context. Treat `includedBecause`, matched rules, and warnings
-as part of the retrieval explanation.
+as part of the retrieval explanation. During startup/resume, callers may pass
+`workspaceKey` to `bootstrap_context` to receive a separate `workspace` block
+with bounded supplemental member-scope results. Top-level `includeShared=true`
+adds shared memory to the primary bootstrap view only; workspace shared results
+require a workspace routing rule with `includeShared`.
 
 In remote mode, workspace profile reads/writes/resolve calls must hit the
 remote canonical server. There is no silent local/project-local fallback.
@@ -53,7 +57,7 @@ Workspace profiles should store canonical scope identity only, not local
 `repoPath`, tokens, raw transcripts, or machine-private paths.
 
 Treat `includeByDefault` as scope-plan inclusion only. It does not justify
-unbounded retrieval from that scope; future workspace retrieval must still obey
+unbounded retrieval from that scope; workspace retrieval must still obey
 per-scope and total result limits. Workspace profile deactivation is soft
 delete: the profile becomes inactive and can be reactivated by upserting the
 same key.
@@ -137,10 +141,11 @@ At the start of non-trivial project work:
    `latestCandidateAt`, `latestPromotedAt`, pending counts, and recent
    candidate/promotion counts.
 7. For multi-repo work, pass repo `relatedScopeKeys` for parent/suite/subrepo scopes whose latest handoff may matter. `latestCheckpointLimit` applies per scope.
-8. Set `includeShared: true` only for cross-repo/user-wide policy, credentials location, deployment, or recurring preference questions.
-9. Read the storage block and result trust roles.
-10. Use targeted `search` calls only when more detail is needed.
-11. Use `get_memory` only when you already know the exact durable key.
+8. When a workspace profile is configured and the task needs cross-repo context, pass `workspaceKey` to receive bounded supplemental workspace results in `workspace.results`.
+9. Set `includeShared: true` only for cross-repo/user-wide policy, credentials location, deployment, or recurring preference questions.
+10. Read the storage block and result trust roles.
+11. Use targeted `search` calls only when more detail is needed.
+12. Use `get_memory` only when you already know the exact durable key.
 
 `bootstrap_context` does not create a session. It retrieves scoped context.
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -103,6 +103,11 @@ function toCoreOptions(options) {
     limit: options.limit == null ? 10 : Number(options.limit),
     memoryMapLimit: options.memoryMapLimit == null ? undefined : Number(options.memoryMapLimit),
     memoryMapClusterSize: options.memoryMapClusterSize == null ? undefined : Number(options.memoryMapClusterSize),
+    workspaceResultLimit: options.workspaceResultLimit == null ? undefined : Number(options.workspaceResultLimit),
+    workspacePerScopeLimit: options.workspacePerScopeLimit == null ? undefined : Number(options.workspacePerScopeLimit),
+    includeWorkspaceHandoffs: options.includeWorkspaceHandoffs === true || options.includeWorkspaceHandoffs === 'true',
+    includePrimaryInWorkspaceResults:
+      options.includePrimaryInWorkspaceResults === true || options.includePrimaryInWorkspaceResults === 'true',
     searchScopes: options.searchScopes,
     sharedScopeKey: options.sharedScopeKey,
     includeProvenance: options.includeProvenance === true || options.includeProvenance === 'true',

--- a/src/core.js
+++ b/src/core.js
@@ -963,6 +963,169 @@ function bootstrapSummary(results) {
   return `Found ${results.length} relevant ContextForge result(s): ${parts}. Treat them as context candidates and verify live state before acting.`;
 }
 
+function scopeIdentity(scopeType, scopeKey) {
+  return `${scopeType}:${scopeKey}`;
+}
+
+function queryContainsAny(query, terms) {
+  const text = String(query || '').toLowerCase();
+  return terms.some((term) => text.includes(term));
+}
+
+function workspaceRoleBoost(role, query) {
+  if (
+    role === 'api-domain-ssot' &&
+    queryContainsAny(query, ['endpoint', 'schema', 'permission', 'migration', 'openapi'])
+  ) {
+    return 350;
+  }
+  if (
+    role === 'cross-repo-contract' &&
+    queryContainsAny(query, ['rfc', 'e2e', 'contract', 'release', 'consumer'])
+  ) {
+    return 320;
+  }
+  if (
+    ['consumer', 'mobile-consumer', 'desktop-web-consumer'].includes(role) &&
+    queryContainsAny(query, ['frontend', 'mobile', 'desktop', 'flutter', 'react', 'electron', 'client'])
+  ) {
+    return 220;
+  }
+  return 0;
+}
+
+function workspaceTypeBoost(type) {
+  if (type === 'memory') return 600;
+  if (type === 'checkpoint') return 120;
+  if (type === 'memory_candidate') return 60;
+  return 0;
+}
+
+function workspaceTypeTier(type) {
+  if (type === 'memory') return 3;
+  if (type === 'checkpoint') return 2;
+  if (type === 'memory_candidate') return 1;
+  return 0;
+}
+
+function workspaceResultSortScore(result, member, query) {
+  return (
+    workspaceTypeBoost(result.type) +
+    workspaceRoleBoost(member.role, query) +
+    Number(member.priority || 0) +
+    Math.min(500, Number(result.score || 0))
+  );
+}
+
+function workspaceSearchMemberFromScope(scope) {
+  return {
+    scopeType: scope.scopeType || scope.scope,
+    scopeKey: scope.scopeKey,
+    memberName: scope.memberName || null,
+    role: scope.role || 'member',
+    priority: Number(scope.priority || 0),
+    includedBecause: scope.includedBecause || [],
+  };
+}
+
+function workspaceBootstrapResult(result, member, workspaceKey, query) {
+  const compact = bootstrapResult(result, 'workspace');
+  const scope = {
+    scope: member.scopeType,
+    scopeType: member.scopeType,
+    scopeKey: member.scopeKey,
+    workspaceKey,
+    memberName: member.memberName,
+    role: member.role,
+  };
+  return {
+    ...compact,
+    scope,
+    source: {
+      ...(compact.source || {}),
+      ...scope,
+    },
+    includedBecause: member.includedBecause || [],
+    workspaceRank: workspaceResultSortScore(result, member, query),
+  };
+}
+
+function buildWorkspaceMemoryMap({ workspaceKey, scopePlan, results }) {
+  const byScope = new Map();
+  for (const scope of scopePlan.includedScopes || []) {
+    byScope.set(scopeIdentity(scope.scopeType, scope.scopeKey), {
+      scope: scope.scopeType,
+      scopeType: scope.scopeType,
+      scopeKey: scope.scopeKey,
+      memberName: scope.memberName,
+      role: scope.role,
+      includedBecause: scope.includedBecause || [],
+      resultCount: 0,
+      topResults: [],
+    });
+  }
+  for (const result of results) {
+    const key = scopeIdentity(result.scope?.scopeType, result.scope?.scopeKey);
+    let entry = byScope.get(key);
+    if (!entry && result.scope?.scopeType && result.scope?.scopeKey) {
+      entry = {
+        scope: result.scope.scopeType,
+        scopeType: result.scope.scopeType,
+        scopeKey: result.scope.scopeKey,
+        memberName: result.scope.memberName || null,
+        role: result.scope.role || 'member',
+        includedBecause: result.includedBecause || [],
+        resultCount: 0,
+        topResults: [],
+      };
+      byScope.set(key, entry);
+    }
+    if (!entry) continue;
+    entry.resultCount += 1;
+    if (entry.topResults.length < 3) {
+      entry.topResults.push({
+        type: result.type,
+        key: result.key,
+        category: result.category,
+        trust: result.trust,
+        verificationRequired: result.verificationRequired,
+      });
+    }
+  }
+  return {
+    kind: 'workspace_memory_map',
+    workspaceKey,
+    policy: {
+      navigation: 'scope_plan_first_expand_on_demand',
+      detail:
+        'Use primary repo results first, then workspace contract and member summaries; expand per-scope details only when needed.',
+    },
+    scopes: [...byScope.values()],
+  };
+}
+
+function workspaceSummary(results) {
+  if (!results.length) {
+    return 'No supplemental workspace results found for this query.';
+  }
+  const counts = results.reduce((acc, result) => {
+    acc[result.type] = (acc[result.type] || 0) + 1;
+    return acc;
+  }, {});
+  const parts = Object.entries(counts)
+    .map(([type, count]) => `${count} ${type}`)
+    .join(', ');
+  return `Found ${results.length} supplemental workspace result(s): ${parts}. Use scope provenance before acting.`;
+}
+
+function workspaceBlockSummary(scopePlan, results) {
+  if (!scopePlan.enabled) {
+    const warning = scopePlan.warnings?.[0];
+    return warning?.message || 'Workspace federation is disabled for this request.';
+  }
+  return workspaceSummary(results);
+}
+
 function storageBootstrapInfo(config, info) {
   const vectorReady = Boolean(info.vector?.sqliteVecAvailable && info.embeddings?.enabled);
   const staleSources = Number(info.embeddings?.coverage?.staleSources || 0);
@@ -3387,6 +3550,7 @@ export function createContextForge(options = {}) {
         : null;
       const mapLimit = memoryMapLimit(options.memoryMapLimit, 5, 'memoryMapLimit');
       const mapClusterSize = memoryMapLimit(options.memoryMapClusterSize, 6, 'memoryMapClusterSize');
+      const workspaceRequested = options.workspaceKey != null && options.workspaceKey !== '';
       return useStore(async (store) => {
         const info = buildDbInfo(store);
         const storage = storageBootstrapInfo(config, info);
@@ -3428,6 +3592,128 @@ export function createContextForge(options = {}) {
           ...repoResults.map((result) => bootstrapResult(result, 'primary')),
           ...sharedResults.map((result) => bootstrapResult(result, 'shared')),
         ];
+        let workspaceBlock = null;
+        if (workspaceRequested) {
+          const workspaceKey = normalizeWorkspaceKey(options.workspaceKey);
+          const workspaceMode = normalizeWorkspaceMode(options.workspaceMode || options.mode || 'auto');
+          const workspaceResultLimit = positiveInteger(
+            options.workspaceResultLimit == null ? 8 : Number(options.workspaceResultLimit),
+            'workspaceResultLimit',
+          );
+          const workspacePerScopeLimit = positiveInteger(
+            options.workspacePerScopeLimit == null ? 4 : Number(options.workspacePerScopeLimit),
+            'workspacePerScopeLimit',
+          );
+          const includeWorkspaceHandoffs = truthyOption(options.includeWorkspaceHandoffs);
+          const includePrimaryInWorkspaceResults = truthyOption(options.includePrimaryInWorkspaceResults);
+          const workspaceProfile = store.getWorkspaceProfileByKey({ workspaceKey, includeInactive: true });
+          const workspaceMembers = workspaceProfile ? store.listWorkspaceMembers({ workspaceKey }) : [];
+          const workspaceRoutingRules = workspaceProfile
+            ? store.listWorkspaceRoutingRules({ workspaceKey, status: 'all' })
+            : [];
+          const scopePlan = resolveWorkspaceScopePlan({
+            workspace: workspaceProfile,
+            members: workspaceMembers,
+            routingRules: workspaceRoutingRules,
+            primaryScope: scope.scopeType,
+            primaryScopeKey: scope.scopeKey,
+            query: options.query,
+            consultReason,
+            mode: workspaceMode,
+            includeShared: false,
+          });
+          const workspaceWarnings = [...(scopePlan.warnings || [])];
+          let workspaceResults = [];
+          if (scopePlan.enabled) {
+            const primaryIdentity = scopeIdentity(scope.scopeType, scope.scopeKey);
+            const searchMembers = (scopePlan.includedScopes || [])
+              .map((includedScope) => workspaceSearchMemberFromScope(includedScope))
+              .filter(
+                (member) =>
+                  includePrimaryInWorkspaceResults || scopeIdentity(member.scopeType, member.scopeKey) !== primaryIdentity,
+              );
+            const seenSearchScopes = new Set();
+            for (const member of searchMembers) {
+              const identity = scopeIdentity(member.scopeType, member.scopeKey);
+              if (seenSearchScopes.has(identity)) {
+                continue;
+              }
+              seenSearchScopes.add(identity);
+              const scopedResults = searchStoreWithScope(
+                store,
+                {
+                  scopeType: member.scopeType,
+                  scopeKey: member.scopeKey,
+                },
+                {
+                  query: options.query,
+                  limit: workspacePerScopeLimit,
+                  sharedScopeKey,
+                },
+                queryEmbedding,
+              )
+                .filter((result) => includeWorkspaceHandoffs || result.type !== 'checkpoint')
+                .map((result) => workspaceBootstrapResult(result, member, workspaceKey, options.query));
+              workspaceResults.push(...scopedResults);
+            }
+            if (scopePlan.includeShared) {
+              if (!sharedScopeKey) {
+                workspaceWarnings.push({
+                  code: 'missing_shared_scope_key',
+                  message: 'Workspace scope plan requested shared scope, but no shared scope key is configured.',
+                });
+              } else {
+                const sharedMember = {
+                  scopeType: 'shared',
+                  scopeKey: sharedScopeKey,
+                  memberName: null,
+                  role: 'shared',
+                  priority: 0,
+                  includedBecause: ['include_shared'],
+                };
+                const sharedWorkspaceResults = searchStoreWithScope(
+                  store,
+                  {
+                    scopeType: 'shared',
+                    scopeKey: sharedScopeKey,
+                  },
+                  {
+                    query: options.query,
+                    limit: workspacePerScopeLimit,
+                    sharedScopeKey,
+                  },
+                  queryEmbedding,
+                )
+                  .filter((result) => includeWorkspaceHandoffs || result.type !== 'checkpoint')
+                  .map((result) => workspaceBootstrapResult(result, sharedMember, workspaceKey, options.query));
+                workspaceResults.push(...sharedWorkspaceResults);
+              }
+            }
+            workspaceResults = workspaceResults
+              .sort(
+                (a, b) =>
+                  workspaceTypeTier(b.type) - workspaceTypeTier(a.type) ||
+                  b.workspaceRank - a.workspaceRank ||
+                  String(a.scope?.scopeKey || '').localeCompare(String(b.scope?.scopeKey || '')) ||
+                  String(a.key || '').localeCompare(String(b.key || '')),
+              )
+              .slice(0, workspaceResultLimit);
+          }
+          workspaceBlock = {
+            enabled: Boolean(scopePlan.enabled),
+            scopePlan,
+            results: workspaceResults,
+            memoryMap: buildWorkspaceMemoryMap({ workspaceKey, scopePlan, results: workspaceResults }),
+            warnings: workspaceWarnings,
+            limits: {
+              resultLimit: workspaceResultLimit,
+              perScopeLimit: workspacePerScopeLimit,
+              includeWorkspaceHandoffs,
+              includePrimaryInWorkspaceResults,
+            },
+            summary: workspaceBlockSummary(scopePlan, workspaceResults),
+          };
+        }
         const memoryMapSeeds = repoResults
           .filter((result) => result.type === 'memory' && result.memory)
           .map((result) => result.memory);
@@ -3524,6 +3810,7 @@ export function createContextForge(options = {}) {
           memoryLifecycle: memoryLifecycleForScope(store, scope),
           ...(sessionId ? { sessionId, workingSummary, structuredWorkingContext, rawTail, rawTailLimit } : {}),
           ...(sharedSkippedReason ? { sharedSkippedReason } : {}),
+          ...(workspaceBlock ? { workspace: workspaceBlock } : {}),
           memoryMap,
           summary: bootstrapSummary(results),
           results,

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -335,7 +335,7 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Bootstrap Context',
       description:
-        'Resolve scoped ContextForge memory for startup/resume/compaction recovery in one call. Includes query-independent latest checkpoint handoff (default 1, max 3) before search results, plus a compact memoryMap for progressive durable-memory navigation. Pass consultReason to distinguish startup/resume/compaction_recovery/agent_switch from active_session, targeted_search, or live_state_check. During active work, prefer search for file/API/error/domain lookups and live sources for mutable state. Does not create a session; pass a known Codex/Claude/ContextForge sessionId to load session working state. rawTailLimit defaults to 0; set a positive value to include raw tail.',
+        'Resolve scoped ContextForge memory for startup/resume/compaction recovery in one call. Includes query-independent latest checkpoint handoff (default 1, max 3) before search results, plus a compact memoryMap for progressive durable-memory navigation. Pass workspaceKey to add a separate bounded workspace federation block; workspace profiles define which existing scopes are consulted together and do not change storage mode. Pass consultReason to distinguish startup/resume/compaction_recovery/agent_switch from active_session, targeted_search, or live_state_check. During active work, prefer search for file/API/error/domain lookups and live sources for mutable state. Does not create a session; pass a known Codex/Claude/ContextForge sessionId to load session working state. rawTailLimit defaults to 0; set a positive value to include raw tail.',
       inputSchema: {
         ...scopedSchema,
         query: z.string(),
@@ -345,6 +345,12 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
         latestCheckpointLimit: z.number().int().min(0).max(3).optional(),
         relatedScopeKeys: z.array(z.string()).optional(),
         includeShared: z.boolean().optional(),
+        workspaceKey: z.string().optional(),
+        workspaceMode: workspaceModeSchema.optional(),
+        workspaceResultLimit: z.number().int().positive().optional(),
+        workspacePerScopeLimit: z.number().int().positive().optional(),
+        includeWorkspaceHandoffs: z.boolean().optional(),
+        includePrimaryInWorkspaceResults: z.boolean().optional(),
         limit: z.number().int().positive().optional(),
         memoryMapLimit: z.number().int().positive().max(20).optional(),
         memoryMapClusterSize: z.number().int().positive().max(20).optional(),

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -10886,6 +10886,242 @@ test('CLI supports workspace profile upsert member rule and resolve commands', a
   );
 });
 
+test('bootstrapContext adds bounded supplemental workspace results when workspaceKey is provided', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+  app.upsertWorkspaceProfile({
+    workspaceKey: 'bootstrap-workspace',
+    displayName: 'Bootstrap Workspace',
+    canonicalScope: 'repo',
+    canonicalScopeKey: 'github.com/example/suite',
+  });
+  app.upsertWorkspaceMember({
+    workspaceKey: 'bootstrap-workspace',
+    name: 'suite',
+    scope: 'repo',
+    scopeKey: 'github.com/example/suite',
+    role: 'cross-repo-contract',
+    priority: 100,
+    includeByDefault: true,
+  });
+  app.upsertWorkspaceMember({
+    workspaceKey: 'bootstrap-workspace',
+    name: 'backend',
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    role: 'api-domain-ssot',
+    priority: 90,
+  });
+  app.upsertWorkspaceMember({
+    workspaceKey: 'bootstrap-workspace',
+    name: 'web',
+    scope: 'repo',
+    scopeKey: 'github.com/example/web',
+    role: 'desktop-web-consumer',
+    priority: 60,
+  });
+  app.upsertWorkspaceRoutingRule({
+    workspaceKey: 'bootstrap-workspace',
+    ruleKey: 'contract_terms',
+    priority: 100,
+    match: { termsAny: ['OpenAPI', 'contract', 'frontend'] },
+    include: { roles: ['cross-repo-contract', 'api-domain-ssot', 'desktop-web-consumer'] },
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    key: 'backend-openapi-contract',
+    content: 'Backend owns the OpenAPI permission contract.',
+    category: 'contract',
+    importance: 8,
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/example/suite',
+    key: 'suite-openapi-contract',
+    content: 'Suite records the cross-repo OpenAPI frontend contract.',
+    category: 'contract',
+    importance: 8,
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/example/web',
+    key: 'web-openapi-consumer',
+    content: 'Web frontend consumes the OpenAPI contract.',
+    category: 'consumer',
+    importance: 5,
+  });
+
+  const withoutWorkspace = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    query: 'OpenAPI frontend contract',
+    consultReason: 'startup',
+  });
+  assert.equal(Object.prototype.hasOwnProperty.call(withoutWorkspace, 'workspace'), false);
+
+  const bootstrap = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    query: 'OpenAPI frontend contract',
+    consultReason: 'startup',
+    workspaceKey: 'bootstrap-workspace',
+    workspaceResultLimit: 2,
+    workspacePerScopeLimit: 1,
+  });
+
+  assert.equal(bootstrap.workspace.enabled, true);
+  assert.equal(bootstrap.workspace.scopePlan.primaryScope.memberName, 'backend');
+  assert.deepEqual(
+    bootstrap.workspace.scopePlan.includedScopes.map((scope) => scope.memberName),
+    ['suite', 'backend', 'web'],
+  );
+  assert.equal(bootstrap.results.some((result) => result.key === 'backend-openapi-contract'), true);
+  assert.equal(bootstrap.workspace.results.length, 2);
+  assert.equal(bootstrap.workspace.results.some((result) => result.key === 'backend-openapi-contract'), false);
+  assert.deepEqual(
+    bootstrap.workspace.results.map((result) => result.scope.memberName),
+    ['suite', 'web'],
+  );
+  assert.deepEqual(bootstrap.workspace.results[0].includedBecause, ['include_by_default', 'canonical_scope', 'routing_rule:contract_terms']);
+  assert.equal(bootstrap.workspace.results[0].scope.workspaceKey, 'bootstrap-workspace');
+  assert.equal(bootstrap.workspace.memoryMap.kind, 'workspace_memory_map');
+  assert.equal(
+    bootstrap.workspace.memoryMap.scopes.find((scope) => scope.memberName === 'backend').resultCount,
+    0,
+  );
+  assert.equal(bootstrap.workspace.limits.includeWorkspaceHandoffs, false);
+});
+
+test('bootstrapContext workspace shared retrieval is opt-in and provenance tagged', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_SHARED_SCOPE_KEY: 'team-shared',
+    },
+    cwd: process.cwd(),
+  });
+  app.upsertWorkspaceProfile({
+    workspaceKey: 'shared-workspace',
+    canonicalScope: 'repo',
+    canonicalScopeKey: 'github.com/example/backend',
+  });
+  app.upsertWorkspaceMember({
+    workspaceKey: 'shared-workspace',
+    name: 'backend',
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    role: 'api-domain-ssot',
+  });
+  app.upsertWorkspaceRoutingRule({
+    workspaceKey: 'shared-workspace',
+    ruleKey: 'shared_terms',
+    match: { termsAny: ['policy'] },
+    include: { roles: ['api-domain-ssot'] },
+    includeShared: true,
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    key: 'backend-policy',
+    content: 'Backend policy memory.',
+  });
+  app.remember({
+    scope: 'shared',
+    scopeKey: 'team-shared',
+    key: 'shared-policy',
+    content: 'Shared policy memory for workspace retrieval.',
+  });
+
+  const ordinary = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    query: 'policy',
+    consultReason: 'startup',
+    workspaceKey: 'shared-workspace',
+  });
+  assert.equal(ordinary.workspace.scopePlan.includeShared, true);
+  assert.equal(ordinary.workspace.results.some((result) => result.scope.scopeType === 'shared'), true);
+  assert.equal(ordinary.workspace.results.find((result) => result.scope.scopeType === 'shared').scope.workspaceKey, 'shared-workspace');
+
+  const off = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    query: 'policy',
+    consultReason: 'startup',
+    workspaceKey: 'shared-workspace',
+    workspaceMode: 'off',
+  });
+  assert.equal(off.workspace.enabled, false);
+  assert.equal(off.workspace.results.length, 0);
+  assert.equal(off.workspace.scopePlan.warnings[0].code, 'workspace_mode_off');
+});
+
+test('bootstrapContext does not let primary includeShared enable workspace shared retrieval', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_SHARED_SCOPE_KEY: 'team-shared',
+    },
+    cwd: process.cwd(),
+  });
+  app.upsertWorkspaceProfile({
+    workspaceKey: 'primary-shared-workspace',
+    canonicalScope: 'repo',
+    canonicalScopeKey: 'github.com/example/backend',
+  });
+  app.upsertWorkspaceMember({
+    workspaceKey: 'primary-shared-workspace',
+    name: 'backend',
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    role: 'api-domain-ssot',
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    key: 'backend-policy',
+    content: 'Backend policy memory.',
+  });
+  app.remember({
+    scope: 'shared',
+    scopeKey: 'team-shared',
+    key: 'shared-policy',
+    content: 'Shared policy memory should stay in top-level shared results only.',
+  });
+
+  const bootstrap = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    query: 'policy',
+    consultReason: 'startup',
+    includeShared: true,
+    workspaceKey: 'primary-shared-workspace',
+  });
+
+  assert.equal(bootstrap.results.some((result) => result.group === 'shared' && result.key === 'shared-policy'), true);
+  assert.equal(bootstrap.workspace.scopePlan.includeShared, false);
+  assert.equal(bootstrap.workspace.results.some((result) => result.scope.scopeType === 'shared'), false);
+});
+
+test('bootstrapContext ignores workspace-only limits when workspaceKey is absent', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  const bootstrap = await app.bootstrapContext({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    query: 'policy',
+    consultReason: 'startup',
+    workspaceResultLimit: 0,
+    workspacePerScopeLimit: 0,
+  });
+
+  assert.equal(Object.prototype.hasOwnProperty.call(bootstrap, 'workspace'), false);
+});
+
 test('CLI supports the v0 workflow with synthetic data', async () => {
   const dataDir = await makeTempDir();
   const env = { ...process.env, CONTEXTFORGE_DATA_DIR: dataDir };


### PR DESCRIPTION
## Summary

Implements PR 2 from #147: `bootstrapContext` / `bootstrap_context` can now opt into workspace profile federation with `workspaceKey` while keeping existing single-repo bootstrap behavior unchanged by default.

## What changed

- Adds workspace bootstrap options:
  - `workspaceKey`
  - `workspaceMode`
  - `workspaceResultLimit` (default 8)
  - `workspacePerScopeLimit` (default 4)
  - `includeWorkspaceHandoffs` (default false)
  - `includePrimaryInWorkspaceResults` (default false)
- Keeps top-level `results` as the primary-scope view.
- Adds a separate `workspace` block with:
  - `scopePlan`
  - bounded supplemental `results`
  - compact `workspace_memory_map`
  - warnings, limits, and summary
- Tags workspace results with `workspaceKey`, `memberName`, `role`, and `includedBecause` provenance.
- Excludes primary scope from `workspace.results` by default to avoid duplicate primary memory.
- Keeps top-level `includeShared` scoped to the primary bootstrap view; workspace shared retrieval is enabled by workspace routing rules with `includeShared`.
- Excludes workspace checkpoint handoffs by default because member-repo checkpoint state can be stale.
- Keeps durable memory ahead of checkpoint handoff state with a result-type ranking tier.
- Updates MCP schema, CLI option plumbing, docs, and agent guidance.

## Review follow-up

Addressed non-blocking review notes from the first draft:

- Decoupled primary `includeShared` from workspace shared retrieval to avoid duplicate shared results.
- Moved workspace-only limit validation behind `workspaceKey` so ordinary bootstrap calls are not affected.
- Added a disabled-workspace summary path instead of reporting disabled plans as empty searches.
- Preserved `mode` alias handling for bootstrap workspace mode consistency.

## Notes

This PR intentionally does not extend standalone `search` with `workspaceKey` yet. The first integration point is `bootstrap_context`, because it is the agent startup/resume entrypoint and keeps the cross-repo retrieval surface bounded and explainable.

Refs #147.

## Verification

- `node --test --test-name-pattern "workspace|bootstrapContext workspace|bootstrapContext does not let primary includeShared|bootstrapContext ignores workspace-only" test/core.test.js`
- `git diff --check`
- `npm test` (182 passing)
