### PR TITLE
[codex] Add agent lifecycle CLI wrappers

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -158,6 +158,35 @@ codex, claude_code, opencode, grok, cursor_cli
 node src/cli.js listAgentAdapters
 ```
 
+Agent-neutral lifecycle helper도 제공한다. `agentStart`는 기존
+`bootstrapContext`를 감싸고 `workspaceKey`를 그대로 넘길 수 있다.
+`agentCloseout`은 정확한 `sessionId` 또는 `checkpointId` 기준으로만 closeout
+review를 수행하며, 필요하면 distill을 실행하고 candidate audit/suggestion을 반환한다.
+기본값은 `dryRun=true`라 durable memory를 직접 승격하지 않는다.
+
+```bash
+node src/cli.js agentStart \
+  --agent codex \
+  --scope repo \
+  --scopeKey github.com/example/backend \
+  --workspaceKey synthetic-product \
+  --query "monthly closing export review" \
+  --consultReason startup
+
+node src/cli.js agentCloseout \
+  --agent codex \
+  --sessionId codex:00000000-0000-0000-0000-000000000000 \
+  --scope repo \
+  --scopeKey github.com/example/backend \
+  --trigger manual_closeout \
+  --distill auto \
+  --audit true \
+  --dryRun true
+```
+
+`agentCloseout`은 broad scope backlog를 기본으로 훑지 않는다. durable promotion은
+기존 explicit promote 도구나 의도적으로 켠 auto-promotion policy를 따른다.
+
 여러 에이전트 session store를 한 번에 repo registry로 라우팅할 수 있다.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -962,6 +962,36 @@ the available set:
 node src/cli.js listAgentAdapters
 ```
 
+Agent-neutral lifecycle helpers wrap existing ContextForge calls without
+changing their authority or review policy. `agentStart` calls
+`bootstrapContext` and can pass `workspaceKey`; `agentCloseout` checks the exact
+session/checkpoint source, optionally distills, runs read-only candidate audit
+and promotion suggestions, and defaults to `dryRun=true`.
+
+```bash
+node src/cli.js agentStart \
+  --agent codex \
+  --scope repo \
+  --scopeKey github.com/example/backend \
+  --workspaceKey synthetic-product \
+  --query "monthly closing export review" \
+  --consultReason startup
+
+node src/cli.js agentCloseout \
+  --agent codex \
+  --sessionId codex:00000000-0000-0000-0000-000000000000 \
+  --scope repo \
+  --scopeKey github.com/example/backend \
+  --trigger manual_closeout \
+  --distill auto \
+  --audit true \
+  --dryRun true
+```
+
+`agentCloseout` requires `sessionId` or `checkpointId`; it never scans the scope
+backlog by default. Durable promotion still requires the existing explicit
+promotion tools or intentional auto-promotion policy.
+
 For a bounded multi-agent routed scan, use `ingestAgentRoutedSessions`. Each
 adapter keeps its own source provenance and session id prefix while writing
 matched records into the same repo `scopeKey`.

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -103,6 +103,14 @@ Workspace bootstrap result provenance should preserve `workspaceKey`,
 `memberName`, `role`, and `includedBecause`; checkpoint results from member
 repos require live-state verification before action.
 
+For CLI-driven agent lifecycle, use `agentStart` and `agentCloseout` as
+agent-neutral convenience wrappers. `agentStart` calls `bootstrapContext` with
+the selected adapter id and optional `workspaceKey`. `agentCloseout` requires
+`sessionId` or `checkpointId`, preserves adapter-prefixed session ids such as
+`codex:<id>` and `claude_code:<id>`, defaults to `dryRun=true`, and must not
+review broad scope backlog unless an explicit lower-level closeout command is
+used for that purpose.
+
 Read `handoff.latestCheckpoints` before durable memory for recent work status,
 recent decisions, open todos, branch/PR/CI flow, and next actions. Treat
 `handoff.latestConsolidation` as optional thread/repo period context when

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,6 +182,16 @@ limits. Deactivating a workspace profile is a soft delete that marks the
 profile inactive; upserting the same `workspaceKey` later reactivates the
 existing profile.
 
+## Agent Lifecycle Helpers
+
+Agent lifecycle helpers are convenience wrappers over existing core operations,
+not a separate adapter-specific workflow. `agentStart` delegates to
+`bootstrapContext` and can include workspace federation. `agentCloseout`
+requires an exact `sessionId` or `checkpointId`, preserves adapter-prefixed
+session ids, optionally distills, runs closeout-scoped candidate audit and
+promotion suggestions, and defaults to `dryRun=true`. It must not use broad
+scope backlog fallback by default.
+
 ## Retrieval Quality
 
 Durable memory remains canonical in the `memories` table. SQLite FTS5 is a

