### PR TITLE
[codex] Add workspace retrieval eval fixture

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -210,6 +210,18 @@ node src/cli.js ingestAgentRoutedSessions \
 경우 router는 해당 checkout의 Git `origin` remote를 읽어 registry `scopeKey`와
 비교한다. path와 Git remote 둘 다 맞지 않는 세션만 unmatched로 건너뛴다.
 
+Workspace retrieval 품질은 public-safe synthetic fixture로 확인할 수 있다.
+
+```bash
+node src/cli.js evalRetrieval \
+  --fixture docs/examples/workspace-eval/wastelite.synthetic.json
+```
+
+이 CLI 명령은 호출자가 평소 project-local이나 remote mode를 쓰더라도 항상 격리된
+임시 local store에 fixture 데이터만 심고 실행한다. top primary/workspace result
+window에서 필수 term이나 기대 scope role이 빠지면 JSON detail을 출력한 뒤 non-zero로
+종료한다.
+
 systemd user service로는 통합 router 하나를 설치하는 것이 기본 권장 형태다.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -186,6 +186,18 @@ bounded per-scope and total result limits. `workspaceDeactivate` soft-deletes a
 profile by marking it inactive, and a later `workspaceUpsert` with the same key
 reactivates the existing profile.
 
+Workspace retrieval can be checked with a public-safe synthetic eval fixture:
+
+```bash
+node src/cli.js evalRetrieval \
+  --fixture docs/examples/workspace-eval/wastelite.synthetic.json
+```
+
+The CLI command always runs against an isolated temporary local store, even when
+the caller normally uses project-local or remote mode. It seeds only the fixture
+data and exits non-zero when required terms or expected scope roles are missing
+from the top primary/workspace result windows.
+
 ## Distillation
 
 ContextForge assumes useful checkpoints need an LLM. The runtime should support

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,6 +205,16 @@ retrieval metadata such as the FTS rank and method. This keeps better ranking
 debuggable and leaves room for future vector search as another retrieval
 surface, not canonical storage.
 
+Workspace retrieval evals use synthetic fixtures and, in the CLI path, an
+isolated temporary local store even when the caller normally uses project-local
+or remote mode. They seed workspace profiles, members, routing rules, and
+durable memories, then run `bootstrapContext` queries and check expected terms
+and scope roles in the top primary/workspace result windows. Evals must not
+depend on private repositories, network access, raw transcripts, or the caller's
+configured live storage mode. Library callers may still inject an app for
+specialized harnesses, but should avoid writing synthetic fixtures to a live
+canonical store.
+
 ## Memory Layers
 
 ContextForge separates memory into layers.

