### PR TITLE
[codex] Fix CI path filter coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,25 +28,29 @@ jobs:
         run: |
           set -euo pipefail
 
+          changed_files="$(mktemp)"
+
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Refresh the base ref for PRs from forks or stale checkouts before
+            # comparing against the merge base.
             git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
             if git merge-base "origin/${{ github.base_ref }}" HEAD >/dev/null; then
-              git diff --name-only "origin/${{ github.base_ref }}...HEAD" > /tmp/contextforge-changed-files.txt
+              git diff --name-only "origin/${{ github.base_ref }}...HEAD" > "$changed_files"
             else
               echo "No merge base found with origin/${{ github.base_ref }}; run tests defensively."
-              printf '__force_tests__\n' > /tmp/contextforge-changed-files.txt
+              printf '__force_tests__\n' > "$changed_files"
             fi
           else
             before="${{ github.event.before }}"
             after="${{ github.sha }}"
             if [[ "$before" =~ ^0+$ ]]; then
-              git diff-tree --no-commit-id --name-only -r "$after" > /tmp/contextforge-changed-files.txt
+              git diff-tree --no-commit-id --name-only -r "$after" > "$changed_files"
             else
-              git diff --name-only "$before" "$after" > /tmp/contextforge-changed-files.txt
+              git diff --name-only "$before" "$after" > "$changed_files"
             fi
           fi
 
-          run_tests="$(bash scripts/ci-detect-run-tests.sh < /tmp/contextforge-changed-files.txt)"
+          run_tests="$(bash scripts/ci-detect-run-tests.sh < "$changed_files")"
 
           printf 'run_tests=%s\n' "$run_tests" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,27 +30,23 @@ jobs:
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
-            mapfile -t files < <(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+            if git merge-base "origin/${{ github.base_ref }}" HEAD >/dev/null; then
+              git diff --name-only "origin/${{ github.base_ref }}...HEAD" > /tmp/contextforge-changed-files.txt
+            else
+              echo "No merge base found with origin/${{ github.base_ref }}; run tests defensively."
+              printf '__force_tests__\n' > /tmp/contextforge-changed-files.txt
+            fi
           else
             before="${{ github.event.before }}"
             after="${{ github.sha }}"
             if [[ "$before" =~ ^0+$ ]]; then
-              mapfile -t files < <(git diff-tree --no-commit-id --name-only -r "$after")
+              git diff-tree --no-commit-id --name-only -r "$after" > /tmp/contextforge-changed-files.txt
             else
-              mapfile -t files < <(git diff --name-only "$before" "$after")
+              git diff --name-only "$before" "$after" > /tmp/contextforge-changed-files.txt
             fi
           fi
 
-          run_tests=false
-          for file in "${files[@]}"; do
-            case "$file" in
-              *.md|LICENSE)
-                ;;
-              *)
-                run_tests=true
-                ;;
-            esac
-          done
+          run_tests="$(bash scripts/ci-detect-run-tests.sh < /tmp/contextforge-changed-files.txt)"
 
           printf 'run_tests=%s\n' "$run_tests" >> "$GITHUB_OUTPUT"
 

