### PR TITLE
[codex] Add workspace federation to standalone search

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -471,6 +471,12 @@ node src/cli.js bootstrapContext \
 - `workingSummary`: sessionId를 알 때 가져오는 현재 세션 resume state.
 - `rawTail`: 필요한 경우에만 요청하는 최근 raw event 꼬리.
 
+작업 중 targeted lookup에는 `search`에도 `--workspaceKey`를 넘길 수 있다.
+`workspaceKey`가 없으면 `search`는 기존 배열 응답을 유지한다. `workspaceKey`
+가 있으면 `{ kind: "workspace_search", results, workspace }`를 반환하며,
+`results`는 primary scope 검색 결과, `workspace.results`는 provenance가 붙은
+bounded supplemental member-scope 결과다.
+
 에이전트는 `handoff.latestHandoff`를 먼저 읽고, `liveState.verifyHints`로
 branch/PR/CI/worktree를 재검증한 뒤 durable memory와 검색 결과를 참고해야 한다.
 

--- a/README.md
+++ b/README.md
@@ -1266,6 +1266,12 @@ For configured workspace profiles, pass `--workspaceKey` to add a separate
 and compact per-scope memory overview. Top-level `results` remain the primary
 scope view unless the caller explicitly enables primary duplication in the
 workspace block.
+Targeted `search` calls can also opt into the same bounded workspace federation
+with `--workspaceKey`. Without `workspaceKey`, `search` keeps the legacy array
+response. With `workspaceKey`, it returns `{ kind: "workspace_search", results,
+workspace }`, where `results` are the primary-scope search view and
+`workspace.results` are bounded supplemental member-scope results with
+workspace provenance.
 Bootstrap also returns a separate `memoryMap` channel for progressive durable
 memory navigation. The map groups related active memories into compact clusters,
 chooses a canonical `consolidatedMemory` for each cluster, and includes an

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -42,6 +42,10 @@ enabled, read top-level `results` as the primary-scope view and
 `workspace.results` as bounded supplemental member-scope context. Top-level
 `includeShared=true` does not by itself enable workspace shared retrieval;
 workspace shared results require a workspace routing rule with `includeShared`.
+During active work, targeted `search` calls may also pass `workspaceKey` when a
+file/API/error/domain lookup needs cross-repo memory. Without `workspaceKey`,
+`search` keeps its ordinary scoped array response; with `workspaceKey`, inspect
+the separate `workspace` block for supplemental member-scope results.
 
 Do not call `bootstrap_context` just to re-confirm current intent inside the
 same uninterrupted active session. For active-session file/API/error/domain

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,6 +175,14 @@ overtaken by checkpoint handoff state when handoffs are explicitly included.
 Top-level `includeShared` belongs to the primary bootstrap view; workspace
 shared retrieval is enabled by workspace routing rules with `includeShared`.
 
+Standalone `search` can also opt into workspace federation with `workspaceKey`
+for active-session targeted lookup. It preserves the existing array response
+when `workspaceKey` is absent. When `workspaceKey` is present, it returns a
+`workspace_search` envelope with primary-scope `results` and a separate bounded
+`workspace` block. Search workspace federation uses the same scope plan,
+per-scope limits, provenance, shared opt-in, and raw-evidence-free retrieval
+policy as bootstrap.
+
 `include_by_default` is a scope-plan convenience, not permission to retrieve an
 unbounded amount of memory. Use it sparingly, usually for the canonical suite or
 contract repo, and keep workspace retrieval bounded by per-scope and total

--- a/docs/skills/contextforge-memory/SKILL.md
+++ b/docs/skills/contextforge-memory/SKILL.md
@@ -150,7 +150,7 @@ At the start of non-trivial project work:
 8. When a workspace profile is configured and the task needs cross-repo context, pass `workspaceKey` to receive bounded supplemental workspace results in `workspace.results`.
 9. Set `includeShared: true` only for cross-repo/user-wide policy, credentials location, deployment, or recurring preference questions.
 10. Read the storage block and result trust roles.
-11. Use targeted `search` calls only when more detail is needed.
+11. Use targeted `search` calls only when more detail is needed. For active-session cross-repo lookups, pass `workspaceKey`; without it, `search` keeps the ordinary scoped array response.
 12. Use `get_memory` only when you already know the exact durable key.
 
 `bootstrap_context` does not create a session. It retrieves scoped context.

--- a/src/core.js
+++ b/src/core.js
@@ -1079,6 +1079,10 @@ function workspaceSearchResult(result, member, workspaceKey, query) {
   };
 }
 
+function workspaceKeyRequested(value) {
+  return String(value ?? '').trim() !== '';
+}
+
 function buildWorkspaceMemoryMap({ workspaceKey, scopePlan, results }) {
   const byScope = new Map();
   for (const scope of scopePlan.includedScopes || []) {
@@ -3308,7 +3312,12 @@ export function createContextForge(options = {}) {
     });
   }
 
