### PR TITLE
[codex] Update agent guidance for workspace search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,11 @@ search shared memory only when cross-repo or user-wide policy may matter. Use
 the inferred repo scope key, or an explicit `github.com/owner/repo` key when
 cross-machine continuity matters.
 
+When a configured workspace profile is relevant, use `resolve_workspace` or pass
+`workspaceKey` to `bootstrap_context` for bounded supplemental cross-repo
+retrieval. During uninterrupted active work, prefer targeted `search`; pass
+`workspaceKey` there only when the lookup genuinely needs cross-repo memory.
+
 Before relying on retrieval, distinguish storage authority. Remote
 ContextForge storage is canonical shared memory for the configured scope;
 local or project-local storage is machine/check-out local context unless the


### PR DESCRIPTION
## Summary

Follow-up after #158/#159.

- Adds a short `AGENTS.md` note for workspace profile usage.
- Points agents to `resolve_workspace` / `bootstrap_context --workspaceKey` for bounded cross-repo startup/resume context.
- Clarifies that uninterrupted active work should prefer targeted `search`, with `workspaceKey` only when the lookup genuinely needs cross-repo memory.

## Verification

- `git diff --check`
- PR CI: Detect changes / Workflow lint / Node 20 / Node 22 / Node 24 / CI Summary all passing

## Notes

No code changes. Separately from this PR diff, the installed personal `contextforge-memory` skill on this machine was synced to the already-merged repository copy at `docs/skills/contextforge-memory/SKILL.md`, so future local Codex sessions read the merged #147/#152 workspace guidance.