--- a/scripts/ci-detect-run-tests.sh
+++ b/scripts/ci-detect-run-tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_tests=false
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  case "$file" in
+    README.md|README.ko.md|CHANGELOG.md|LICENSE)
+      ;;
+    docs/skills/*|docs/examples/*)
+      run_tests=true
+      ;;
+    docs/*.md|docs/issues/*.md|docs/assets/*)
+      ;;
+    *)
+      run_tests=true
+      ;;
+  esac
+done
+
+printf '%s\n' "$run_tests"

--- a/scripts/ci-detect-run-tests.sh
+++ b/scripts/ci-detect-run-tests.sh
@@ -6,7 +6,10 @@ run_tests=false
 while IFS= read -r file; do
   [[ -z "$file" ]] && continue
   case "$file" in
-    README.md|README.ko.md|CHANGELOG.md|LICENSE)
+    __force_tests__)
+      run_tests=true
+      ;;
+    README*.md|CHANGELOG.md|LICENSE)
       ;;
     docs/skills/*|docs/examples/*)
       run_tests=true

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { execFile } from 'node:child_process';
+import { execFile, spawnSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
@@ -26,6 +26,16 @@ import { startContextForgeServer } from '../src/server.js';
 import { ContextForgeStore, SCHEMA_VERSION } from '../src/storage/sqlite.js';
 
 const execFileAsync = promisify(execFile);
+
+function ciDetectRunTests(files) {
+  const result = spawnSync('bash', ['scripts/ci-detect-run-tests.sh'], {
+    cwd: process.cwd(),
+    input: `${files.join('\n')}\n`,
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
 
 async function makeTempDir() {
   return fs.mkdtemp(path.join(os.tmpdir(), 'contextforge-test-'));
@@ -12872,4 +12882,21 @@ test('runtime database artifacts are ignored by git rules', async () => {
   assert.match(gitignore, /^\*\.db$/m);
   assert.match(gitignore, /^\*\.db-wal$/m);
   assert.match(gitignore, /^\*\.db-shm$/m);
+});
+
+test('CI path filter runs tests for source, workflow, test, and eval fixture changes', () => {
+  assert.equal(ciDetectRunTests(['README.md']), 'false');
+  assert.equal(ciDetectRunTests(['docs/architecture.md']), 'false');
+  assert.equal(ciDetectRunTests(['docs/assets/contextforge-explainer-comic-en.jpg']), 'false');
+
+  assert.equal(ciDetectRunTests(['src/eval/retrieval.js']), 'true');
+  assert.equal(ciDetectRunTests(['src/workspaces/resolve.js']), 'true');
+  assert.equal(ciDetectRunTests(['src/core.js']), 'true');
+  assert.equal(ciDetectRunTests(['test/core.test.js']), 'true');
+  assert.equal(ciDetectRunTests(['.github/workflows/ci.yml']), 'true');
+  assert.equal(ciDetectRunTests(['package-lock.json']), 'true');
+  assert.equal(ciDetectRunTests(['scripts/install-agent-router-service.sh']), 'true');
+  assert.equal(ciDetectRunTests(['docs/examples/workspace-eval/wastelite.synthetic.json']), 'true');
+  assert.equal(ciDetectRunTests(['docs/skills/contextforge-memory/SKILL.md']), 'true');
+  assert.equal(ciDetectRunTests(['README.md', 'src/cli.js']), 'true');
 });

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -12886,9 +12886,12 @@ test('runtime database artifacts are ignored by git rules', async () => {
 
 test('CI path filter runs tests for source, workflow, test, and eval fixture changes', () => {
   assert.equal(ciDetectRunTests(['README.md']), 'false');
+  assert.equal(ciDetectRunTests(['README.ja.md']), 'false');
   assert.equal(ciDetectRunTests(['docs/architecture.md']), 'false');
+  assert.equal(ciDetectRunTests(['docs/issues/001-design-note.md']), 'false');
   assert.equal(ciDetectRunTests(['docs/assets/contextforge-explainer-comic-en.jpg']), 'false');
 
+  assert.equal(ciDetectRunTests(['__force_tests__']), 'true');
   assert.equal(ciDetectRunTests(['src/eval/retrieval.js']), 'true');
   assert.equal(ciDetectRunTests(['src/workspaces/resolve.js']), 'true');
   assert.equal(ciDetectRunTests(['src/core.js']), 'true');


### PR DESCRIPTION
## Summary

Fixes #153 by making CI path filtering explicit and test-covered.

## What changed

- Moves run-test path classification into `scripts/ci-detect-run-tests.sh`.
- Keeps the existing repository principle that draft PRs do not run CI; CI still runs only when a PR is ready/non-draft or on `main` push.
- Runs tests for source, workflow, test, package, script, workspace/eval fixture, and skill changes.
- Keeps ordinary README / docs markdown / docs asset-only changes lightweight.
- Makes missing PR merge-base defensive: if CI cannot compute the base diff, it forces tests instead of producing a fake-green skipped matrix.
- Adds unit coverage for the path classifier.

## Notes

This does not change the AI mention review workflow. That path is currently separate from this CI cleanup.

## Verification

- `bash -n scripts/ci-detect-run-tests.sh`
- `node --test --test-name-pattern "CI path filter" test/core.test.js`
- `git diff --check`
- `npm test` (194 passing)