--- a/docs/skills/contextforge-memory/SKILL.md
+++ b/docs/skills/contextforge-memory/SKILL.md
@@ -56,6 +56,12 @@ remote canonical server. There is no silent local/project-local fallback.
 Workspace profiles should store canonical scope identity only, not local
 `repoPath`, tokens, raw transcripts, or machine-private paths.
 
+CLI users may use `agentStart` and `agentCloseout` as agent-neutral lifecycle
+wrappers. `agentStart` is a bootstrap convenience and may pass `workspaceKey`.
+`agentCloseout` requires `sessionId` or `checkpointId`, preserves
+adapter-prefixed ids, defaults to `dryRun=true`, and does not scan broad scope
+backlog by default.
+
 Treat `includeByDefault` as scope-plan inclusion only. It does not justify
 unbounded retrieval from that scope; workspace retrieval must still obey
 per-scope and total result limits. Workspace profile deactivation is soft
@@ -198,6 +204,11 @@ Adapter-ingested stream:
 1. Preserve or recover the adapter session ID, for example `codex:<id>` or `claude_code:<id>`.
 2. Use that ID for `session_status`, `distill_checkpoint`, and closeout.
 3. Do not replace it with a new `cf_...` session.
+
+For CLI closeout, `agentCloseout --agent <adapter> --sessionId <adapter:id>`
+wraps `sessionStatus`, optional `distillCheckpoint`, `auditMemoryCandidates`,
+and `suggestMemoryPromotions`. It defaults to dry-run and does not promote
+durable memory by itself.
 
 ## Distillation
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -53,6 +53,19 @@ function parseArgs(argv) {
   return { command, options, positionals };
 }
 