-  function workspaceSearchBlock(store, scope, options, queryEmbedding = null) {
+  function buildWorkspaceFederationBlock(
+    store,
+    scope,
+    options,
+    { queryEmbedding = null, consultReason = null, resultMapper } = {},
+  ) {
     const workspaceKey = normalizeWorkspaceKey(options.workspaceKey);
     const workspaceMode = normalizeWorkspaceMode(options.workspaceMode || options.mode || 'auto');
     const workspaceResultLimit = positiveInteger(
@@ -3322,7 +3331,7 @@ export function createContextForge(options = {}) {
     const includeWorkspaceHandoffs = truthyOption(options.includeWorkspaceHandoffs);
     const includePrimaryInWorkspaceResults = truthyOption(options.includePrimaryInWorkspaceResults);
     const sharedScopeKey = options.sharedScopeKey || config.defaultSharedScopeKey;
-    const consultReason = normalizeConsultReason(options.consultReason || 'targeted_search');
+    const normalizedConsultReason = normalizeConsultReason(consultReason || options.consultReason || 'targeted_search');
     const workspaceProfile = store.getWorkspaceProfileByKey({ workspaceKey, includeInactive: true });
     const workspaceMembers = workspaceProfile ? store.listWorkspaceMembers({ workspaceKey }) : [];
     const workspaceRoutingRules = workspaceProfile
@@ -3335,7 +3344,7 @@ export function createContextForge(options = {}) {
       primaryScope: scope.scopeType,
       primaryScopeKey: scope.scopeKey,
       query: options.query,
-      consultReason,
+      consultReason: normalizedConsultReason,
       mode: workspaceMode,
       includeShared: false,
     });
@@ -3370,7 +3379,7 @@ export function createContextForge(options = {}) {
           queryEmbedding,
         )
           .filter((result) => includeWorkspaceHandoffs || result.type !== 'checkpoint')
-          .map((result) => workspaceSearchResult(result, member, workspaceKey, options.query));
+          .map((result) => resultMapper(result, member, workspaceKey, options.query));
         workspaceResults.push(...scopedResults);
       }
       if (scopePlan.includeShared) {
@@ -3380,6 +3389,16 @@ export function createContextForge(options = {}) {
             message: 'Workspace scope plan requested shared scope, but no shared scope key is configured.',
           });
         } else {
+          const sharedIdentity = scopeIdentity('shared', sharedScopeKey);
+          const sharedAlreadyIncluded = seenSearchScopes.has(sharedIdentity);
+          if (sharedAlreadyIncluded) {
+            workspaceWarnings.push({
+              code: 'shared_scope_already_included',
+              message: 'Workspace shared scope was already included as a member scope.',
+            });
+          } else {
+            seenSearchScopes.add(sharedIdentity);
+          }
           const sharedMember = {
             scopeType: 'shared',
             scopeKey: sharedScopeKey,
@@ -3388,22 +3407,24 @@ export function createContextForge(options = {}) {
             priority: 0,
             includedBecause: ['include_shared'],
           };
-          const sharedWorkspaceResults = searchStoreWithScope(
-            store,
-            {
-              scopeType: 'shared',
-              scopeKey: sharedScopeKey,
-            },
-            {
-              query: options.query,
-              limit: workspacePerScopeLimit,
-              sharedScopeKey,
-            },
-            queryEmbedding,
-          )
-            .filter((result) => includeWorkspaceHandoffs || result.type !== 'checkpoint')
-            .map((result) => workspaceSearchResult(result, sharedMember, workspaceKey, options.query));
-          workspaceResults.push(...sharedWorkspaceResults);
+          if (!sharedAlreadyIncluded) {
+            const sharedWorkspaceResults = searchStoreWithScope(
+              store,
+              {
+                scopeType: 'shared',
+                scopeKey: sharedScopeKey,
+              },
+              {
+                query: options.query,
+                limit: workspacePerScopeLimit,
+                sharedScopeKey,
+              },
+              queryEmbedding,
+            )
+              .filter((result) => includeWorkspaceHandoffs || result.type !== 'checkpoint')
+              .map((result) => resultMapper(result, sharedMember, workspaceKey, options.query));
+            workspaceResults.push(...sharedWorkspaceResults);
+          }
         }
       }
       workspaceResults = workspaceResults
@@ -3804,7 +3825,7 @@ export function createContextForge(options = {}) {
         : null;
       const mapLimit = memoryMapLimit(options.memoryMapLimit, 5, 'memoryMapLimit');
       const mapClusterSize = memoryMapLimit(options.memoryMapClusterSize, 6, 'memoryMapClusterSize');
-      const workspaceRequested = options.workspaceKey != null && options.workspaceKey !== '';
+      const workspaceRequested = workspaceKeyRequested(options.workspaceKey);
       return useStore(async (store) => {
         const info = buildDbInfo(store);
         const storage = storageBootstrapInfo(config, info);
@@ -3848,125 +3869,11 @@ export function createContextForge(options = {}) {
         ];
         let workspaceBlock = null;
         if (workspaceRequested) {
-          const workspaceKey = normalizeWorkspaceKey(options.workspaceKey);
-          const workspaceMode = normalizeWorkspaceMode(options.workspaceMode || options.mode || 'auto');
-          const workspaceResultLimit = positiveInteger(
-            options.workspaceResultLimit == null ? 8 : Number(options.workspaceResultLimit),
-            'workspaceResultLimit',
-          );
-          const workspacePerScopeLimit = positiveInteger(
-            options.workspacePerScopeLimit == null ? 4 : Number(options.workspacePerScopeLimit),
-            'workspacePerScopeLimit',
-          );
-          const includeWorkspaceHandoffs = truthyOption(options.includeWorkspaceHandoffs);
-          const includePrimaryInWorkspaceResults = truthyOption(options.includePrimaryInWorkspaceResults);
-          const workspaceProfile = store.getWorkspaceProfileByKey({ workspaceKey, includeInactive: true });
-          const workspaceMembers = workspaceProfile ? store.listWorkspaceMembers({ workspaceKey }) : [];
-          const workspaceRoutingRules = workspaceProfile
-            ? store.listWorkspaceRoutingRules({ workspaceKey, status: 'all' })
-            : [];
-          const scopePlan = resolveWorkspaceScopePlan({
-            workspace: workspaceProfile,
-            members: workspaceMembers,
-            routingRules: workspaceRoutingRules,
-            primaryScope: scope.scopeType,
-            primaryScopeKey: scope.scopeKey,
-            query: options.query,
+          workspaceBlock = buildWorkspaceFederationBlock(store, scope, options, {
+            queryEmbedding,
             consultReason,
-            mode: workspaceMode,
-            includeShared: false,
+            resultMapper: workspaceBootstrapResult,
           });
-          const workspaceWarnings = [...(scopePlan.warnings || [])];
-          let workspaceResults = [];
-          if (scopePlan.enabled) {
-            const primaryIdentity = scopeIdentity(scope.scopeType, scope.scopeKey);
-            const searchMembers = (scopePlan.includedScopes || [])
-              .map((includedScope) => workspaceSearchMemberFromScope(includedScope))
-              .filter(
-                (member) =>
-                  includePrimaryInWorkspaceResults || scopeIdentity(member.scopeType, member.scopeKey) !== primaryIdentity,
-              );
-            const seenSearchScopes = new Set();
-            for (const member of searchMembers) {
-              const identity = scopeIdentity(member.scopeType, member.scopeKey);
-              if (seenSearchScopes.has(identity)) {
-                continue;
-              }
-              seenSearchScopes.add(identity);
-              const scopedResults = searchStoreWithScope(
-                store,
-                {
-                  scopeType: member.scopeType,
-                  scopeKey: member.scopeKey,
-                },
-                {
-                  query: options.query,
-                  limit: workspacePerScopeLimit,
-                  sharedScopeKey,
-                },
-                queryEmbedding,
-              )
-                .filter((result) => includeWorkspaceHandoffs || result.type !== 'checkpoint')
-                .map((result) => workspaceBootstrapResult(result, member, workspaceKey, options.query));
-              workspaceResults.push(...scopedResults);
-            }
-            if (scopePlan.includeShared) {
-              if (!sharedScopeKey) {
-                workspaceWarnings.push({
-                  code: 'missing_shared_scope_key',
-                  message: 'Workspace scope plan requested shared scope, but no shared scope key is configured.',
-                });
-              } else {
-                const sharedMember = {
-                  scopeType: 'shared',
-                  scopeKey: sharedScopeKey,
-                  memberName: null,
-                  role: 'shared',
-                  priority: 0,
-                  includedBecause: ['include_shared'],
-                };
-                const sharedWorkspaceResults = searchStoreWithScope(
-                  store,
-                  {
-                    scopeType: 'shared',
-                    scopeKey: sharedScopeKey,
-                  },
-                  {
-                    query: options.query,
-                    limit: workspacePerScopeLimit,
-                    sharedScopeKey,
-                  },
-                  queryEmbedding,
-                )
-                  .filter((result) => includeWorkspaceHandoffs || result.type !== 'checkpoint')
-                  .map((result) => workspaceBootstrapResult(result, sharedMember, workspaceKey, options.query));
-                workspaceResults.push(...sharedWorkspaceResults);
-              }
-            }
-            workspaceResults = workspaceResults
-              .sort(
-                (a, b) =>
-                  workspaceTypeTier(b.type) - workspaceTypeTier(a.type) ||
-                  b.workspaceRank - a.workspaceRank ||
-                  String(a.scope?.scopeKey || '').localeCompare(String(b.scope?.scopeKey || '')) ||
-                  String(a.key || '').localeCompare(String(b.key || '')),
-              )
-              .slice(0, workspaceResultLimit);
-          }
-          workspaceBlock = {
-            enabled: Boolean(scopePlan.enabled),
-            scopePlan,
-            results: workspaceResults,
-            memoryMap: buildWorkspaceMemoryMap({ workspaceKey, scopePlan, results: workspaceResults }),
-            warnings: workspaceWarnings,
-            limits: {
-              resultLimit: workspaceResultLimit,
-              perScopeLimit: workspacePerScopeLimit,
-              includeWorkspaceHandoffs,
-              includePrimaryInWorkspaceResults,
-            },
-            summary: workspaceBlockSummary(scopePlan, workspaceResults),
-          };
         }
         const memoryMapSeeds = repoResults
           .filter((result) => result.type === 'memory' && result.memory)
@@ -6254,7 +6161,7 @@ export function createContextForge(options = {}) {
     search(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.query, 'query');
-      const workspaceRequested = options.workspaceKey != null && options.workspaceKey !== '';
+      const workspaceRequested = workspaceKeyRequested(options.workspaceKey);
       if (workspaceRequested) {
         if (!embeddingProvider) {
           return useStore((store) => {
@@ -6264,7 +6171,9 @@ export function createContextForge(options = {}) {
               scope,
               query: options.query,
               results,
-              workspace: workspaceSearchBlock(store, scope, options),
+              workspace: buildWorkspaceFederationBlock(store, scope, options, {
+                resultMapper: workspaceSearchResult,
+              }),
             };
           });
         }
@@ -6276,7 +6185,10 @@ export function createContextForge(options = {}) {
             scope,
             query: options.query,
             results,
-            workspace: workspaceSearchBlock(store, scope, options, queryEmbedding),
+            workspace: buildWorkspaceFederationBlock(store, scope, options, {
+              queryEmbedding,
+              resultMapper: workspaceSearchResult,
+            }),
           };
         });
       }

--- a/src/core.js
+++ b/src/core.js
@@ -1051,6 +1051,34 @@ function workspaceBootstrapResult(result, member, workspaceKey, query) {
   };
 }
 
+function workspaceSearchResult(result, member, workspaceKey, query) {
+  const summary = bootstrapResultSummary(result);
+  const scope = {
+    scope: member.scopeType,
+    scopeType: member.scopeType,
+    scopeKey: member.scopeKey,
+    workspaceKey,
+    memberName: member.memberName,
+    role: member.role,
+  };
+  return {
+    ...result,
+    key: summary.key,
+    category: summary.category,
+    content: summary.content,
+    trust: bootstrapTrustForType(result.type),
+    verificationRequired: result.type !== 'memory' ? true : requiresLiveStateVerification(result),
+    whyUse: bootstrapUseHint(result),
+    scope,
+    source: {
+      ...(result.source || {}),
+      ...scope,
+    },
+    includedBecause: member.includedBecause || [],
+    workspaceRank: workspaceResultSortScore(result, member, query),
+  };
+}
+
 function buildWorkspaceMemoryMap({ workspaceKey, scopePlan, results }) {
   const byScope = new Map();
   for (const scope of scopePlan.includedScopes || []) {
@@ -3278,6 +3306,130 @@ export function createContextForge(options = {}) {
       const [queryEmbedding] = await embeddingProvider.embed([options.query]);
       return searchStoreWithScope(store, scope, options, queryEmbedding);
     });
+  }
+
+  function workspaceSearchBlock(store, scope, options, queryEmbedding = null) {
+    const workspaceKey = normalizeWorkspaceKey(options.workspaceKey);
+    const workspaceMode = normalizeWorkspaceMode(options.workspaceMode || options.mode || 'auto');
+    const workspaceResultLimit = positiveInteger(
+      options.workspaceResultLimit == null ? 8 : Number(options.workspaceResultLimit),
+      'workspaceResultLimit',
+    );
+    const workspacePerScopeLimit = positiveInteger(
+      options.workspacePerScopeLimit == null ? 4 : Number(options.workspacePerScopeLimit),
+      'workspacePerScopeLimit',
+    );
+    const includeWorkspaceHandoffs = truthyOption(options.includeWorkspaceHandoffs);
+    const includePrimaryInWorkspaceResults = truthyOption(options.includePrimaryInWorkspaceResults);
+    const sharedScopeKey = options.sharedScopeKey || config.defaultSharedScopeKey;
+    const consultReason = normalizeConsultReason(options.consultReason || 'targeted_search');
+    const workspaceProfile = store.getWorkspaceProfileByKey({ workspaceKey, includeInactive: true });
+    const workspaceMembers = workspaceProfile ? store.listWorkspaceMembers({ workspaceKey }) : [];
+    const workspaceRoutingRules = workspaceProfile
+      ? store.listWorkspaceRoutingRules({ workspaceKey, status: 'all' })
+      : [];
+    const scopePlan = resolveWorkspaceScopePlan({
+      workspace: workspaceProfile,
+      members: workspaceMembers,
+      routingRules: workspaceRoutingRules,
+      primaryScope: scope.scopeType,
+      primaryScopeKey: scope.scopeKey,
+      query: options.query,
+      consultReason,
+      mode: workspaceMode,
+      includeShared: false,
+    });
+    const workspaceWarnings = [...(scopePlan.warnings || [])];
+    let workspaceResults = [];
+    if (scopePlan.enabled) {
+      const primaryIdentity = scopeIdentity(scope.scopeType, scope.scopeKey);
+      const searchMembers = (scopePlan.includedScopes || [])
+        .map((includedScope) => workspaceSearchMemberFromScope(includedScope))
+        .filter(
+          (member) =>
+            includePrimaryInWorkspaceResults || scopeIdentity(member.scopeType, member.scopeKey) !== primaryIdentity,
+        );
+      const seenSearchScopes = new Set();
+      for (const member of searchMembers) {
+        const identity = scopeIdentity(member.scopeType, member.scopeKey);
+        if (seenSearchScopes.has(identity)) {
+          continue;
+        }
+        seenSearchScopes.add(identity);
+        const scopedResults = searchStoreWithScope(
+          store,
+          {
+            scopeType: member.scopeType,
+            scopeKey: member.scopeKey,
+          },
+          {
+            query: options.query,
+            limit: workspacePerScopeLimit,
+            sharedScopeKey,
+          },
+          queryEmbedding,
+        )
+          .filter((result) => includeWorkspaceHandoffs || result.type !== 'checkpoint')
+          .map((result) => workspaceSearchResult(result, member, workspaceKey, options.query));
+        workspaceResults.push(...scopedResults);
+      }
+      if (scopePlan.includeShared) {
+        if (!sharedScopeKey) {
+          workspaceWarnings.push({
+            code: 'missing_shared_scope_key',
+            message: 'Workspace scope plan requested shared scope, but no shared scope key is configured.',
+          });
+        } else {
+          const sharedMember = {
+            scopeType: 'shared',
+            scopeKey: sharedScopeKey,
+            memberName: null,
+            role: 'shared',
+            priority: 0,
+            includedBecause: ['include_shared'],
+          };
+          const sharedWorkspaceResults = searchStoreWithScope(
+            store,
+            {
+              scopeType: 'shared',
+              scopeKey: sharedScopeKey,
+            },
+            {
+              query: options.query,
+              limit: workspacePerScopeLimit,
+              sharedScopeKey,
+            },
+            queryEmbedding,
+          )
+            .filter((result) => includeWorkspaceHandoffs || result.type !== 'checkpoint')
+            .map((result) => workspaceSearchResult(result, sharedMember, workspaceKey, options.query));
+          workspaceResults.push(...sharedWorkspaceResults);
+        }
+      }
+      workspaceResults = workspaceResults
+        .sort(
+          (a, b) =>
+            workspaceTypeTier(b.type) - workspaceTypeTier(a.type) ||
+            b.workspaceRank - a.workspaceRank ||
+            String(a.scope?.scopeKey || '').localeCompare(String(b.scope?.scopeKey || '')) ||
+            String(a.key || '').localeCompare(String(b.key || '')),
+        )
+        .slice(0, workspaceResultLimit);
+    }
+    return {
+      enabled: Boolean(scopePlan.enabled),
+      scopePlan,
+      results: workspaceResults,
+      memoryMap: buildWorkspaceMemoryMap({ workspaceKey, scopePlan, results: workspaceResults }),
+      warnings: workspaceWarnings,
+      limits: {
+        resultLimit: workspaceResultLimit,
+        perScopeLimit: workspacePerScopeLimit,
+        includeWorkspaceHandoffs,
+        includePrimaryInWorkspaceResults,
+      },
+      summary: workspaceBlockSummary(scopePlan, workspaceResults),
+    };
   }
 
   async function memoryVectorRelations(store, scope, seeds, storage, limit = 50) {
@@ -6102,6 +6254,32 @@ export function createContextForge(options = {}) {
     search(options) {
       const scope = normalizeScopeOptions(options, config);
       requireOption(options.query, 'query');
+      const workspaceRequested = options.workspaceKey != null && options.workspaceKey !== '';
+      if (workspaceRequested) {
+        if (!embeddingProvider) {
+          return useStore((store) => {
+            const results = searchStoreWithScope(store, scope, options);
+            return {
+              kind: 'workspace_search',
+              scope,
+              query: options.query,
+              results,
+              workspace: workspaceSearchBlock(store, scope, options),
+            };
+          });
+        }
+        return useStore(async (store) => {
+          const [queryEmbedding] = await embeddingProvider.embed([options.query]);
+          const results = searchStoreWithScope(store, scope, options, queryEmbedding);
+          return {
+            kind: 'workspace_search',
+            scope,
+            query: options.query,
+            results,
+            workspace: workspaceSearchBlock(store, scope, options, queryEmbedding),
+          };
+        });
+      }
       return searchWithScope(scope, options);
     },
 

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -576,13 +576,20 @@ export function createContextForgeMcpServer({ app = createContextForge() } = {})
     {
       title: 'Search Memory',
       description:
-        'Search scoped ContextForge retrieval results. Results may include type=memory reviewed durable facts, type=checkpoint credible recent handoff state, and type=memory_candidate unreviewed promotion candidates. Pass repoPath or cwd to retrieve repo results for a checkout outside the MCP process cwd; repoPath takes precedence. Pass scopeKey to pin the canonical repo memory key.',
+        'Search scoped ContextForge retrieval results. Results may include type=memory reviewed durable facts, type=checkpoint credible recent handoff state, and type=memory_candidate unreviewed promotion candidates. Pass repoPath or cwd to retrieve repo results for a checkout outside the MCP process cwd; repoPath takes precedence. Pass scopeKey to pin the canonical repo memory key. Pass workspaceKey to add bounded workspace federation over existing scopes; workspace profiles do not change storage mode.',
       inputSchema: {
         ...scopedSchema,
         query: z.string(),
         limit: z.number().int().positive().optional(),
         searchScopes: z.enum(['scope', 'repo', 'shared', 'repo+shared', 'local']).optional(),
         sharedScopeKey: z.string().optional(),
+        workspaceKey: z.string().optional(),
+        workspaceMode: workspaceModeSchema.optional(),
+        workspaceResultLimit: z.number().int().positive().optional(),
+        workspacePerScopeLimit: z.number().int().positive().optional(),
+        includeWorkspaceHandoffs: z.boolean().optional(),
+        includePrimaryInWorkspaceResults: z.boolean().optional(),
+        consultReason: consultReasonSchema.optional(),
       },
       annotations: {
         title: 'Search Memory',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -11227,6 +11227,7 @@ test('bootstrapContext ignores workspace-only limits when workspaceKey is absent
     scopeKey: 'github.com/example/backend',
     query: 'policy',
     consultReason: 'startup',
+    workspaceKey: '   ',
     workspaceResultLimit: 0,
     workspacePerScopeLimit: 0,
   });
@@ -11254,6 +11255,15 @@ test('search keeps the legacy array shape unless workspaceKey is provided', asyn
 
   assert.equal(Array.isArray(results), true);
   assert.equal(results[0].memory.key, 'backend-openapi-contract');
+
+  const blankWorkspaceKey = await app.search({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    query: 'OpenAPI permission',
+    workspaceKey: '   ',
+  });
+  assert.equal(Array.isArray(blankWorkspaceKey), true);
+  assert.equal(blankWorkspaceKey[0].memory.key, 'backend-openapi-contract');
 });
 
 test('search adds bounded supplemental workspace results when workspaceKey is provided', async () => {
@@ -11375,6 +11385,42 @@ test('search adds bounded supplemental workspace results when workspaceKey is pr
   ]);
   assert.equal(search.workspace.memoryMap.kind, 'workspace_memory_map');
   assert.equal(search.workspace.limits.includePrimaryInWorkspaceResults, false);
+
+  const withPrimary = await app.search({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    query: 'OpenAPI frontend contract',
+    workspaceKey: 'search-workspace',
+    workspaceResultLimit: 3,
+    workspacePerScopeLimit: 1,
+    includePrimaryInWorkspaceResults: true,
+  });
+  assert.equal(withPrimary.workspace.limits.includePrimaryInWorkspaceResults, true);
+  assert.equal(withPrimary.workspace.results.some((result) => result.key === 'backend-openapi-contract'), true);
+});
+
+test('search reports a workspace warning when a requested profile is missing', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    key: 'backend-policy',
+    content: 'Backend policy memory remains searchable without workspace profile state.',
+  });
+
+  const search = await app.search({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    query: 'policy',
+    workspaceKey: 'missing-workspace',
+  });
+
+  assert.equal(search.kind, 'workspace_search');
+  assert.equal(search.results[0].memory.key, 'backend-policy');
+  assert.equal(search.workspace.enabled, false);
+  assert.equal(search.workspace.results.length, 0);
+  assert.equal(search.workspace.warnings[0].code, 'workspace_not_found');
 });
 
 test('search workspace shared retrieval stays routing-rule opt-in', async () => {
@@ -11397,6 +11443,14 @@ test('search workspace shared retrieval stays routing-rule opt-in', async () => 
     scope: 'repo',
     scopeKey: 'github.com/example/backend',
     role: 'api-domain-ssot',
+  });
+  app.upsertWorkspaceMember({
+    workspaceKey: 'search-shared-workspace',
+    name: 'team',
+    scope: 'shared',
+    scopeKey: 'team-shared',
+    role: 'shared-policy',
+    includeByDefault: true,
   });
   app.upsertWorkspaceRoutingRule({
     workspaceKey: 'search-shared-workspace',
@@ -11429,6 +11483,14 @@ test('search workspace shared retrieval stays routing-rule opt-in', async () => 
   assert.equal(
     search.workspace.results.find((result) => result.scope.scopeType === 'shared').scope.workspaceKey,
     'search-shared-workspace',
+  );
+  assert.equal(
+    search.workspace.results.filter((result) => result.key === 'shared-policy').length,
+    1,
+  );
+  assert.equal(
+    search.workspace.warnings.some((warning) => warning.code === 'shared_scope_already_included'),
+    true,
   );
 });
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -11234,6 +11234,204 @@ test('bootstrapContext ignores workspace-only limits when workspaceKey is absent
   assert.equal(Object.prototype.hasOwnProperty.call(bootstrap, 'workspace'), false);
 });
 
+test('search keeps the legacy array shape unless workspaceKey is provided', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    key: 'backend-openapi-contract',
+    content: 'Backend owns the OpenAPI permission contract.',
+    category: 'contract',
+  });
+
+  const results = await app.search({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    query: 'OpenAPI permission',
+  });
+
+  assert.equal(Array.isArray(results), true);
+  assert.equal(results[0].memory.key, 'backend-openapi-contract');
+});
+
+test('search adds bounded supplemental workspace results when workspaceKey is provided', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({ env: { CONTEXTFORGE_DATA_DIR: dataDir }, cwd: process.cwd() });
+  app.upsertWorkspaceProfile({
+    workspaceKey: 'search-workspace',
+    displayName: 'Search Workspace',
+    canonicalScope: 'repo',
+    canonicalScopeKey: 'github.com/example/suite',
+  });
+  app.upsertWorkspaceMember({
+    workspaceKey: 'search-workspace',
+    name: 'suite',
+    scope: 'repo',
+    scopeKey: 'github.com/example/suite',
+    role: 'cross-repo-contract',
+    priority: 100,
+    includeByDefault: true,
+  });
+  app.upsertWorkspaceMember({
+    workspaceKey: 'search-workspace',
+    name: 'backend',
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    role: 'api-domain-ssot',
+    priority: 90,
+  });
+  app.upsertWorkspaceMember({
+    workspaceKey: 'search-workspace',
+    name: 'web',
+    scope: 'repo',
+    scopeKey: 'github.com/example/web',
+    role: 'desktop-web-consumer',
+    priority: 60,
+  });
+  app.upsertWorkspaceMember({
+    workspaceKey: 'search-workspace',
+    name: 'ops',
+    scope: 'repo',
+    scopeKey: 'github.com/example/ops',
+    role: 'ops',
+    priority: 10,
+  });
+  app.upsertWorkspaceRoutingRule({
+    workspaceKey: 'search-workspace',
+    ruleKey: 'contract_terms',
+    priority: 100,
+    match: { termsAny: ['OpenAPI', 'contract', 'frontend'] },
+    include: { roles: ['cross-repo-contract', 'api-domain-ssot', 'desktop-web-consumer'] },
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    key: 'backend-openapi-contract',
+    content: 'Backend owns the OpenAPI permission contract.',
+    category: 'contract',
+    importance: 8,
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/example/suite',
+    key: 'suite-openapi-contract',
+    content: 'Suite records the cross-repo OpenAPI frontend contract.',
+    category: 'contract',
+    importance: 8,
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/example/web',
+    key: 'web-openapi-consumer',
+    content: 'Web frontend consumes the OpenAPI contract.',
+    category: 'consumer',
+    importance: 5,
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/example/ops',
+    key: 'ops-openapi-note',
+    content: 'Ops mentions the OpenAPI frontend contract but is not a workspace routing match.',
+    category: 'ops',
+    importance: 10,
+  });
+
+  const search = await app.search({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    query: 'OpenAPI frontend contract',
+    workspaceKey: 'search-workspace',
+    workspaceResultLimit: 2,
+    workspacePerScopeLimit: 1,
+  });
+
+  assert.equal(search.kind, 'workspace_search');
+  assert.equal(search.scope.scopeKey, 'github.com/example/backend');
+  assert.equal(search.results.some((result) => result.memory.key === 'backend-openapi-contract'), true);
+  assert.equal(search.workspace.enabled, true);
+  assert.equal(search.workspace.scopePlan.primaryScope.memberName, 'backend');
+  assert.deepEqual(
+    search.workspace.scopePlan.includedScopes.map((scope) => scope.memberName),
+    ['suite', 'backend', 'web'],
+  );
+  assert.equal(
+    search.workspace.scopePlan.excludedScopes.some((scope) => scope.memberName === 'ops'),
+    true,
+  );
+  assert.equal(search.workspace.results.length, 2);
+  assert.equal(search.workspace.results.some((result) => result.key === 'backend-openapi-contract'), false);
+  assert.equal(search.workspace.results.some((result) => result.key === 'ops-openapi-note'), false);
+  assert.deepEqual(
+    search.workspace.results.map((result) => result.scope.memberName),
+    ['suite', 'web'],
+  );
+  assert.equal(search.workspace.results[0].scope.workspaceKey, 'search-workspace');
+  assert.deepEqual(search.workspace.results[0].includedBecause, [
+    'include_by_default',
+    'canonical_scope',
+    'routing_rule:contract_terms',
+  ]);
+  assert.equal(search.workspace.memoryMap.kind, 'workspace_memory_map');
+  assert.equal(search.workspace.limits.includePrimaryInWorkspaceResults, false);
+});
+
+test('search workspace shared retrieval stays routing-rule opt-in', async () => {
+  const dataDir = await makeTempDir();
+  const app = createContextForge({
+    env: {
+      CONTEXTFORGE_DATA_DIR: dataDir,
+      CONTEXTFORGE_SHARED_SCOPE_KEY: 'team-shared',
+    },
+    cwd: process.cwd(),
+  });
+  app.upsertWorkspaceProfile({
+    workspaceKey: 'search-shared-workspace',
+    canonicalScope: 'repo',
+    canonicalScopeKey: 'github.com/example/backend',
+  });
+  app.upsertWorkspaceMember({
+    workspaceKey: 'search-shared-workspace',
+    name: 'backend',
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    role: 'api-domain-ssot',
+  });
+  app.upsertWorkspaceRoutingRule({
+    workspaceKey: 'search-shared-workspace',
+    ruleKey: 'shared_terms',
+    match: { termsAny: ['policy'] },
+    include: { roles: ['api-domain-ssot'] },
+    includeShared: true,
+  });
+  app.remember({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    key: 'backend-policy',
+    content: 'Backend policy memory.',
+  });
+  app.remember({
+    scope: 'shared',
+    scopeKey: 'team-shared',
+    key: 'shared-policy',
+    content: 'Shared policy memory for workspace search.',
+  });
+
+  const search = await app.search({
+    scope: 'repo',
+    scopeKey: 'github.com/example/backend',
+    query: 'policy',
+    workspaceKey: 'search-shared-workspace',
+  });
+  assert.equal(search.workspace.scopePlan.includeShared, true);
+  assert.equal(search.workspace.results.some((result) => result.scope.scopeType === 'shared'), true);
+  assert.equal(
+    search.workspace.results.find((result) => result.scope.scopeType === 'shared').scope.workspaceKey,
+    'search-shared-workspace',
+  );
+});
+
 test('evalRetrieval passes for the synthetic workspace fixture', async () => {
   const result = await execFileAsync('node', [
     'src/cli.js',
@@ -11866,6 +12064,13 @@ test('MCP stdio server exposes core tools for synthetic integration', async () =
     assert.ok(bootstrapTool.description.includes('Does not create a session'));
     assert.ok(bootstrapTool.description.includes('latest checkpoint handoff'));
     assert.ok(bootstrapTool.description.includes('memoryMap'));
+    const searchTool = toolList.tools.find((tool) => tool.name === 'search');
+    assert.ok(searchTool.inputSchema.properties.workspaceKey);
+    assert.ok(searchTool.inputSchema.properties.workspaceMode);
+    assert.ok(searchTool.inputSchema.properties.workspaceResultLimit);
+    assert.ok(searchTool.inputSchema.properties.workspacePerScopeLimit);
+    assert.ok(searchTool.inputSchema.properties.includePrimaryInWorkspaceResults);
+    assert.ok(searchTool.description.includes('workspace federation'));
     const expandClusterTool = toolList.tools.find((tool) => tool.name === 'expand_memory_cluster');
     assert.ok(expandClusterTool.inputSchema.properties.clusterId);
     assert.ok(expandClusterTool.inputSchema.properties.includeProvenance);


### PR DESCRIPTION
## Summary

Fixes #152.

Adds opt-in workspace federation to standalone `search` for active-session targeted lookup.

- Preserves existing `search` behavior when `workspaceKey` is absent: callers still receive the legacy array response.
- When `workspaceKey` is present, returns a `workspace_search` envelope with:
  - primary-scope `results`
  - a separate bounded `workspace` block
  - `scopePlan`, `memoryMap`, limits, warnings, and provenance
- Reuses the workspace resolver and bounded retrieval policy from bootstrap federation.
- Keeps primary results out of `workspace.results` by default unless `includePrimaryInWorkspaceResults` is enabled.
- Keeps shared workspace retrieval routing-rule opt-in via `includeShared`.
- Exposes workspace search options through MCP `search` schema.
- Documents when to use workspace search vs `bootstrapContext`.

## Notes

This does not touch CI or AI review workflows. The PR is opened ready, not draft, so the existing ready-PR CI policy can run normally.

## Verification

- `node --test --test-name-pattern "search .*workspace|MCP stdio" test/core.test.js`
- `node --test --test-name-pattern "search .*workspace" test/core.test.js`
- `git diff --check`
- `npm test` -> 196 passing