--- a/docs/examples/workspace-eval/wastelite.synthetic.json
+++ b/docs/examples/workspace-eval/wastelite.synthetic.json
@@ -1,0 +1,170 @@
+{
+  "name": "synthetic-wastelite",
+  "workspaceKey": "synthetic-wastelite",
+  "displayName": "Synthetic WasteLite",
+  "primaryScope": "repo",
+  "primaryScopeKey": "github.com/example/wastelite",
+  "workspaceResultLimit": 6,
+  "workspacePerScopeLimit": 3,
+  "topN": 8,
+  "workspace": {
+    "workspaceKey": "synthetic-wastelite",
+    "displayName": "Synthetic WasteLite",
+    "canonicalScope": "repo",
+    "canonicalScopeKey": "github.com/example/wastelite-suite"
+  },
+  "members": [
+    {
+      "name": "suite",
+      "scope": "repo",
+      "scopeKey": "github.com/example/wastelite-suite",
+      "role": "cross-repo-contract",
+      "priority": 100,
+      "includeByDefault": true
+    },
+    {
+      "name": "backend",
+      "scope": "repo",
+      "scopeKey": "github.com/example/wastelite",
+      "role": "api-domain-ssot",
+      "priority": 90
+    },
+    {
+      "name": "react",
+      "scope": "repo",
+      "scopeKey": "github.com/example/wastelite_frontend_react",
+      "role": "desktop-web-consumer",
+      "priority": 60
+    },
+    {
+      "name": "flutter",
+      "scope": "repo",
+      "scopeKey": "github.com/example/wastelite_frontend",
+      "role": "mobile-consumer",
+      "priority": 60
+    }
+  ],
+  "routingRules": [
+    {
+      "ruleKey": "contract_terms",
+      "priority": 100,
+      "match": {
+        "termsAny": [
+          "contract",
+          "RFC",
+          "OpenAPI",
+          "permission",
+          "E2E",
+          "frontend",
+          "consumer",
+          "migration",
+          "release gate",
+          "schema",
+          "generated",
+          "browser test",
+          "monthly closing",
+          "export"
+        ]
+      },
+      "include": {
+        "roles": [
+          "cross-repo-contract",
+          "api-domain-ssot",
+          "desktop-web-consumer",
+          "mobile-consumer"
+        ]
+      }
+    }
+  ],
+  "memories": [
+    {
+      "scope": "repo",
+      "scopeKey": "github.com/example/wastelite-suite",
+      "key": "openapi-mirror-contract",
+      "category": "contract",
+      "content": "Synthetic contract: OpenAPI mirror files are backend-owned mirror artifacts. Frontend consumers must not hand-edit generated schema files; do not hand-edit the backend source of truth.",
+      "tags": ["OpenAPI", "frontend", "generated", "contract"],
+      "importance": 8
+    },
+    {
+      "scope": "repo",
+      "scopeKey": "github.com/example/wastelite",
+      "key": "backend-openapi-source",
+      "category": "contract",
+      "content": "Backend is the api-domain-ssot for OpenAPI endpoint schema and permission migration behavior.",
+      "tags": ["OpenAPI", "schema", "permission"],
+      "importance": 8
+    },
+    {
+      "scope": "repo",
+      "scopeKey": "github.com/example/wastelite_frontend_react",
+      "key": "react-openapi-consumer",
+      "category": "consumer",
+      "content": "React desktop client consumes generated OpenAPI mirror files and should not hand-edit the generated contract.",
+      "tags": ["react", "OpenAPI", "consumer"],
+      "importance": 6
+    },
+    {
+      "scope": "repo",
+      "scopeKey": "github.com/example/wastelite-suite",
+      "key": "monthly-closing-tier-contract",
+      "category": "contract",
+      "content": "Synthetic monthly closing permission contract: small customers are Stable, mid customers are Beta, and live preview requires accounting.view_live_preview.",
+      "tags": ["monthly closing", "permission", "tier", "contract"],
+      "importance": 8
+    },
+    {
+      "scope": "repo",
+      "scopeKey": "github.com/example/wastelite",
+      "key": "monthly-closing-permission-source",
+      "category": "contract",
+      "content": "Backend permission source maps monthly closing small to Stable and mid to Beta with accounting.view_live_preview enforced by the API.",
+      "tags": ["monthly closing", "permission", "api"],
+      "importance": 8
+    },
+    {
+      "scope": "repo",
+      "scopeKey": "github.com/example/wastelite_frontend_react",
+      "key": "export-download-browser-test",
+      "category": "e2e",
+      "content": "Browser test for export download must open downloaded file bytes and verify the response is not SPA index.html and not 404.",
+      "tags": ["export", "download", "browser test"],
+      "importance": 7
+    },
+    {
+      "scope": "repo",
+      "scopeKey": "github.com/example/wastelite-suite",
+      "key": "export-release-gate",
+      "category": "contract",
+      "content": "Release gate for export download checks browser test evidence: open downloaded file, not SPA index.html, and not 404.",
+      "tags": ["export", "release gate", "browser test"],
+      "importance": 7
+    }
+  ],
+  "queries": [
+    {
+      "query": "OpenAPI mirror frontend can edit?",
+      "primaryScopeKey": "github.com/example/wastelite_frontend_react",
+      "expected": {
+        "mustContain": ["backend-owned mirror", "do not hand-edit"],
+        "expectedScopeRoles": ["api-domain-ssot", "desktop-web-consumer"]
+      }
+    },
+    {
+      "query": "monthly closing permission tier beta stable",
+      "primaryScopeKey": "github.com/example/wastelite",
+      "expected": {
+        "mustContain": ["small", "Stable", "mid", "Beta", "accounting.view_live_preview"],
+        "expectedScopeRoles": ["cross-repo-contract", "api-domain-ssot"]
+      }
+    },
+    {
+      "query": "export download browser test",
+      "primaryScopeKey": "github.com/example/wastelite_frontend_react",
+      "expected": {
+        "mustContain": ["open downloaded file", "not SPA index.html", "not 404"],
+        "expectedScopeRoles": ["desktop-web-consumer", "cross-repo-contract"]
+      }
+    }
+  ]
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,6 +20,7 @@ import {
   listAgentAdapters,
   watchAgentRoutedSessions,
 } from './ingest/agents.js';
+import { runRetrievalEval } from './eval/retrieval.js';
 import { startContextForgeServer } from './server.js';
 
 function parseArgs(argv) {
@@ -185,6 +186,7 @@ function toCoreOptions(options) {
     minCheckpoints: options.minCheckpoints == null ? undefined : Number(options.minCheckpoints),
     ttlDays: options.ttlDays == null ? undefined : Number(options.ttlDays),
     file: options.file,
+    fixture: options.fixture,
     repoRegistry: options.repoRegistry || options.registry || options.repoRegistryFile,
     agent: options.agent,
     adapter: options.adapter,
@@ -313,6 +315,7 @@ async function main() {
     search: (app, coreOptions) => app.search(coreOptions),
     rebuildEmbeddings: (app, coreOptions) => app.rebuildEmbeddings(coreOptions),
     processEmbeddingJobs: (app, coreOptions) => app.processEmbeddingJobs(coreOptions),
+    evalRetrieval: (_app, coreOptions) => runRetrievalEval(coreOptions),
     listEmbeddingJobs: (app, coreOptions) => app.listEmbeddingJobs(coreOptions),
     listScopeKeys: (app, coreOptions) => app.listScopeKeys(coreOptions),
     getMemory: (app, coreOptions) => app.getMemory(coreOptions),
@@ -401,7 +404,11 @@ async function main() {
   if (!handler) {
     throw new Error(`Unknown command: ${command}`);
   }
-  printJson(await handler(app, coreOptions, options));
+  const result = await handler(app, coreOptions, options);
+  printJson(result);
+  if (result?.kind === 'retrieval_eval' && Number(result.failed || 0) > 0) {
+    process.exitCode = 1;
+  }
 }
 
 main().catch((error) => {

--- a/src/eval/retrieval.js
+++ b/src/eval/retrieval.js
@@ -1,0 +1,228 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { createContextForge } from '../core.js';
+
+function arrayOfStrings(value) {
+  if (value == null) return [];
+  if (!Array.isArray(value)) {
+    throw new Error('Expected an array of strings.');
+  }
+  return value.map((item) => String(item));
+}
+
+function normalizedText(value) {
+  return String(value || '').toLowerCase();
+}
+
+function resultText(result) {
+  return [result.key, result.category, result.content, ...(result.why || []).map((hit) => hit.token)]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function scopeIdentity(scopeType, scopeKey) {
+  return `${scopeType}:${scopeKey}`;
+}
+
+function scopePlanRoleMap(scopePlan) {
+  const roles = new Map();
+  for (const scope of scopePlan?.includedScopes || []) {
+    roles.set(scopeIdentity(scope.scopeType || scope.scope, scope.scopeKey), {
+      scope: scope.scopeType || scope.scope,
+      scopeKey: scope.scopeKey,
+      memberName: scope.memberName || null,
+      role: scope.role || 'member',
+    });
+  }
+  return roles;
+}
+
+function resultScope(result, roles) {
+  const source = result.scope || result.source || {};
+  const scopeType = source.scopeType || source.scope || 'repo';
+  const scopeKey = source.scopeKey || null;
+  const mapped = roles.get(scopeIdentity(scopeType, scopeKey)) || {};
+  const role = source.role && source.role !== 'repo' ? source.role : mapped.role || 'member';
+  return {
+    scope: scopeType,
+    scopeType,
+    scopeKey,
+    memberName: source.memberName || mapped.memberName || null,
+    role,
+    key: result.key,
+    type: result.type,
+  };
+}
+
+function applyFixture(app, fixture) {
+  const workspace = fixture.workspace || fixture.workspaceProfile || {};
+  const workspaceKey = fixture.workspaceKey || workspace.workspaceKey;
+  if (!workspaceKey) {
+    throw new Error('Fixture requires workspaceKey.');
+  }
+
+  app.upsertWorkspaceProfile({
+    workspaceKey,
+    displayName: workspace.displayName || fixture.displayName,
+    canonicalScope: workspace.canonicalScope || workspace.canonicalScopeType || fixture.canonicalScope || 'repo',
+    canonicalScopeKey: workspace.canonicalScopeKey || fixture.canonicalScopeKey,
+    metadata: workspace.metadata || {},
+  });
+
+  for (const member of fixture.members || []) {
+    app.upsertWorkspaceMember({
+      workspaceKey,
+      name: member.name,
+      scope: member.scope || member.scopeType || 'repo',
+      scopeKey: member.scopeKey,
+      role: member.role || 'member',
+      priority: member.priority == null ? 0 : Number(member.priority),
+      includeByDefault: Boolean(member.includeByDefault || member.include_by_default),
+      metadata: member.metadata || {},
+      allowLocal: Boolean(member.allowLocal),
+    });
+  }
+
+  for (const rule of fixture.routingRules || fixture.rules || []) {
+    app.upsertWorkspaceRoutingRule({
+      workspaceKey,
+      ruleKey: rule.ruleKey,
+      priority: rule.priority == null ? 0 : Number(rule.priority),
+      match: rule.match || {},
+      include: rule.include || {},
+      exclude: rule.exclude || {},
+      includeShared: Boolean(rule.includeShared),
+      status: rule.status || 'active',
+      metadata: rule.metadata || {},
+    });
+  }
+
+  for (const memory of fixture.memories || []) {
+    app.remember({
+      scope: memory.scope || memory.scopeType || 'repo',
+      scopeKey: memory.scopeKey,
+      key: memory.key,
+      content: memory.content,
+      category: memory.category || 'runbook',
+      tags: memory.tags || [],
+      importance: memory.importance == null ? 5 : Number(memory.importance),
+    });
+  }
+}
+
+async function evaluateQuery(app, fixture, querySpec) {
+  const workspaceKey = fixture.workspaceKey || fixture.workspace?.workspaceKey || fixture.workspaceProfile?.workspaceKey;
+  const primaryScope = querySpec.scope || querySpec.primaryScope || fixture.primaryScope || 'repo';
+  const primaryScopeKey = querySpec.scopeKey || querySpec.primaryScopeKey || fixture.primaryScopeKey;
+  if (!primaryScopeKey) {
+    throw new Error(`Eval query requires primaryScopeKey: ${querySpec.query}`);
+  }
+
+  const topN = Number(querySpec.topN || fixture.topN || 10);
+  const expected = querySpec.expected || {};
+  const requiredTerms = arrayOfStrings(expected.mustContain);
+  const expectedScopeRoles = arrayOfStrings(expected.expectedScopeRoles);
+  const bootstrap = await app.bootstrapContext({
+    scope: primaryScope,
+    scopeKey: primaryScopeKey,
+    workspaceKey,
+    workspaceMode: querySpec.workspaceMode || fixture.workspaceMode || 'auto',
+    workspaceResultLimit: querySpec.workspaceResultLimit || fixture.workspaceResultLimit || topN,
+    workspacePerScopeLimit: querySpec.workspacePerScopeLimit || fixture.workspacePerScopeLimit || 4,
+    includeWorkspaceHandoffs: Boolean(querySpec.includeWorkspaceHandoffs || fixture.includeWorkspaceHandoffs),
+    query: querySpec.query,
+    consultReason: querySpec.consultReason || fixture.consultReason || 'startup',
+    limit: querySpec.limit || fixture.limit || topN,
+  });
+  const primaryResults = (bootstrap.results || []).slice(0, topN);
+  const workspaceResults = (bootstrap.workspace?.results || []).slice(0, topN);
+  const combinedResults = [...primaryResults, ...workspaceResults];
+  const combinedText = normalizedText(combinedResults.map(resultText).join('\n'));
+  const roles = scopePlanRoleMap(bootstrap.workspace?.scopePlan);
+  const topScopes = combinedResults.map((result) => resultScope(result, roles));
+  const presentRoles = new Set(topScopes.map((scope) => scope.role).filter(Boolean));
+  const matchedRequiredTerms = requiredTerms.filter((term) => combinedText.includes(normalizedText(term)));
+  const missingRequiredTerms = requiredTerms.filter((term) => !combinedText.includes(normalizedText(term)));
+  const matchedScopeRoles = expectedScopeRoles.filter((role) => presentRoles.has(role));
+  const missingScopeRoles = expectedScopeRoles.filter((role) => !presentRoles.has(role));
+  const passed = missingRequiredTerms.length === 0 && missingScopeRoles.length === 0;
+
+  return {
+    query: querySpec.query,
+    passed,
+    topN,
+    resultWindow: {
+      primary: primaryResults.length,
+      workspace: workspaceResults.length,
+    },
+    topScopes,
+    resultKeys: combinedResults.map((result) => result.key),
+    matchedRequiredTerms,
+    missingRequiredTerms,
+    matchedScopeRoles,
+    missingScopeRoles,
+    workspaceWarnings: bootstrap.workspace?.warnings || [],
+  };
+}
+
+export async function evaluateRetrievalFixture(fixture, options = {}) {
+  if (!options.app && !options.dataDir) {
+    throw new Error('evaluateRetrievalFixture requires an isolated dataDir when app is not supplied.');
+  }
+  const app =
+    options.app ||
+    createContextForge({
+      env: {
+        ...process.env,
+        CONTEXTFORGE_DATA_DIR: options.dataDir,
+        CONTEXTFORGE_STORAGE_MODE: 'local',
+        CONTEXTFORGE_EMBEDDINGS_PROVIDER: 'none',
+      },
+      cwd: options.cwd || process.cwd(),
+    });
+  try {
+    applyFixture(app, fixture);
+    const details = [];
+    for (const query of fixture.queries || []) {
+      details.push(await evaluateQuery(app, fixture, query));
+    }
+    const failed = details.filter((detail) => !detail.passed).length;
+    return {
+      kind: 'retrieval_eval',
+      fixture: fixture.name || fixture.workspaceKey || fixture.workspace?.workspaceKey || null,
+      workspaceKey: fixture.workspaceKey || fixture.workspace?.workspaceKey || fixture.workspaceProfile?.workspaceKey,
+      queries: details.length,
+      passed: details.length - failed,
+      failed,
+      details,
+    };
+  } finally {
+    if (!options.app) {
+      app.close?.();
+    }
+  }
+}
+
+export async function runRetrievalEval(options = {}) {
+  const fixturePath = options.fixture;
+  if (!fixturePath) {
+    throw new Error('evalRetrieval requires --fixture <path>.');
+  }
+  let fixture;
+  try {
+    fixture = JSON.parse(await readFile(fixturePath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Invalid eval fixture ${fixturePath}: ${error.message}`);
+  }
+  const dataDir = await mkdtemp(path.join(tmpdir(), 'contextforge-eval-'));
+  try {
+    return await evaluateRetrievalFixture(fixture, {
+      dataDir,
+      cwd: options.cwd || process.cwd(),
+    });
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+}

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -11234,6 +11234,66 @@ test('bootstrapContext ignores workspace-only limits when workspaceKey is absent
   assert.equal(Object.prototype.hasOwnProperty.call(bootstrap, 'workspace'), false);
 });
 
+test('evalRetrieval passes for the synthetic workspace fixture', async () => {
+  const result = await execFileAsync('node', [
+    'src/cli.js',
+    'evalRetrieval',
+    '--fixture',
+    'docs/examples/workspace-eval/wastelite.synthetic.json',
+  ]);
+  const evalResult = JSON.parse(result.stdout);
+  assert.equal(evalResult.kind, 'retrieval_eval');
+  assert.equal(evalResult.queries, 3);
+  assert.equal(evalResult.failed, 0);
+  assert.equal(evalResult.passed, 3);
+  assert.equal(evalResult.details.every((detail) => detail.passed), true);
+  assert.ok(evalResult.details.every((detail) => detail.resultWindow.primary >= 0));
+  assert.ok(evalResult.details.every((detail) => detail.resultWindow.workspace >= 0));
+});
+
+test('evalRetrieval fails with useful missing term and role details', async () => {
+  const dataDir = await makeTempDir();
+  const fixturePath = path.join(dataDir, 'failing-eval.json');
+  const fixture = JSON.parse(await fs.readFile('docs/examples/workspace-eval/wastelite.synthetic.json', 'utf8'));
+  fixture.queries = [
+    {
+      query: 'OpenAPI mirror frontend can edit?',
+      primaryScopeKey: 'github.com/example/wastelite_frontend_react',
+      expected: {
+        mustContain: ['missing required phrase'],
+        expectedScopeRoles: ['missing-role'],
+      },
+    },
+  ];
+  await fs.writeFile(fixturePath, JSON.stringify(fixture, null, 2));
+
+  await assert.rejects(
+    async () => execFileAsync('node', ['src/cli.js', 'evalRetrieval', '--fixture', fixturePath]),
+    (error) => {
+      const evalResult = JSON.parse(error.stdout);
+      assert.equal(evalResult.kind, 'retrieval_eval');
+      assert.equal(evalResult.failed, 1);
+      assert.deepEqual(evalResult.details[0].missingRequiredTerms, ['missing required phrase']);
+      assert.deepEqual(evalResult.details[0].missingScopeRoles, ['missing-role']);
+      return true;
+    },
+  );
+});
+
+test('evalRetrieval reports fixture parse errors with the fixture path', async () => {
+  const dataDir = await makeTempDir();
+  const fixturePath = path.join(dataDir, 'invalid-eval.json');
+  await fs.writeFile(fixturePath, '{not valid json');
+
+  await assert.rejects(
+    async () => execFileAsync('node', ['src/cli.js', 'evalRetrieval', '--fixture', fixturePath]),
+    (error) => {
+      assert.match(error.stderr, new RegExp(`Invalid eval fixture ${fixturePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      return true;
+    },
+  );
+});
+
 test('agentStart is adapter-neutral and forwards workspaceKey to bootstrapContext', async () => {
   const dataDir = await makeTempDir();
   const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });


### PR DESCRIPTION
## Summary

Implements PR 4 from #147: add a deterministic, public-safe workspace retrieval eval fixture and CLI command.

## What changed

- Adds `node src/cli.js evalRetrieval --fixture <path>`.
- Adds `src/eval/retrieval.js` to run evals against an isolated temporary local store.
- Adds `docs/examples/workspace-eval/wastelite.synthetic.json` with synthetic cross-repo workspace data.
- Checks each golden query for:
  - required terms in top primary/workspace result windows
  - expected workspace/member scope roles in top primary/workspace result windows
- Returns detailed JSON with `matchedRequiredTerms`, `missingRequiredTerms`, `matchedScopeRoles`, `missingScopeRoles`, `resultWindow`, and `topScopes`.
- Exits non-zero when any query fails.
- Documents the command in README, README.ko, and architecture docs.

## Review follow-up

Addressed the actionable non-blocking review notes:

- Clarified that the CLI always runs in an isolated temporary local store even when the caller normally uses project-local or remote mode.
- Kept library-level app injection available for specialized harnesses, with docs warning not to write synthetic fixtures to live canonical stores.
- Runs eval queries sequentially for deterministic fixture execution.
- Evaluates top primary and workspace result windows separately before combining, so dense primary results cannot hide expected workspace roles.
- Replaced the `--file` alias with the documented `--fixture` option for `evalRetrieval`.
- Uses `member` as the role fallback instead of `repo`.
- Improves invalid JSON fixture errors with the fixture path.
- Tidied the synthetic fixture wording while preserving required term matching.

## Safety notes

The eval does not write to the caller's configured ContextForge store. The CLI forces an isolated temporary local data dir and disables embeddings for deterministic fixture execution.

The fixture is synthetic and contains no private repo paths, tokens, raw transcripts, or production data.

Refs #147.

## Verification

- `node src/cli.js evalRetrieval --fixture docs/examples/workspace-eval/wastelite.synthetic.json`
- `node --test --test-name-pattern "evalRetrieval|workspace" test/core.test.js` (13 passing)
- `git diff --check`
- `npm test` (193 passing)