+function cliBooleanOption(value, name) {
+  if (value == null) {
+    return undefined;
+  }
+  if (value === true || value === false) {
+    return value;
+  }
+  const text = String(value).trim().toLowerCase();
+  if (['true', '1', 'yes'].includes(text)) return true;
+  if (['false', '0', 'no'].includes(text)) return false;
+  throw new Error(`--${name} must be true, false, 1, 0, yes, or no.`);
+}
+
 function toCoreOptions(options) {
   const tags = options.tag || options.tags;
   let metadata = {};
@@ -134,7 +147,10 @@ function toCoreOptions(options) {
     candidateType: options.candidateType,
     promotionRecommendation: options.promotionRecommendation,
     trigger: options.trigger,
-    dryRun: options.dryRun == null ? undefined : options.dryRun === true || options.dryRun === 'true',
+    dryRun: cliBooleanOption(options.dryRun, 'dryRun'),
+    audit: cliBooleanOption(options.audit, 'audit'),
+    suggest: cliBooleanOption(options.suggest, 'suggest'),
+    autoPromote: cliBooleanOption(options.autoPromote, 'autoPromote'),
     minConfidence: options.minConfidence == null ? undefined : Number(options.minConfidence),
     minStability: options.minStability == null ? undefined : Number(options.minStability),
     minOverlap: options.minOverlap == null ? undefined : Number(options.minOverlap),
@@ -170,6 +186,8 @@ function toCoreOptions(options) {
     ttlDays: options.ttlDays == null ? undefined : Number(options.ttlDays),
     file: options.file,
     repoRegistry: options.repoRegistry || options.registry || options.repoRegistryFile,
+    agent: options.agent,
+    adapter: options.adapter,
     adapters: options.adapters || options.adapter,
     sessionsDir: options.sessionsDir,
     codexSessionsDir: options.codexSessionsDir,
@@ -264,6 +282,8 @@ async function main() {
     workspaceRuleRemove: (app, coreOptions) => app.removeWorkspaceRoutingRule(coreOptions),
     workspaceResolve: (app, coreOptions) => app.resolveWorkspace(coreOptions),
     bootstrapContext: (app, coreOptions) => app.bootstrapContext(coreOptions),
+    agentStart: (app, coreOptions) => app.agentStart(coreOptions),
+    agentCloseout: (app, coreOptions) => app.agentCloseout(coreOptions),
     expandMemoryCluster: (app, coreOptions) => app.expandMemoryCluster(coreOptions),
     doctorCodexExec: (app, coreOptions) => app.checkCodexExec(coreOptions),
     beginSession: (app, coreOptions) => app.beginSession(coreOptions),

--- a/src/core.js
+++ b/src/core.js
@@ -7,6 +7,7 @@ import { checkCodexExecProvider } from './distill/providers/codex_exec.js';
 import { checkOpenAiCompatibleProvider } from './distill/providers/openai_compatible.js';
 import { STRUCTURED_CHECKPOINT_SCHEMA_VERSION, validateDistillOutput } from './distill/validate.js';
 import { createEmbeddingProvider } from './embeddings/index.js';
+import { normalizeAgentAdapterIds } from './ingest/agents.js';
 import { createRemoteContextForge } from './remote/client.js';
 import { searchMemories } from './retrieval/search.js';
 import { normalizeScopeOptions } from './scopes/index.js';
@@ -1124,6 +1125,107 @@ function workspaceBlockSummary(scopePlan, results) {
     return warning?.message || 'Workspace federation is disabled for this request.';
   }
   return workspaceSummary(results);
+}
+
+function normalizeSingleAgent(value) {
+  requireOption(value, 'agent');
+  if (value === true) {
+    throw new Error('agentStart and agentCloseout require an agent adapter id value.');
+  }
+  const agents = normalizeAgentAdapterIds(value);
+  if (agents.length !== 1) {
+    throw new Error('agentStart and agentCloseout require exactly one agent adapter id.');
+  }
+  return agents[0];
+}
+
+function normalizeAgentDistillMode(value = 'auto') {
+  const mode = String(value || 'auto').trim().toLowerCase();
+  if (!['auto', 'always', 'never'].includes(mode)) {
+    throw new Error('distill must be auto, always, or never.');
+  }
+  return mode;
+}
+
+function compactAgentBootstrap(bootstrap) {
+  return {
+    scope: bootstrap.scope,
+    storage: bootstrap.storage,
+    consult: bootstrap.consult,
+    handoff: {
+      latestHandoffId: bootstrap.handoff?.latestHandoff?.id || null,
+      latestHandoffAt: bootstrap.handoff?.latestHandoff?.createdAt || null,
+      latestCheckpointCount: bootstrap.handoff?.latestCheckpoints?.length || 0,
+      latestByAgent: Object.fromEntries(
+        Object.entries(bootstrap.handoff?.latestByAgent || {}).map(([agent, checkpoint]) => [
+          agent,
+          {
+            id: checkpoint.id,
+            createdAt: checkpoint.createdAt,
+            sessionId: checkpoint.sessionId,
+          },
+        ]),
+      ),
+    },
+    resultCount: bootstrap.results?.length || 0,
+    memoryMapClusters: bootstrap.memoryMap?.clusters?.length || 0,
+    workspace: bootstrap.workspace
+      ? {
+          enabled: bootstrap.workspace.enabled,
+          workspaceKey: bootstrap.workspace.scopePlan?.workspace?.workspaceKey || null,
+          includedScopeCount: bootstrap.workspace.scopePlan?.includedScopes?.length || 0,
+          resultCount: bootstrap.workspace.results?.length || 0,
+          warnings: bootstrap.workspace.warnings || [],
+        }
+      : null,
+  };
+}
+
+function compactAgentCloseoutResult({ status, checkpoint, audit, suggestions, autoPromote }) {
+  return {
+    status: status
+      ? {
+          shouldDistill: status.shouldDistill,
+          reasons: status.reasons || [],
+          rawEventCount: status.rawEventCount,
+          eventsSinceLastCheckpoint: status.eventsSinceLastCheckpoint,
+          latestCheckpointId: status.latestCheckpointId,
+          latestCheckpointMemoryCandidateCount: status.latestCheckpointMemoryCandidateCount,
+        }
+      : null,
+    checkpoint: checkpoint
+      ? {
+          id: checkpoint.id,
+          createdAt: checkpoint.createdAt,
+          memoryCandidateCount: checkpoint.memoryCandidateCount,
+          candidateAudit: checkpoint.candidateAudit || null,
+        }
+      : null,
+    audit: audit
+      ? {
+          proposalCount: audit.proposals?.length || 0,
+          skippedCount: audit.skipped?.length || 0,
+          requestWarnings: audit.requestWarnings || [],
+          audit: audit.policy?.audit || null,
+        }
+      : null,
+    suggestions: suggestions
+      ? {
+          proposalCount: suggestions.proposals?.length || 0,
+          skippedCount: suggestions.skipped?.length || 0,
+          requestWarnings: suggestions.requestWarnings || [],
+          source: suggestions.source || null,
+        }
+      : null,
+    autoPromote: autoPromote
+      ? {
+          dryRun: autoPromote.dryRun,
+          promotedCount: autoPromote.promoted?.length || 0,
+          skippedCount: autoPromote.skipped?.length || 0,
+          requestWarnings: autoPromote.requestWarnings || [],
+        }
+      : null,
+  };
 }
 
 function storageBootstrapInfo(config, info) {
@@ -4004,6 +4106,147 @@ export function createContextForge(options = {}) {
           'Use checkpoint handoff actively for continuity, planning, prior intent, recent decisions, and unfinished work.',
           'Verify only mutable live state such as git, GitHub, CI, runtime, and migrations before acting.',
           'Do not propose memory promotions during resume sync.',
+        ],
+      };
+    },
+
+    async agentStart(options = {}) {
+      const agent = normalizeSingleAgent(options.agent || options.adapter);
+      requireOption(options.query, 'query');
+      const bootstrap = await this.bootstrapContext({
+        ...options,
+        consultReason: options.consultReason || 'startup',
+      });
+      return {
+        kind: 'agent_start_context',
+        agent,
+        scope: bootstrap.scope,
+        workspaceKey: options.workspaceKey || null,
+        query: bootstrap.query,
+        consultReason: bootstrap.consult?.reason || options.consultReason || 'startup',
+        context: bootstrap,
+        summary: compactAgentBootstrap(bootstrap),
+        nextActions: [
+          'Read handoff.latestHandoff and workspace.scopePlan before acting when present.',
+          'Verify mutable live state such as git, GitHub, CI, runtime, deployment, and migrations before final claims.',
+          'Use targeted search or expand_memory_cluster only when more detail is needed.',
+        ],
+      };
+    },
+
+    async agentCloseout(options = {}) {
+      const agent = normalizeSingleAgent(options.agent || options.adapter);
+      const trigger = options.trigger || 'manual_closeout';
+      if (!CLOSEOUT_TRIGGERS.has(trigger)) {
+        throw new Error('trigger must be a closeout trigger.');
+      }
+      const sessionId = options.sessionId || null;
+      const requestedCheckpointId = options.checkpointId || null;
+      if (!sessionId && !requestedCheckpointId) {
+        throw new Error('agentCloseout requires sessionId or checkpointId to avoid broad scope backlog review.');
+      }
+      const scope = normalizeScopeOptions(options, config);
+      const distillMode = normalizeAgentDistillMode(options.distill || 'auto');
+      const dryRun = options.dryRun == null ? true : truthyOption(options.dryRun);
+      const auditEnabled = options.audit == null ? true : truthyOption(options.audit);
+      const suggestEnabled = options.suggest == null ? true : truthyOption(options.suggest);
+      const autoPromoteEnabled = truthyOption(options.autoPromote);
+
+      let status = null;
+      if (sessionId) {
+        status = await this.sessionStatus({ ...options, sessionId });
+      }
+
+      let checkpoint = null;
+      const shouldDistill =
+        sessionId && distillMode !== 'never' && (distillMode === 'always' || status?.shouldDistill);
+      if (shouldDistill) {
+        checkpoint = await this.distillCheckpoint({
+          ...options,
+          sessionId,
+          auditTrigger: trigger,
+        });
+      }
+
+      const checkpointId = requestedCheckpointId || checkpoint?.id || status?.latestCheckpointId || null;
+      const closeoutSource = {
+        sessionId,
+        checkpointId,
+        mode: checkpoint?.id
+          ? 'new_checkpoint'
+          : requestedCheckpointId
+            ? 'provided_checkpoint'
+            : checkpointId
+              ? 'latest_checkpoint'
+              : 'session_pending_batch',
+      };
+      const sourceOptions = {
+        ...options,
+        trigger,
+        sessionId,
+        checkpointId,
+      };
+
+      let audit = null;
+      if (auditEnabled) {
+        audit = await this.auditMemoryCandidates(sourceOptions);
+      }
+
+      let suggestions = null;
+      if (suggestEnabled) {
+        suggestions = await this.suggestMemoryPromotions({
+          ...sourceOptions,
+          createUpdateCandidates: truthyOption(options.createUpdateCandidates),
+        });
+      }
+
+      let autoPromote = null;
+      if (autoPromoteEnabled) {
+        autoPromote = await this.autoPromoteMemoryCandidates({
+          ...sourceOptions,
+          dryRun,
+        });
+      }
+      const distillSkippedReason = checkpoint
+        ? null
+        : distillMode === 'never'
+          ? 'distill_never'
+          : !sessionId
+            ? 'checkpoint_only_source'
+            : !status?.shouldDistill && distillMode === 'auto'
+              ? 'below_threshold'
+              : shouldDistill
+                ? 'distill_returned_empty'
+                : 'not_requested';
+      const closeoutNextAction = dryRun
+        ? 'Review audit/suggestion output; no durable memory was promoted by agentCloseout dry-run.'
+        : autoPromote
+          ? 'Verify durable memory write policy before trusting any auto-promotion result.'
+          : 'No auto-promotion was requested; review audit/suggestion output and promote explicitly if appropriate.';
+
+      return {
+        kind: 'agent_closeout_review',
+        agent,
+        scope,
+        workspaceKey: options.workspaceKey || null,
+        trigger,
+        dryRun,
+        distill: {
+          mode: distillMode,
+          executed: Boolean(checkpoint),
+          skippedReason: distillSkippedReason,
+        },
+        source: closeoutSource,
+        status,
+        checkpoint,
+        audit,
+        suggestions,
+        autoPromote,
+        summary: compactAgentCloseoutResult({ status, checkpoint, audit, suggestions, autoPromote }),
+        nextActions: [
+          closeoutNextAction,
+          'Promote or reject candidates explicitly by candidateId after review.',
+          'Do not use scope fallback unless intentionally reviewing a manual closeout backlog.',
         ],
       };
     },

--- a/src/remote/client.js
+++ b/src/remote/client.js
@@ -18,6 +18,8 @@ const REMOTE_METHODS = [
   'resolveWorkspace',
   'listScopeKeys',
   'bootstrapContext',
+  'agentStart',
+  'agentCloseout',
   'expandMemoryCluster',
   'syncResumeContext',
   'checkCodexExec',
@@ -238,6 +240,68 @@ export function createRemoteContextForge(config, options = {}) {
             serverAuthority: result.storage?.authority || null,
             note:
               'This bootstrap call used a remote ContextForge client. serverMode describes the server-owned store, not this checkout.',
+          },
+        };
+      };
+      continue;
+    }
+    if (method === 'agentStart') {
+      api[method] = async (callOptions = {}) => {
+        const { cwd, repoPath, ...remoteOptions } = callOptions;
+        const scope = normalizeScopeOptions(callOptions, config);
+        const result = await client.call(method, {
+          ...remoteOptions,
+          scope: scope.scopeType,
+          scopeType: scope.scopeType,
+          scopeKey: scope.scopeKey,
+        });
+        const context = result.context || {};
+        const storage = context.storage || {};
+        const adjustedStorage = {
+          ...storage,
+          mode: 'remote',
+          authority: 'canonical',
+          serverMode: storage.mode || null,
+          serverAuthority: storage.authority || null,
+          note:
+            'This agentStart call used a remote ContextForge client. serverMode describes the server-owned store, not this checkout.',
+        };
+        return {
+          ...result,
+          connection: remoteClientConnection(context.connection || storage.connection || null),
+          context: {
+            ...context,
+            storage: adjustedStorage,
+          },
+          summary: {
+            ...(result.summary || {}),
+            storage: adjustedStorage,
+          },
+        };
+      };
+      continue;
+    }
+    if (method === 'agentCloseout') {
+      api[method] = async (callOptions = {}) => {
+        const { cwd, repoPath, ...remoteOptions } = callOptions;
+        const scope = normalizeScopeOptions(callOptions, config);
+        const result = await client.call(method, {
+          ...remoteOptions,
+          scope: scope.scopeType,
+          scopeType: scope.scopeType,
+          scopeKey: scope.scopeKey,
+        });
+        return {
+          ...result,
+          connection: remoteClientConnection(result.connection || null),
+          storage: {
+            ...(result.storage || {}),
+            mode: 'remote',
+            authority: 'canonical',
+            serverMode: result.storage?.mode || null,
+            serverAuthority: result.storage?.authority || null,
+            note:
+              'This agentCloseout call used a remote ContextForge client. serverMode describes the server-owned store, not this checkout.',
           },
         };
       };

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -10498,6 +10498,8 @@ test('listScopeKeys returns real scopes from memories, candidates, and distill r
 test('REMOTE_METHODS exposes resume, suggestion, auto-promotion, and reconciliation wrappers', () => {
   assert.ok(REMOTE_METHODS.includes('migrateScope'));
   assert.ok(REMOTE_METHODS.includes('syncResumeContext'));
+  assert.ok(REMOTE_METHODS.includes('agentStart'));
+  assert.ok(REMOTE_METHODS.includes('agentCloseout'));
   assert.ok(REMOTE_METHODS.includes('getRuntimeSettings'));
   assert.ok(REMOTE_METHODS.includes('updateRuntimeSettings'));
   assert.ok(REMOTE_METHODS.includes('checkDistillProvider'));
@@ -10782,6 +10784,116 @@ test('remote workspace profile calls dispatch to the canonical server without sc
   assert.equal(result.workspaceKey, 'remote-workspace');
   assert.equal(calls[0].url, 'https://memory.example.test/v0/upsertWorkspaceProfile');
   assert.deepEqual(calls[0].body, { workspaceKey: 'remote-workspace' });
+});
+
+test('remote agentStart resolves local path hints before canonical server dispatch', async () => {
+  const calls = [];
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_STORAGE_MODE: 'remote',
+      CONTEXTFORGE_REMOTE_URL: 'https://memory.example.test',
+      CONTEXTFORGE_DEFAULT_SCOPE_KEY: 'github.com/example/backend',
+    },
+    cwd: process.cwd(),
+    fetchImpl: async (url, init) => {
+      const body = JSON.parse(init.body);
+      calls.push({ url: String(url), body });
+      return new Response(
+        JSON.stringify({
+          result: {
+            kind: 'agent_start_context',
+            agent: body.agent,
+            scope: { scopeType: body.scopeType, scopeKey: body.scopeKey },
+            context: {
+              scope: { scopeType: body.scopeType, scopeKey: body.scopeKey },
+              storage: {
+                mode: 'local',
+                authority: 'local',
+                connection: { mode: 'http-server', accessPath: 'in-process' },
+              },
+              results: [],
+            },
+            summary: {
+              storage: {
+                mode: 'local',
+                authority: 'local',
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    },
+  });
+
+  const result = await app.agentStart({
+    agent: 'codex',
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    repoPath: process.cwd(),
+    query: 'remote agent start',
+  });
+  assert.equal(calls[0].url, 'https://memory.example.test/v0/agentStart');
+  assert.equal(calls[0].body.repoPath, undefined);
+  assert.equal(calls[0].body.scopeKey, 'github.com/example/backend');
+  assert.equal(result.context.storage.mode, 'remote');
+  assert.equal(result.context.storage.authority, 'canonical');
+  assert.equal(result.context.storage.serverMode, 'local');
+});
+
+test('remote agentCloseout resolves local path hints and marks canonical storage', async () => {
+  const calls = [];
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_STORAGE_MODE: 'remote',
+      CONTEXTFORGE_REMOTE_URL: 'https://memory.example.test',
+      CONTEXTFORGE_DEFAULT_SCOPE_KEY: 'github.com/example/backend',
+    },
+    cwd: process.cwd(),
+    fetchImpl: async (url, init) => {
+      const body = JSON.parse(init.body);
+      calls.push({ url: String(url), body });
+      return new Response(
+        JSON.stringify({
+          result: {
+            kind: 'agent_closeout_review',
+            agent: body.agent,
+            scope: { scopeType: body.scopeType, scopeKey: body.scopeKey },
+            source: {
+              sessionId: body.sessionId,
+              checkpointId: body.checkpointId || null,
+              mode: 'session_pending_batch',
+            },
+            storage: {
+              mode: 'local',
+              authority: 'local',
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    },
+  });
+
+  const result = await app.agentCloseout({
+    agent: 'codex',
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    repoPath: process.cwd(),
+    sessionId: 'codex:remote-closeout-session',
+  });
+  assert.equal(calls[0].url, 'https://memory.example.test/v0/agentCloseout');
+  assert.equal(calls[0].body.repoPath, undefined);
+  assert.equal(calls[0].body.scopeKey, 'github.com/example/backend');
+  assert.equal(result.storage.mode, 'remote');
+  assert.equal(result.storage.authority, 'canonical');
+  assert.equal(result.storage.serverMode, 'local');
 });
 
 test('CLI supports workspace profile upsert member rule and resolve commands', async () => {
@@ -11120,6 +11232,273 @@ test('bootstrapContext ignores workspace-only limits when workspaceKey is absent
   });
 
   assert.equal(Object.prototype.hasOwnProperty.call(bootstrap, 'workspace'), false);
+});
+
+test('agentStart is adapter-neutral and forwards workspaceKey to bootstrapContext', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+  app.upsertWorkspaceProfile({
+    workspaceKey: 'agent-start-workspace',
+    canonicalScope: 'repo',
+    canonicalScopeKey: 'github.com/example/backend',
+  });
+  app.upsertWorkspaceMember({
+    workspaceKey: 'agent-start-workspace',
+    name: 'backend',
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    role: 'api-domain-ssot',
+  });
+
+  for (const adapter of listAgentAdapters()) {
+    const result = await app.agentStart({
+      agent: adapter.id,
+      scope: 'repo',
+      scopeKey: 'github.com/example/backend',
+      workspaceKey: 'agent-start-workspace',
+      query: 'OpenAPI startup context',
+      consultReason: 'startup',
+    });
+    assert.equal(result.kind, 'agent_start_context');
+    assert.equal(result.agent, adapter.id);
+    assert.equal(result.context.workspace.enabled, true);
+    assert.equal(result.summary.workspace.workspaceKey, 'agent-start-workspace');
+  }
+});
+
+test('agentCloseout rejects broad backlog review without sessionId or checkpointId', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  await assert.rejects(
+    () =>
+      app.agentCloseout({
+        agent: 'codex',
+        scope: 'repo',
+        scopeKey: 'github.com/example/backend',
+      }),
+    /requires sessionId or checkpointId/,
+  );
+});
+
+test('agent lifecycle rejects a missing agent adapter value clearly', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  await assert.rejects(
+    () =>
+      app.agentStart({
+        agent: true,
+        scope: 'repo',
+        scopeKey: 'github.com/example/backend',
+        query: 'startup',
+      }),
+    /require an agent adapter id value/,
+  );
+});
+
+test('agentCloseout distills, audits, suggests, and preserves adapter session id without promotion', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'agent_closeout_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      agent_closeout_provider: async () => ({
+        summaryShort: 'Agent closeout checkpoint.',
+        summaryText: 'Agent closeout should keep promotion review read-only by default.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'agent-closeout-runbook',
+            content: 'Agent closeout should review candidates without promoting them by default.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.95,
+            stability: 0.95,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    sessionId: 'codex:agent-closeout-session',
+    role: 'assistant',
+    content: 'Close out this agent session with one durable candidate.',
+  });
+
+  const result = await app.agentCloseout({
+    agent: 'codex',
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    sessionId: 'codex:agent-closeout-session',
+    distill: 'always',
+    trigger: 'manual_closeout',
+    audit: true,
+    suggest: true,
+  });
+
+  assert.equal(result.kind, 'agent_closeout_review');
+  assert.equal(result.agent, 'codex');
+  assert.equal(result.dryRun, true);
+  assert.equal(result.source.sessionId, 'codex:agent-closeout-session');
+  assert.equal(result.checkpoint.sessionId, 'codex:agent-closeout-session');
+  assert.equal(result.checkpoint.memoryCandidateCount, 1);
+  assert.equal(result.audit.kind, 'memory_candidate_audit_suggestions');
+  assert.equal(result.suggestions.kind, 'memory_promotion_suggestions');
+  assert.equal(result.summary.suggestions.proposalCount, 1);
+  assert.equal(
+    app.listMemories({
+      scope: 'repo',
+      scopeKey: 'github.com/example/backend',
+    }).length,
+    0,
+  );
+});
+
+test('agentCloseout supports checkpointId-only closeout review without distilling', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_DISTILL_PROVIDER: 'agent_checkpoint_provider',
+    },
+    cwd: process.cwd(),
+    distillProviders: {
+      agent_checkpoint_provider: async () => ({
+        summaryShort: 'Checkpoint-only closeout.',
+        summaryText: 'Checkpoint-only closeout should review existing candidates.',
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        memoryCandidates: [
+          {
+            key: 'checkpoint-only-runbook',
+            content: 'Checkpoint-only closeout should not require the original session id.',
+            category: 'runbook',
+            candidateType: 'runbook',
+            confidence: 0.9,
+            stability: 0.9,
+            sensitivity: 'low',
+            promotionRecommendation: 'promote',
+          },
+        ],
+      }),
+    },
+  });
+  app.appendRaw({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    sessionId: 'claude_code:checkpoint-only-session',
+    role: 'assistant',
+    content: 'Create a checkpoint candidate for checkpoint-only closeout.',
+  });
+  const checkpoint = await app.distillCheckpoint({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    sessionId: 'claude_code:checkpoint-only-session',
+  });
+
+  const result = await app.agentCloseout({
+    agent: 'claude_code',
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    checkpointId: checkpoint.id,
+    trigger: 'manual_closeout',
+    audit: false,
+    suggest: false,
+  });
+
+  assert.equal(result.source.sessionId, null);
+  assert.equal(result.source.checkpointId, checkpoint.id);
+  assert.equal(result.source.mode, 'provided_checkpoint');
+  assert.equal(result.distill.executed, false);
+  assert.equal(result.distill.skippedReason, 'checkpoint_only_source');
+  assert.equal(result.audit, null);
+  assert.equal(result.suggestions, null);
+});
+
+test('CLI supports agentStart and dry-run agentCloseout commands', async () => {
+  const dataDir = await makeTempDir();
+  const env = { ...process.env, CONTEXTFORGE_DATA_DIR: dataDir };
+
+  const start = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'agentStart',
+      '--agent',
+      'claude_code',
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'github.com/example/backend',
+      '--query',
+      'startup handoff',
+    ],
+    { env },
+  );
+  const startResult = JSON.parse(start.stdout);
+  assert.equal(startResult.kind, 'agent_start_context');
+  assert.equal(startResult.agent, 'claude_code');
+
+  await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'appendRaw',
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'github.com/example/backend',
+      '--sessionId',
+      'codex:cli-agent-closeout',
+      '--role',
+      'assistant',
+      '--content',
+      'CLI closeout should preserve adapter-prefixed session id.',
+    ],
+    { env },
+  );
+
+  const closeout = await execFileAsync(
+    'node',
+    [
+      'src/cli.js',
+      'agentCloseout',
+      '--agent',
+      'codex',
+      '--scope',
+      'repo',
+      '--scopeKey',
+      'github.com/example/backend',
+      '--sessionId',
+      'codex:cli-agent-closeout',
+      '--distill',
+      'never',
+      '--audit',
+      '0',
+      '--suggest',
+      'no',
+      '--dryRun',
+      '1',
+    ],
+    { env },
+  );
+  const closeoutResult = JSON.parse(closeout.stdout);
+  assert.equal(closeoutResult.kind, 'agent_closeout_review');
+  assert.equal(closeoutResult.dryRun, true);
+  assert.equal(closeoutResult.audit, null);
+  assert.equal(closeoutResult.suggestions, null);
+  assert.equal(closeoutResult.source.sessionId, 'codex:cli-agent-closeout');
 });
 
 test('CLI supports the v0 workflow with synthetic data', async () => {


### PR DESCRIPTION
## Summary

Implements PR 3 from #147: add agent-neutral lifecycle convenience wrappers for startup bootstrap and closeout review.

## What changed

- Adds core methods:
  - `agentStart`
  - `agentCloseout`
- Adds CLI commands:
  - `node src/cli.js agentStart`
  - `node src/cli.js agentCloseout`
- Reuses the existing adapter registry (`codex`, `claude_code`, `opencode`, `grok`, `cursor_cli`) instead of hardcoding Codex-only behavior.
- `agentStart` delegates to `bootstrapContext`, preserving optional `workspaceKey` federation support.
- `agentCloseout`:
  - requires `sessionId` or `checkpointId`
  - preserves adapter-prefixed session ids such as `codex:<id>` / `claude_code:<id>`
  - supports `distill=auto|always|never`
  - runs closeout-scoped candidate audit and promotion suggestions by default
  - defaults to `dryRun=true`
  - does not use broad scope backlog fallback by default
- Adds remote passthrough for lifecycle methods; remote `agentStart` and `agentCloseout` normalize local path hints before dispatch and report remote canonical storage from the client viewpoint.
- Updates README/docs/agent skill guidance.

## Review follow-up

Addressed the actionable non-blocking review notes from the first PR comments:

- Added `await` consistency for `sessionStatus` inside `agentCloseout`.
- Clarified `distill.skippedReason`, including the empty-distill case.
- Added `checkpointId`-only closeout coverage.
- Made CLI boolean parsing accept `true|false|1|0|yes|no` and reject invalid values loudly.
- Clarified `nextActions` when `dryRun=false` but `autoPromote` is not requested.
- Added remote `agentCloseout` storage authority passthrough and test coverage.
- Added a clearer error for missing `--agent` / agent adapter values.

Kept the distill-time `candidateAudit` plus explicit closeout `auditMemoryCandidates` behavior as-is because the two outputs have different contracts: checkpoint audit metadata vs closeout review proposals.

## Notes

This PR intentionally does not add new MCP tools. The existing lower-level MCP tools remain authoritative, and the lifecycle layer starts as CLI/core convenience as planned in #147.

Refs #147.

## Verification

- `node --test --test-name-pattern "agentStart|agentCloseout|agent lifecycle|REMOTE_METHODS|remote agent" test/core.test.js` (9 passing)
- `git diff --check`
- `npm test` (190 passing)
